### PR TITLE
Set restrictive file permissions on data directory

### DIFF
--- a/src/guidebook/db.py
+++ b/src/guidebook/db.py
@@ -16,6 +16,22 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 logger = logging.getLogger("guidebook")
 
 DB_DIR = Path.home() / ".local" / "guidebook"
+
+
+def _ensure_data_dir(path: Path) -> None:
+    """Create a directory with owner-only permissions (0o700).
+
+    Uses chmod after mkdir because mkdir's mode argument is subject to umask.
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    if sys.platform != "win32":
+        path.chmod(0o700)
+
+
+def _secure_file(path: Path) -> None:
+    """Set owner-only read/write permissions (0o600) on a file."""
+    if sys.platform != "win32" and path.exists():
+        path.chmod(0o600)
 META_DB_PATH = DB_DIR / "__global.db"
 _LAST_OPENED_FILE = DB_DIR / "last_opened.json"
 
@@ -54,8 +70,9 @@ def _read_last_opened() -> dict[str, float]:
 def _record_last_opened(name: str) -> None:
     data = _read_last_opened()
     data[name] = time.time()
-    _LAST_OPENED_FILE.parent.mkdir(parents=True, exist_ok=True)
+    _ensure_data_dir(_LAST_OPENED_FILE.parent)
     _LAST_OPENED_FILE.write_text(json.dumps(data))
+    _secure_file(_LAST_OPENED_FILE)
 
 
 def _lock_exclusive(f) -> None:
@@ -269,7 +286,7 @@ def _backup_before_migration(db_path: Path, current_version: int, target_version
     import shutil
 
     backup_dir = db_path.parent / "backups"
-    backup_dir.mkdir(parents=True, exist_ok=True)
+    _ensure_data_dir(backup_dir)
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%d_%H%M%Sz")
     backup_name = f"{db_path.stem}_premigrate_v{current_version}_to_v{target_version}_{ts}{db_path.suffix}"
     backup_path = backup_dir / backup_name
@@ -460,7 +477,7 @@ class DatabaseManager:
     async def open(self, db_path: str | Path) -> None:
         await self.close()
         db_path = Path(db_path)
-        db_path.parent.mkdir(parents=True, exist_ok=True)
+        _ensure_data_dir(db_path.parent)
         self._acquire_lock(db_path)
         self.db_path = db_path
         # Back up before migration if needed
@@ -503,6 +520,7 @@ class DatabaseManager:
             async with self.engine.begin() as conn:
                 await conn.execute(text("VACUUM"))
                 logger.info("Vacuumed database after migration")
+        _secure_file(db_path)
         async with self.engine.connect() as conn:
             sv = await conn.run_sync(lambda c: _get_schema_version(c, "settings"))
         await self.record_last_opened(db_path.stem)
@@ -520,7 +538,7 @@ class DatabaseManager:
         """Open the shared __global.db with WAL mode for multi-process safety."""
         if self.global_engine is not None:
             return
-        META_DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _ensure_data_dir(META_DB_PATH.parent)
         # Back up before migration if needed
         if META_DB_PATH.exists() and GLOBAL_MIGRATIONS:
             import sqlite3
@@ -550,6 +568,7 @@ class DatabaseManager:
             await conn.run_sync(
                 lambda c: _run_migrations(c, GLOBAL_MIGRATIONS, "settings")
             )
+        _secure_file(META_DB_PATH)
         # Migrate last_opened.json if it exists
         await self._migrate_last_opened()
         async with self.global_engine.connect() as conn:
@@ -659,8 +678,20 @@ def cleanup_stale_locks() -> None:
             pass  # Genuinely locked by another process
 
 
+def _secure_existing_data() -> None:
+    """Fix permissions on existing data directory contents (migration for existing installs)."""
+    if sys.platform == "win32" or not DB_DIR.exists():
+        return
+    for item in DB_DIR.iterdir():
+        if item.is_dir():
+            item.chmod(0o700)
+        elif item.is_file():
+            item.chmod(0o600)
+
+
 async def init_db() -> None:
-    DB_DIR.mkdir(parents=True, exist_ok=True)
+    _ensure_data_dir(DB_DIR)
+    _secure_existing_data()
     cleanup_stale_locks()
     await db_manager.open_global()
     if db_manager.picker_mode:

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -702,9 +702,9 @@ environment variables (overridden by command line options):
         import secrets
         import sqlite3
 
-        from guidebook.db import META_DB_PATH
+        from guidebook.db import META_DB_PATH, _ensure_data_dir
 
-        META_DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _ensure_data_dir(META_DB_PATH.parent)
         conn = sqlite3.connect(str(META_DB_PATH))
         conn.execute(
             "CREATE TABLE IF NOT EXISTS auth_tokens "
@@ -807,9 +807,9 @@ environment variables (overridden by command line options):
         or (sys.platform == "darwin" and not sys.stderr.isatty())
     )
     if _log_to_file:
-        from guidebook.db import DB_DIR
+        from guidebook.db import DB_DIR, _ensure_data_dir
 
-        DB_DIR.mkdir(parents=True, exist_ok=True)
+        _ensure_data_dir(DB_DIR)
         handler = logging.FileHandler(DB_DIR / "guidebook.log", encoding="utf-8")
         handler.setFormatter(
             logging.Formatter(

--- a/src/guidebook/routes/attachments.py
+++ b/src/guidebook/routes/attachments.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, field_serializer
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from guidebook.db import Attachment, Record, DB_DIR, db_manager, get_session
+from guidebook.db import Attachment, Record, DB_DIR, db_manager, get_session, _ensure_data_dir
 from guidebook.routes.records import _broadcast_records_changed
 
 router = APIRouter(
@@ -82,7 +82,7 @@ async def upload_attachments(
 ):
     record = await _get_record(record_id, session)
     att_dir = _attachments_dir(record.uuid)
-    att_dir.mkdir(parents=True, exist_ok=True)
+    _ensure_data_dir(att_dir)
 
     existing = {p.name for p in att_dir.iterdir()} if att_dir.exists() else set()
     created = []

--- a/src/guidebook/routes/settings.py
+++ b/src/guidebook/routes/settings.py
@@ -12,6 +12,7 @@ from guidebook.db import (
     GLOBAL_DEFAULTABLE_KEYS,
     GlobalSetting,
     Setting,
+    _ensure_data_dir,
     db_manager,
     get_global_session,
     get_session,
@@ -155,7 +156,7 @@ async def backup_database():
 
     backup_dir = db_path.parent / "backups"
     try:
-        backup_dir.mkdir(parents=True, exist_ok=True)
+        _ensure_data_dir(backup_dir)
     except OSError as e:
         raise HTTPException(
             status_code=400, detail=f"Cannot create directory: {backup_dir}: {e}"
@@ -307,7 +308,7 @@ async def _auto_backup_loop(initial_delay: float = 5):
                 db_path = db_manager.db_path
                 if db_path and db_path.exists():
                     backup_dir = db_path.parent / "backups"
-                    backup_dir.mkdir(parents=True, exist_ok=True)
+                    _ensure_data_dir(backup_dir)
                     ts = now.strftime("%Y-%m-%d_%H%M%Sz")
                     name = f"{db_path.stem}_autobackup_{ts}{db_path.suffix}"
                     dest = backup_dir / name


### PR DESCRIPTION
## Summary

- Set `0o700` permissions on `~/.local/guidebook/` and all subdirectories (backups, attachments)
- Set `0o600` permissions on database files and other data files
- Fix permissions on existing installs at startup (migration path)
- Skip permission hardening on Windows

Fixes #6