### PR TITLE
Add rate limiting and harden auth surface (fixes #2)

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -153,15 +153,12 @@
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ token }),
       });
-      if (res.ok) {
-        const data = await res.json();
-        if (!data.valid) {
-          // Token already used or expired — redirect to base URL for server 401 page
-          const url = new URL(window.location.href);
-          url.searchParams.delete("auth_token");
-          window.location.replace(url.pathname);
-          return true;
-        }
+      if (!res.ok) {
+        // Token invalid, used, or expired — redirect to base URL for server 401 page
+        const url = new URL(window.location.href);
+        url.searchParams.delete("auth_token");
+        window.location.replace(url.pathname);
+        return true;
       }
     } catch {}
     // Token is valid — show confirmation screen

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -212,7 +212,7 @@
 
   async function checkWelcome() {
     // The welcome screen only shows once — before the first database is created.
-    // We use the /api/databases/mode endpoint (auth-exempt) to check.
+    // We use the /api/databases/mode endpoint to check.
     try {
       const res = await fetch("/api/databases/mode");
       if (res.ok) {

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -136,9 +136,49 @@ _AUTH_EXEMPT_PREFIXES = (
 _AUTH_EXEMPT_EXACT = {"/api/version"}
 
 
+_AUTH_RATE_LIMIT_PATHS = ("/api/auth/login", "/api/auth/check-token")
+
+
+def _rate_limit_429(retry_after: int) -> Response:
+    from fastapi.responses import JSONResponse
+
+    return JSONResponse(
+        status_code=429,
+        content={"detail": "Too many requests"},
+        headers={"Retry-After": str(retry_after)},
+    )
+
+
 @app.middleware("http")
 async def http_middleware(request: Request, call_next):
+    from guidebook.ratelimit import auth_limiter, query_limiter, upload_limiter
+
     path = request.url.path
+    client_ip = request.client.host if request.client else "unknown"
+
+    # Rate limit: auth endpoints (check prior failures)
+    if path in _AUTH_RATE_LIMIT_PATHS:
+        allowed, retry_after = auth_limiter.check(client_ip)
+        if not allowed:
+            return _rate_limit_429(retry_after)
+
+    # Rate limit: query endpoints
+    if path.startswith("/api/query/") or path == "/api/query":
+        allowed, retry_after = query_limiter.check(client_ip)
+        if not allowed:
+            return _rate_limit_429(retry_after)
+        query_limiter.record(client_ip)
+
+    # Rate limit: upload endpoints
+    if (
+        request.method == "POST"
+        and "/attachments" in path
+        and path.startswith("/api/records/")
+    ):
+        allowed, retry_after = upload_limiter.check(client_ip)
+        if not allowed:
+            return _rate_limit_429(retry_after)
+        upload_limiter.record(client_ip)
 
     # Auth check for API routes
     if path.startswith("/api/") and not any(
@@ -191,6 +231,11 @@ async def http_middleware(request: Request, call_next):
                     )
 
     response: Response = await call_next(request)
+
+    # Record auth failures for rate limiting (successful logins don't count)
+    if path in _AUTH_RATE_LIMIT_PATHS and response.status_code == 401:
+        auth_limiter.record(client_ip)
+
     if path.startswith("/api/"):
         response.headers["Cache-Control"] = "no-store"
     else:

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -129,9 +129,6 @@ app = FastAPI(title="Guidebook", version=version("guidebook"), lifespan=lifespan
 _AUTH_EXEMPT_PREFIXES = ("/api/auth/",)
 
 
-_AUTH_RATE_LIMIT_PATHS = ("/api/auth/login", "/api/auth/check-token")
-
-
 def _rate_limit_429(retry_after: int) -> Response:
     from fastapi.responses import JSONResponse
 
@@ -150,7 +147,7 @@ async def http_middleware(request: Request, call_next):
     client_ip = request.client.host if request.client else "unknown"
 
     # Rate limit: auth endpoints (check prior failures)
-    if path in _AUTH_RATE_LIMIT_PATHS:
+    if path.startswith("/api/auth/"):
         allowed, retry_after = auth_limiter.check(client_ip)
         if not allowed:
             return _rate_limit_429(retry_after)
@@ -204,7 +201,7 @@ async def http_middleware(request: Request, call_next):
     response: Response = await call_next(request)
 
     # Record auth failures for rate limiting (successful logins don't count)
-    if path in _AUTH_RATE_LIMIT_PATHS and response.status_code == 401:
+    if path.startswith("/api/auth/") and response.status_code == 401:
         auth_limiter.record(client_ip)
 
     if path.startswith("/api/"):

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -151,7 +151,7 @@ def _rate_limit_429(retry_after: int) -> Response:
 
 @app.middleware("http")
 async def http_middleware(request: Request, call_next):
-    from guidebook.ratelimit import auth_limiter, query_limiter, upload_limiter
+    from guidebook.ratelimit import auth_limiter
 
     path = request.url.path
     client_ip = request.client.host if request.client else "unknown"
@@ -161,24 +161,6 @@ async def http_middleware(request: Request, call_next):
         allowed, retry_after = auth_limiter.check(client_ip)
         if not allowed:
             return _rate_limit_429(retry_after)
-
-    # Rate limit: query endpoints
-    if path.startswith("/api/query/") or path == "/api/query":
-        allowed, retry_after = query_limiter.check(client_ip)
-        if not allowed:
-            return _rate_limit_429(retry_after)
-        query_limiter.record(client_ip)
-
-    # Rate limit: upload endpoints
-    if (
-        request.method == "POST"
-        and "/attachments" in path
-        and path.startswith("/api/records/")
-    ):
-        allowed, retry_after = upload_limiter.check(client_ip)
-        if not allowed:
-            return _rate_limit_429(retry_after)
-        upload_limiter.record(client_ip)
 
     # Auth check for API routes
     if path.startswith("/api/") and not any(

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -180,12 +180,8 @@ async def http_middleware(request: Request, call_next):
                         content={"detail": "Authentication required"},
                     )
 
-    # Auth check for non-API routes (HTML pages only, not static assets)
-    if (
-        not path.startswith("/api/")
-        and not path.startswith("/assets/")
-        and "auth_token" not in request.url.query
-    ):
+    # Auth check for non-API routes (HTML pages and static assets)
+    if not path.startswith("/api/") and "auth_token" not in request.url.query:
         from guidebook.routes.auth import check_auth
         from guidebook.db import db_manager
 

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -126,14 +126,7 @@ app = FastAPI(title="Guidebook", version=version("guidebook"), lifespan=lifespan
 
 
 # Paths that bypass auth checking
-_AUTH_EXEMPT_PREFIXES = (
-    "/api/auth/",
-    "/api/version",
-    "/api/global-settings/welcome_acknowledged",
-    "/api/databases/mode",
-    "/api/databases/current",
-)
-_AUTH_EXEMPT_EXACT = {"/api/version"}
+_AUTH_EXEMPT_PREFIXES = ("/api/auth/",)
 
 
 _AUTH_RATE_LIMIT_PATHS = ("/api/auth/login", "/api/auth/check-token")

--- a/src/guidebook/ratelimit.py
+++ b/src/guidebook/ratelimit.py
@@ -62,9 +62,3 @@ class RateLimiter:
 
 # Auth: 5 failed attempts per 5-minute window
 auth_limiter = RateLimiter(max_requests=5, window_seconds=300)
-
-# Query: 10 requests per minute
-query_limiter = RateLimiter(max_requests=10, window_seconds=60)
-
-# Upload: 5 uploads per minute
-upload_limiter = RateLimiter(max_requests=5, window_seconds=60)

--- a/src/guidebook/ratelimit.py
+++ b/src/guidebook/ratelimit.py
@@ -1,0 +1,70 @@
+"""In-memory per-IP sliding window rate limiter."""
+
+import time
+from collections import deque
+
+
+class RateLimiter:
+    """Sliding window rate limiter.
+
+    Tracks timestamps of events per key (typically client IP) and rejects
+    new events when the count within the window exceeds the maximum.
+    """
+
+    def __init__(self, max_requests: int, window_seconds: int):
+        self.max_requests = max_requests
+        self.window_seconds = window_seconds
+        self._hits: dict[str, deque[float]] = {}
+        self._last_cleanup = time.monotonic()
+
+    def _cleanup(self) -> None:
+        """Remove stale entries every 60 seconds."""
+        now = time.monotonic()
+        if now - self._last_cleanup < 60:
+            return
+        self._last_cleanup = now
+        cutoff = now - self.window_seconds
+        stale = [k for k, dq in self._hits.items() if not dq or dq[-1] < cutoff]
+        for k in stale:
+            del self._hits[k]
+
+    def check(self, key: str) -> tuple[bool, int]:
+        """Check if the key is within the rate limit.
+
+        Returns (allowed, retry_after_seconds).
+        """
+        now = time.monotonic()
+        self._cleanup()
+
+        dq = self._hits.get(key)
+        if dq is None:
+            return True, 0
+
+        cutoff = now - self.window_seconds
+        while dq and dq[0] < cutoff:
+            dq.popleft()
+
+        if len(dq) >= self.max_requests:
+            retry_after = int(dq[0] - cutoff) + 1
+            return False, max(retry_after, 1)
+
+        return True, 0
+
+    def record(self, key: str) -> None:
+        """Record a hit for the given key."""
+        now = time.monotonic()
+        dq = self._hits.get(key)
+        if dq is None:
+            dq = deque()
+            self._hits[key] = dq
+        dq.append(now)
+
+
+# Auth: 5 failed attempts per 5-minute window
+auth_limiter = RateLimiter(max_requests=5, window_seconds=300)
+
+# Query: 10 requests per minute
+query_limiter = RateLimiter(max_requests=10, window_seconds=60)
+
+# Upload: 5 uploads per minute
+upload_limiter = RateLimiter(max_requests=5, window_seconds=60)

--- a/src/guidebook/routes/auth.py
+++ b/src/guidebook/routes/auth.py
@@ -286,14 +286,14 @@ async def check_token(
     body = await request.json()
     token_str = body.get("token", "")
     if not token_str:
-        return {"valid": False}
+        raise HTTPException(401, "Invalid token")
     tok = await _validate_token_by_raw(gdb, token_str)
     if not tok:
-        return {"valid": False}
+        raise HTTPException(401, "Invalid token")
     if tok.last_seen_at is not None and not tok.is_transfer:
-        return {"valid": False}
+        raise HTTPException(401, "Token already used")
     if tok.last_seen_at is None and (time.time() - tok.created_at) > LOGIN_LINK_TTL:
-        return {"valid": False}
+        raise HTTPException(401, "Token expired")
     return {"valid": True}
 
 


### PR DESCRIPTION
- Add per-IP rate limiting to all /api/auth/ endpoints (5 failures per 5 min)
- Restrict auth-exempt API paths to /api/auth/ only
- Require auth for static assets (JS, CSS, etc.)
- Return 401 from check-token on invalid tokens (closes brute-force gap)