### PR TITLE
CIDR proxy trust, server-side auth login, and hardening

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -46,11 +46,6 @@ build-binary: _check-uv build-frontend
 # Build everything (frontend + binary)
 build: build-frontend build-binary
 
-# Run frontend dev server with HMR
-dev: _check-node
-    @test -d frontend/node_modules || { echo "Error: frontend dependencies not installed. Run 'just deps' first."; exit 1; }
-    cd frontend && npm run dev
-
 # Run tests
 test: _check-uv
     uv run pytest

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -137,61 +137,6 @@
   let switcherDatabases = [];
   let authBlocked = false; // true when server returns 401
   let authLoginError = "";
-  let authConfirmToken = ""; // set when ?auth_token= is in URL, awaiting user confirmation
-  let authConfirmUrl = ""; // the full URL for copying
-  let authConfirming = false;
-  let authConfirmCopied = false;
-
-  async function handleAuthToken() {
-    const params = new URLSearchParams(window.location.search);
-    const token = params.get("auth_token");
-    if (!token) return false;
-    // Check if the token is still valid before showing confirmation
-    try {
-      const res = await fetch("/api/auth/check-token", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ token }),
-      });
-      if (!res.ok) {
-        // Token invalid, used, or expired — redirect to base URL for server 401 page
-        const url = new URL(window.location.href);
-        url.searchParams.delete("auth_token");
-        window.location.replace(url.pathname);
-        return true;
-      }
-    } catch {}
-    // Token is valid — show confirmation screen
-    authConfirmUrl = window.location.href;
-    authConfirmToken = token;
-    // Remove token from URL bar (but keep it in state)
-    const url = new URL(window.location.href);
-    url.searchParams.delete("auth_token");
-    window.history.replaceState({}, "", url.pathname + url.search + url.hash);
-    return true;
-  }
-
-  async function confirmAuthLogin() {
-    authConfirming = true;
-    authLoginError = "";
-    try {
-      const res = await fetch("/api/auth/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ token: authConfirmToken }),
-      });
-      if (res.ok) {
-        location.reload();
-        return;
-      } else {
-        const data = await res.json().catch(() => null);
-        authLoginError = data?.detail || "Login failed";
-      }
-    } catch (e) {
-      authLoginError = "Login failed: " + e.message;
-    }
-    authConfirming = false;
-  }
 
   async function checkAuthStatus() {
     try {
@@ -962,9 +907,6 @@
     window.addEventListener("keydown", onGlobalKeydown);
     window.addEventListener("hashchange", onHashChange);
     window.addEventListener("resize", onResize);
-    // Handle auth token from URL (login link)
-    const tokenHandled = await handleAuthToken();
-    if (tokenHandled) return;
     // Check if auth blocks us
     const authOk = await checkAuthStatus();
     if (!authOk) return;
@@ -1016,28 +958,7 @@
 </script>
 
 <main class:picker-mode={pickerMode && !databaseOpen} class:dual-mode={page === "dual"} class:records-mode={page === "records" || page === "add"} class:query-mode={page === "query"} class:scratchpad-mode={page === "scratchpad"} class:settings-mode={page === "settings"}>
-  {#if authConfirmToken}
-    <div class="auth-confirm">
-      <div class="auth-confirm-panel">
-        <h1>Create Session</h1>
-        <p class="auth-confirm-desc">You are about to lock in a long-term browser session with Guidebook. This browser will be the only one able to access the app unless additional sessions are granted.</p>
-        {#if authLoginError}
-          <p class="auth-confirm-error">{authLoginError}</p>
-        {/if}
-        <button class="auth-confirm-btn" on:click={confirmAuthLogin} disabled={authConfirming}>
-          {authConfirming ? "Creating session..." : "Create Session"}
-        </button>
-        <div class="auth-confirm-separator"><span>or</span></div>
-        <div class="auth-confirm-url-box">
-          <label>Copy this one-time login URL to open in a different browser</label>
-          <div class="auth-confirm-url-row">
-            <input type="text" value={authConfirmUrl} readonly on:click={(e) => e.target.select()} />
-            <button class="auth-confirm-copy" class:copied={authConfirmCopied} on:click={() => { navigator.clipboard.writeText(authConfirmUrl).then(() => { authConfirmCopied = true; setTimeout(() => authConfirmCopied = false, 1500); }).catch(() => {}); }}>{authConfirmCopied ? "Copied!" : "Copy"}</button>
-          </div>
-        </div>
-      </div>
-    </div>
-  {:else if authBlocked}
+  {#if authBlocked}
     <div class="auth-blocked">
       <p>You need a login link from the owner to access this site.</p>
       {#if authLoginError}
@@ -1695,110 +1616,6 @@
     color: var(--danger, #e74c3c);
   }
 
-  .auth-confirm {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 100vh;
-    background: var(--bg, #1a1b1e);
-  }
-  .auth-confirm-panel {
-    background: var(--bg-card, #24252b);
-    border: 1px solid var(--border, #3a3b3f);
-    border-radius: 12px;
-    padding: 2rem 2.5rem;
-    max-width: 500px;
-    width: 90vw;
-  }
-  .auth-confirm-panel h1 {
-    margin: 0 0 0.5rem;
-    font-size: 1.5rem;
-    color: var(--text, #eaeaea);
-  }
-  .auth-confirm-desc {
-    font-size: 0.85rem;
-    color: var(--text-dim, #888);
-    line-height: 1.5;
-    margin: 0 0 1.5rem;
-  }
-  .auth-confirm-separator {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    margin: 1.5rem 0;
-    color: var(--text-dim, #888);
-    font-size: 0.8rem;
-  }
-  .auth-confirm-separator::before,
-  .auth-confirm-separator::after {
-    content: "";
-    flex: 1;
-    border-top: 1px solid var(--border, #3a3b3f);
-  }
-  .auth-confirm-url-box {
-    margin-bottom: 0;
-  }
-  .auth-confirm-url-box label {
-    display: block;
-    font-size: 0.75rem;
-    color: var(--text-dim, #888);
-    margin-bottom: 0.35rem;
-  }
-  .auth-confirm-url-row {
-    display: flex;
-    gap: 0.5rem;
-  }
-  .auth-confirm-url-row input {
-    flex: 1;
-    padding: 0.4rem 0.6rem;
-    border: 1px solid var(--border, #3a3b3f);
-    border-radius: 4px;
-    background: var(--bg-input, transparent);
-    color: var(--text, #eaeaea);
-    font-size: 0.8rem;
-    font-family: monospace;
-  }
-  .auth-confirm-copy {
-    padding: 0.4rem 0.8rem;
-    border: 1px solid var(--border, #3a3b3f);
-    border-radius: 4px;
-    background: var(--bg-input, #2a2b30);
-    color: var(--text, #eaeaea);
-    font-size: 0.8rem;
-    cursor: pointer;
-    white-space: nowrap;
-  }
-  .auth-confirm-copy:hover {
-    background: var(--border, #3a3b3f);
-  }
-  .auth-confirm-copy.copied {
-    background: var(--accent, #00ff88);
-    color: var(--accent-text, #000);
-    border-color: var(--accent, #00ff88);
-  }
-  .auth-confirm-error {
-    color: #ff4444;
-    font-size: 0.8rem;
-    margin: 0 0 1rem;
-  }
-  .auth-confirm-btn {
-    width: 100%;
-    padding: 0.75rem 1.5rem;
-    background: var(--accent, #00ff88);
-    color: var(--accent-text, #000);
-    border: none;
-    border-radius: 6px;
-    font-size: 1rem;
-    font-weight: 600;
-    cursor: pointer;
-  }
-  .auth-confirm-btn:hover:not(:disabled) {
-    opacity: 0.9;
-  }
-  .auth-confirm-btn:disabled {
-    opacity: 0.5;
-    cursor: default;
-  }
   .auth-blocked {
     display: flex;
     flex-direction: column;

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -207,6 +207,13 @@
     return true;
   }
 
+  async function tryRenewSession() {
+    try {
+      const res = await fetch("/api/auth/renew", { method: "POST" });
+      if (res.status === 401) location.reload();
+    } catch {}
+  }
+
   async function checkWelcome() {
     // The welcome screen only shows once — before the first database is created.
     // We use the /api/databases/mode endpoint to check.
@@ -961,6 +968,8 @@
     // Check if auth blocks us
     const authOk = await checkAuthStatus();
     if (!authOk) return;
+    tryRenewSession();
+    setInterval(tryRenewSession, 3600_000); // renew check every hour
     connectSSE(); // connect early to prevent auto-shutdown during welcome
     await checkWelcome();
     if (!welcomeAcknowledged) return; // Welcome screen will handle the rest

--- a/src/guidebook/db.py
+++ b/src/guidebook/db.py
@@ -32,6 +32,8 @@ def _secure_file(path: Path) -> None:
     """Set owner-only read/write permissions (0o600) on a file."""
     if sys.platform != "win32" and path.exists():
         path.chmod(0o600)
+
+
 META_DB_PATH = DB_DIR / "__global.db"
 _LAST_OPENED_FILE = DB_DIR / "last_opened.json"
 
@@ -204,6 +206,7 @@ class AuthToken(GlobalBase):
     expires_at: Mapped[float | None] = mapped_column(Float, nullable=True)
     last_ip: Mapped[str | None] = mapped_column(String, nullable=True)
     is_transfer: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    jwt_nonce: Mapped[str | None] = mapped_column(String, nullable=True)
 
 
 class DatabaseLockError(Exception):

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -611,7 +611,7 @@ environment variables (overridden by command line options):
   GUIDEBOOK_NO_SHUTDOWN           Disable shutdown endpoint (default: false)
   GUIDEBOOK_HOST                  Bind address (default: 127.0.0.1)
   GUIDEBOOK_PORT                  Port (default: 4280)
-  GUIDEBOOK_BROWSER_URL           Override browser URL
+  GUIDEBOOK_BROWSER_URL           Override browser URL base
   GUIDEBOOK_DISABLE_AUTH          Disable authentication (default: false)
   GUIDEBOOK_AUTH_SLOTS            Max concurrent sessions (default: 1)
   GUIDEBOOK_AUTH_TTL              Session cookie TTL (e.g. 30d, 24h, 3600; default: 30d)

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -171,8 +171,12 @@ async def http_middleware(request: Request, call_next):
                         content={"detail": "Authentication required"},
                     )
 
-    # Auth check for non-API routes (HTML pages and static assets)
-    if not path.startswith("/api/") and "auth_token" not in request.url.query:
+    # Auth check for non-API routes (HTML pages, skip hashed static assets)
+    if (
+        not path.startswith("/api/")
+        and not path.startswith("/assets/")
+        and "auth_token" not in request.url.query
+    ):
         from guidebook.routes.auth import check_auth
         from guidebook.db import db_manager
 

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -130,6 +130,27 @@ app = FastAPI(title="Guidebook", version=version("guidebook"), lifespan=lifespan
 _AUTH_EXEMPT_PREFIXES = ("/api/auth/",)
 
 
+_INLINE_STYLE = (
+    "body{background:#111;color:#ccc;font-family:sans-serif;"
+    "display:flex;align-items:center;justify-content:center;"
+    "min-height:100vh;margin:0;font-size:.95rem}"
+    ".box{max-width:420px;text-align:center;line-height:1.6}"
+    "code{background:#222;padding:2px 6px;border-radius:3px;font-size:.85rem;color:#e6a700}"
+    ".dim{color:#777;font-size:.8rem;margin-top:1.2rem}"
+    "button{background:#e6a700;color:#111;border:none;padding:10px 24px;"
+    "border-radius:4px;font-size:1rem;cursor:pointer;margin-top:1rem}"
+    "button:hover{background:#f0b800}"
+    "h2{margin:0 0 .5rem;font-size:1.2rem}"
+)
+
+
+def _inline_page(body: str) -> str:
+    return (
+        f"<html><head><style>{_INLINE_STYLE}</style></head>"
+        f'<body><div class="box">{body}</div></body></html>'
+    )
+
+
 def _rate_limit_429(retry_after: int) -> Response:
     from fastapi.responses import JSONResponse
 
@@ -171,16 +192,53 @@ async def http_middleware(request: Request, call_next):
                         content={"detail": "Authentication required"},
                     )
 
-    # Auth check for non-API routes (HTML pages; hashed assets are public)
-    if (
-        not path.startswith("/api/")
-        and not path.startswith("/assets/")
-        and "auth_token" not in request.url.query
-    ):
-        from guidebook.routes.auth import check_auth
+    # Server-side auth_token login (no SPA/JS needed)
+    if not path.startswith("/api/"):
         from guidebook.db import db_manager
 
+        auth_token = request.query_params.get("auth_token")
+        if auth_token and db_manager._global_session_factory:
+            from guidebook.routes.auth import (
+                server_side_check_token,
+                server_side_login,
+            )
+            from fastapi.responses import HTMLResponse, RedirectResponse
+            from urllib.parse import urlencode
+
+            async with db_manager._global_session_factory() as gdb:
+                err = await server_side_check_token(gdb, auth_token)
+            if err:
+                return HTMLResponse(
+                    status_code=401,
+                    content=_inline_page(f"<p>{err}</p>"),
+                )
+            if request.method == "POST":
+                async with db_manager._global_session_factory() as gdb:
+                    redirect = RedirectResponse(url="/", status_code=303)
+                    login_err = await server_side_login(
+                        gdb, request, redirect, auth_token
+                    )
+                if login_err:
+                    return HTMLResponse(
+                        status_code=401,
+                        content=_inline_page(f"<p>{login_err}</p>"),
+                    )
+                return redirect
+            # GET with auth_token — show confirmation page
+            return HTMLResponse(
+                content=_inline_page(
+                    "<h2>Create Session</h2>"
+                    "<p>You are about to create a long-term browser session with Guidebook.</p>"
+                    f'<form method="POST" action="/?{urlencode({"auth_token": auth_token})}">'
+                    '<button type="submit">Create Session</button>'
+                    "</form>",
+                ),
+            )
+
+        # Auth check for non-API routes (HTML pages and static assets)
         if db_manager._global_session_factory:
+            from guidebook.routes.auth import check_auth
+
             async with db_manager._global_session_factory() as gdb:
                 ok = await check_auth(request, gdb)
                 if not ok:
@@ -188,19 +246,11 @@ async def http_middleware(request: Request, call_next):
 
                     return HTMLResponse(
                         status_code=401,
-                        content="<html><head><style>"
-                        "body{background:#111;color:#ccc;font-family:sans-serif;"
-                        "display:flex;align-items:center;justify-content:center;"
-                        "min-height:100vh;margin:0;font-size:.95rem}"
-                        ".box{max-width:420px;text-align:center;line-height:1.6}"
-                        "code{background:#222;padding:2px 6px;border-radius:3px;font-size:.85rem;color:#e6a700}"
-                        ".dim{color:#777;font-size:.8rem;margin-top:1.2rem}"
-                        "</style></head><body>"
-                        '<div class="box">'
-                        "<p>You need a login link from the owner to access this site.</p>"
-                        '<p class="dim">If you are the owner and have lost access, restart the server with '
-                        "<code style='white-space:nowrap'>--reset-auth</code> to clear all sessions and generate a new login link.</p>"
-                        "</div></body></html>",
+                        content=_inline_page(
+                            "<p>You need a login link from the owner to access this site.</p>"
+                            '<p class="dim">If you are the owner and have lost access, restart the server with '
+                            "<code style='white-space:nowrap'>--reset-auth</code> to clear all sessions and generate a new login link.</p>"
+                        ),
                     )
 
     response: Response = await call_next(request)

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -171,12 +171,8 @@ async def http_middleware(request: Request, call_next):
                         content={"detail": "Authentication required"},
                     )
 
-    # Auth check for non-API routes (HTML pages, skip hashed static assets)
-    if (
-        not path.startswith("/api/")
-        and not path.startswith("/assets/")
-        and "auth_token" not in request.url.query
-    ):
+    # Auth check for non-API routes (HTML pages and static assets)
+    if not path.startswith("/api/") and "auth_token" not in request.url.query:
         from guidebook.routes.auth import check_auth
         from guidebook.db import db_manager
 
@@ -211,8 +207,10 @@ async def http_middleware(request: Request, call_next):
 
     if path.startswith("/api/"):
         response.headers["Cache-Control"] = "no-store"
+    elif path.startswith("/assets/"):
+        response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
     else:
-        response.headers["Cache-Control"] = "no-cache"
+        response.headers["Cache-Control"] = "no-store"
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -1,3 +1,4 @@
+import ipaddress
 import json
 import logging
 import os
@@ -618,7 +619,7 @@ environment variables (overridden by command line options):
   GUIDEBOOK_AUTH_RENEW_COOLDOWN   Min time before cookie renewal (default: 24h)
   GUIDEBOOK_ALLOW_TRANSFER        Enable session transfer (default: false)
   GUIDEBOOK_NO_TLS                Disable TLS (default: false)
-  GUIDEBOOK_PROXY                 Enable reverse proxy mode (default: false)
+  GUIDEBOOK_PROXY                 Trusted proxy CIDR(s), comma-separated (e.g. 10.0.0.0/8)
 """
     parser = argparse.ArgumentParser(
         description="Guidebook - Web Application Template",
@@ -701,8 +702,8 @@ environment variables (overridden by command line options):
     )
     parser.add_argument(
         "--proxy",
-        action="store_true",
-        help="Enable reverse proxy mode (trust X-Forwarded-* headers)",
+        metavar="CIDR",
+        help="Trusted proxy CIDR(s), comma-separated (e.g. 10.0.0.0/8,172.16.0.0/12)",
     )
     args = parser.parse_args()
 
@@ -764,11 +765,22 @@ environment variables (overridden by command line options):
         "yes",
     )
     # Apply --proxy / GUIDEBOOK_PROXY
-    proxy_mode = args.proxy or os.environ.get("GUIDEBOOK_PROXY", "").lower() in (
-        "1",
-        "true",
-        "yes",
-    )
+    proxy_spec = args.proxy or os.environ.get("GUIDEBOOK_PROXY", "").strip() or None
+    trusted_proxy_networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+    if proxy_spec:
+        for entry in proxy_spec.split(","):
+            entry = entry.strip()
+            if not entry:
+                continue
+            try:
+                trusted_proxy_networks.append(ipaddress.ip_network(entry, strict=False))
+            except ValueError:
+                print(f"Error: invalid proxy CIDR: {entry}")
+                sys.exit(1)
+        if not trusted_proxy_networks:
+            print("Error: --proxy requires at least one CIDR (e.g. 10.0.0.0/8)")
+            sys.exit(1)
+    proxy_mode = bool(trusted_proxy_networks)
     _auth_module.PROXY_MODE = proxy_mode
     _auth_module.TLS_ENABLED = not no_tls
     if args.name and args.name.startswith("__"):
@@ -964,17 +976,21 @@ environment variables (overridden by command line options):
         ssl_kwargs = {"ssl_certfile": certfile, "ssl_keyfile": keyfile}
         logger.info("TLS enabled (self-signed certificate)")
 
-    proxy_kwargs = {}
+    server_app = app
     if proxy_mode:
-        proxy_kwargs = {"proxy_headers": True, "forwarded_allow_ips": "*"}
-        logger.info("Reverse proxy mode enabled (trusting X-Forwarded-* headers)")
+        from guidebook.proxy import TrustedProxyMiddleware
+
+        server_app = TrustedProxyMiddleware(
+            app, trusted_networks=trusted_proxy_networks
+        )
+        cidrs = ", ".join(str(n) for n in trusted_proxy_networks)
+        logger.info("Reverse proxy mode enabled (trusted: %s)", cidrs)
 
     uvicorn.run(
-        app,
+        server_app,
         host=host,
         port=port,
         access_log=False,
         log_config=None,
         **ssl_kwargs,
-        **proxy_kwargs,
     )

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -605,20 +605,20 @@ def run() -> None:
 
     env_help = """
 environment variables (overridden by command line options):
-  GUIDEBOOK_DB              Database name to open (default: guidebook)
-  GUIDEBOOK_PICKER          Enable database picker mode (default: false)
-  GUIDEBOOK_NO_BROWSER      Skip opening browser (default: false)
-  GUIDEBOOK_NO_SHUTDOWN     Disable shutdown endpoint (default: false)
-  GUIDEBOOK_HOST            Bind address (default: 127.0.0.1)
-  GUIDEBOOK_PORT            Port (default: 4280)
-  GUIDEBOOK_BROWSER_URL     Override browser URL
-  GUIDEBOOK_DISABLE_AUTH    Disable authentication (default: false)
-  GUIDEBOOK_AUTH_SLOTS      Max concurrent sessions (default: 1)
-  GUIDEBOOK_AUTH_TTL        Session cookie TTL (e.g. 30d, 24h, 3600; default: 30d)
-  GUIDEBOOK_AUTH_RENEW_COOLDOWN  Min time before cookie renewal (default: 24h)
-  GUIDEBOOK_ALLOW_TRANSFER  Enable session transfer (default: false)
-  GUIDEBOOK_NO_TLS          Disable TLS (default: false)
-  GUIDEBOOK_PROXY           Enable reverse proxy mode (default: false)
+  GUIDEBOOK_DB                    Database name to open (default: guidebook)
+  GUIDEBOOK_PICKER                Enable database picker mode (default: false)
+  GUIDEBOOK_NO_BROWSER            Skip opening browser (default: false)
+  GUIDEBOOK_NO_SHUTDOWN           Disable shutdown endpoint (default: false)
+  GUIDEBOOK_HOST                  Bind address (default: 127.0.0.1)
+  GUIDEBOOK_PORT                  Port (default: 4280)
+  GUIDEBOOK_BROWSER_URL           Override browser URL
+  GUIDEBOOK_DISABLE_AUTH          Disable authentication (default: false)
+  GUIDEBOOK_AUTH_SLOTS            Max concurrent sessions (default: 1)
+  GUIDEBOOK_AUTH_TTL              Session cookie TTL (e.g. 30d, 24h, 3600; default: 30d)
+  GUIDEBOOK_AUTH_RENEW_COOLDOWN   Min time before cookie renewal (default: 24h)
+  GUIDEBOOK_ALLOW_TRANSFER        Enable session transfer (default: false)
+  GUIDEBOOK_NO_TLS                Disable TLS (default: false)
+  GUIDEBOOK_PROXY                 Enable reverse proxy mode (default: false)
 """
     parser = argparse.ArgumentParser(
         description="Guidebook - Web Application Template",

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -220,7 +220,7 @@ async def http_middleware(request: Request, call_next):
         "connect-src 'self'"
     )
     if _auth_module.PROXY_MODE:
-        if request.headers.get("x-forwarded-proto", "").lower() == "https":
+        if request.url.scheme == "https":
             response.headers["Strict-Transport-Security"] = (
                 "max-age=31536000; includeSubDomains"
             )

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -171,8 +171,12 @@ async def http_middleware(request: Request, call_next):
                         content={"detail": "Authentication required"},
                     )
 
-    # Auth check for non-API routes (HTML pages and static assets)
-    if not path.startswith("/api/") and "auth_token" not in request.url.query:
+    # Auth check for non-API routes (HTML pages; hashed assets are public)
+    if (
+        not path.startswith("/api/")
+        and not path.startswith("/assets/")
+        and "auth_token" not in request.url.query
+    ):
         from guidebook.routes.auth import check_auth
         from guidebook.db import db_manager
 

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -614,7 +614,8 @@ environment variables (overridden by command line options):
   GUIDEBOOK_BROWSER_URL     Override browser URL
   GUIDEBOOK_DISABLE_AUTH    Disable authentication (default: false)
   GUIDEBOOK_AUTH_SLOTS      Max concurrent sessions (default: 1)
-  GUIDEBOOK_AUTH_TTL        Session cookie TTL in seconds (default: 10 years)
+  GUIDEBOOK_AUTH_TTL        Session cookie TTL (e.g. 30d, 24h, 3600; default: 30d)
+  GUIDEBOOK_AUTH_RENEW_COOLDOWN  Min time before cookie renewal (default: 24h)
   GUIDEBOOK_ALLOW_TRANSFER  Enable session transfer (default: false)
   GUIDEBOOK_NO_TLS          Disable TLS (default: false)
   GUIDEBOOK_PROXY           Enable reverse proxy mode (default: false)
@@ -678,9 +679,15 @@ environment variables (overridden by command line options):
     )
     parser.add_argument(
         "--auth-ttl",
-        type=int,
+        type=str,
         default=None,
-        help="Set session cookie TTL in seconds (default: 10 years)",
+        help="Session cookie TTL (e.g. 30d, 24h, 3600) (default: 30d)",
+    )
+    parser.add_argument(
+        "--auth-renew-cooldown",
+        type=str,
+        default=None,
+        help="Min time before cookie renewal (e.g. 24h, 1h) (default: 24h)",
     )
     parser.add_argument(
         "--allow-transfer",
@@ -718,12 +725,36 @@ environment variables (overridden by command line options):
                 pass
     # Apply --auth-ttl / GUIDEBOOK_AUTH_TTL
     if args.auth_ttl is not None:
-        _auth_module.AUTH_TTL = args.auth_ttl
+        try:
+            _auth_module.AUTH_TTL = max(30, _auth_module.parse_duration(args.auth_ttl))
+        except ValueError:
+            print(f"Error: invalid --auth-ttl value: {args.auth_ttl}")
+            sys.exit(1)
     else:
         val = os.environ.get("GUIDEBOOK_AUTH_TTL", "").strip()
         if val:
             try:
-                _auth_module.AUTH_TTL = max(30, int(val))
+                _auth_module.AUTH_TTL = max(30, _auth_module.parse_duration(val))
+            except ValueError:
+                pass
+    # Apply --auth-renew-cooldown / GUIDEBOOK_AUTH_RENEW_COOLDOWN
+    if args.auth_renew_cooldown is not None:
+        try:
+            _auth_module.AUTH_RENEW_COOLDOWN = max(
+                0, _auth_module.parse_duration(args.auth_renew_cooldown)
+            )
+        except ValueError:
+            print(
+                f"Error: invalid --auth-renew-cooldown value: {args.auth_renew_cooldown}"
+            )
+            sys.exit(1)
+    else:
+        val = os.environ.get("GUIDEBOOK_AUTH_RENEW_COOLDOWN", "").strip()
+        if val:
+            try:
+                _auth_module.AUTH_RENEW_COOLDOWN = max(
+                    0, _auth_module.parse_duration(val)
+                )
             except ValueError:
                 pass
     # Apply --no-tls / GUIDEBOOK_NO_TLS
@@ -764,7 +795,7 @@ environment variables (overridden by command line options):
             "created_at REAL NOT NULL, last_seen_at REAL, expires_at REAL, last_ip TEXT, "
             "is_transfer INTEGER NOT NULL DEFAULT 0)"
         )
-        for col in ("expires_at REAL", "last_ip TEXT"):
+        for col in ("expires_at REAL", "last_ip TEXT", "jwt_nonce TEXT"):
             try:
                 conn.execute(f"ALTER TABLE auth_tokens ADD COLUMN {col}")
             except sqlite3.OperationalError:

--- a/src/guidebook/proxy.py
+++ b/src/guidebook/proxy.py
@@ -2,6 +2,17 @@ import ipaddress
 
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
+_PROXY_HEADERS = frozenset(
+    {
+        b"x-forwarded-for",
+        b"x-forwarded-proto",
+        b"x-forwarded-host",
+        b"x-forwarded-port",
+        b"x-real-ip",
+        b"forwarded",
+    }
+)
+
 
 class TrustedProxyMiddleware(ProxyHeadersMiddleware):
     """Extends uvicorn's ProxyHeadersMiddleware with CIDR-based trust."""
@@ -21,12 +32,22 @@ class TrustedProxyMiddleware(ProxyHeadersMiddleware):
         if scope["type"] in ("http", "websocket"):
             client = scope.get("client")
             if client:
+                trusted = False
                 try:
                     addr = ipaddress.ip_address(client[0])
+                    trusted = any(addr in net for net in self.trusted_networks)
                 except ValueError:
-                    # Unrecognised address — don't trust proxy headers
-                    return await self.app(scope, receive, send)
-                if not any(addr in net for net in self.trusted_networks):
-                    # Client is not a trusted proxy — skip header processing
+                    pass
+                if not trusted:
+                    # Reject untrusted clients that send proxy headers
+                    headers = scope.get("headers", [])
+                    if any(name in _PROXY_HEADERS for name, _ in headers):
+                        from starlette.responses import Response
+
+                        response = Response(
+                            "Proxy headers not allowed from untrusted source",
+                            status_code=400,
+                        )
+                        return await response(scope, receive, send)
                     return await self.app(scope, receive, send)
         return await super().__call__(scope, receive, send)

--- a/src/guidebook/proxy.py
+++ b/src/guidebook/proxy.py
@@ -1,0 +1,32 @@
+import ipaddress
+
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
+
+
+class TrustedProxyMiddleware(ProxyHeadersMiddleware):
+    """Extends uvicorn's ProxyHeadersMiddleware with CIDR-based trust."""
+
+    def __init__(self, app, trusted_networks):
+        # Pass trusted_hosts="*" so the parent always processes headers;
+        # we override the trust check ourselves.
+        super().__init__(app, trusted_hosts="*")
+        self.trusted_networks = [
+            ipaddress.ip_network(n, strict=False)
+            if not isinstance(n, (ipaddress.IPv4Network, ipaddress.IPv6Network))
+            else n
+            for n in trusted_networks
+        ]
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] in ("http", "websocket"):
+            client = scope.get("client")
+            if client:
+                try:
+                    addr = ipaddress.ip_address(client[0])
+                except ValueError:
+                    # Unrecognised address — don't trust proxy headers
+                    return await self.app(scope, receive, send)
+                if not any(addr in net for net in self.trusted_networks):
+                    # Client is not a trusted proxy — skip header processing
+                    return await self.app(scope, receive, send)
+        return await super().__call__(scope, receive, send)

--- a/src/guidebook/routes/auth.py
+++ b/src/guidebook/routes/auth.py
@@ -406,7 +406,7 @@ async def login_with_token(
 
 def _is_secure(request: Request) -> bool:
     if PROXY_MODE:
-        return request.headers.get("x-forwarded-proto", "").lower() == "https"
+        return request.url.scheme == "https"
     return TLS_ENABLED
 
 

--- a/src/guidebook/routes/auth.py
+++ b/src/guidebook/routes/auth.py
@@ -404,6 +404,74 @@ async def login_with_token(
     return LoginResponse(status="ok")
 
 
+async def server_side_check_token(gdb: AsyncSession, token_str: str) -> str | None:
+    """Check if a login token is valid. Returns None if valid, or an error message."""
+    if not token_str:
+        return "Invalid token"
+    tok = await _validate_token_by_raw(gdb, token_str)
+    if not tok:
+        return "Invalid or expired token"
+    if tok.last_seen_at is not None and not tok.is_transfer:
+        return "This login link has already been used"
+    if tok.last_seen_at is None and (time.time() - tok.created_at) > LOGIN_LINK_TTL:
+        await gdb.delete(tok)
+        await gdb.commit()
+        return "Login link has expired"
+    return None
+
+
+async def server_side_login(
+    gdb: AsyncSession, request: Request, response: Response, token_str: str
+) -> str | None:
+    """Complete a token login server-side. Returns None on success, or error message."""
+    tok = await _validate_token_by_raw(gdb, token_str)
+    if not tok:
+        return "Invalid or expired token"
+    if tok.last_seen_at is not None and not tok.is_transfer:
+        return "This login link has already been used"
+    if tok.last_seen_at is None and (time.time() - tok.created_at) > LOGIN_LINK_TTL:
+        await gdb.delete(tok)
+        await gdb.commit()
+        return "Login link has expired"
+
+    now = time.time()
+    tok.expires_at = now + AUTH_TTL
+
+    if tok.is_transfer:
+        tok.is_transfer = 0
+        tok.label = "Transferred session"
+        tok.last_seen_at = now
+        result = await gdb.execute(
+            select(AuthToken).where(AuthToken.id != tok.id, AuthToken.is_transfer == 0)
+        )
+        for old_tok in result.scalars().all():
+            await gdb.delete(old_tok)
+        await gdb.commit()
+        broadcast("auth-revoked", {})
+        logger.info("Session transferred to new browser")
+    else:
+        tok.last_seen_at = now
+        tok.label = "Logged in session"
+        await gdb.commit()
+        try:
+            await create_notification(
+                "New session logged in",
+                "A new browser session was authenticated via login link.",
+            )
+        except Exception:
+            logger.warning("Failed to create login notification")
+        logger.info("New session logged in via token")
+
+    tok.token = secrets.token_urlsafe(48)
+    nonce = secrets.token_urlsafe(16)
+    tok.jwt_nonce = nonce
+    await gdb.commit()
+
+    jwt_token = _create_jwt(tok.id, nonce)
+    _set_auth_cookie(response, request, jwt_token)
+    return None
+
+
 def _is_secure(request: Request) -> bool:
     if PROXY_MODE:
         return request.url.scheme == "https"

--- a/src/guidebook/routes/auth.py
+++ b/src/guidebook/routes/auth.py
@@ -18,16 +18,30 @@ logger = logging.getLogger("guidebook")
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
 AUTH_COOKIE_NAME = "guidebook_token"
-AUTH_COOKIE_MAX_AGE_DEFAULT = 10 * 365 * 24 * 3600  # 10 years
+AUTH_TTL_DEFAULT = 30 * 24 * 3600  # 30 days
+AUTH_RENEW_COOLDOWN_DEFAULT = 24 * 3600  # 24 hours
 LOGIN_LINK_TTL = 300  # 5 minutes (hardcoded)
 
 # Set at startup by main.py
 DISABLE_AUTH = False
 AUTH_SLOTS: int = 1  # --auth-slots (default 1)
-AUTH_TTL: int = AUTH_COOKIE_MAX_AGE_DEFAULT  # --auth-ttl (default 10 years)
+AUTH_TTL: int = AUTH_TTL_DEFAULT  # --auth-ttl (default 30d)
+AUTH_RENEW_COOLDOWN: int = AUTH_RENEW_COOLDOWN_DEFAULT  # --auth-renew-cooldown
 ALLOW_TRANSFER: bool = False  # --allow-transfer
 PROXY_MODE: bool = False  # --proxy
 TLS_ENABLED: bool = True  # True unless --no-tls
+
+
+def parse_duration(value: str) -> int:
+    """Parse a duration string like '30d', '24h', '60m', or bare seconds."""
+    value = value.strip()
+    if not value:
+        raise ValueError("Empty duration string")
+    suffixes = {"d": 86400, "h": 3600, "m": 60, "s": 1}
+    if value[-1].lower() in suffixes:
+        return int(value[:-1]) * suffixes[value[-1].lower()]
+    return int(value)
+
 
 # JWT signing secret — loaded at startup by main.py
 JWT_SECRET: str = ""
@@ -69,9 +83,11 @@ async def _token_count(gdb: AsyncSession) -> int:
     return result.scalar() or 0
 
 
-def _create_jwt(session_id: int) -> str:
+def _create_jwt(session_id: int, nonce: str) -> str:
     return jwt.encode(
-        {"sid": session_id, "iat": int(time.time())}, JWT_SECRET, algorithm="HS256"
+        {"sid": session_id, "iat": int(time.time()), "nonce": nonce},
+        JWT_SECRET,
+        algorithm="HS256",
     )
 
 
@@ -82,11 +98,15 @@ def _decode_jwt(token_str: str) -> dict | None:
         return None
 
 
-def _get_current_session_id(request: Request) -> int | None:
+def _get_jwt_claims(request: Request) -> dict | None:
     cookie = request.cookies.get(AUTH_COOKIE_NAME)
     if not cookie:
         return None
-    claims = _decode_jwt(cookie)
+    return _decode_jwt(cookie)
+
+
+def _get_current_session_id(request: Request) -> int | None:
+    claims = _get_jwt_claims(request)
     if not claims or "sid" not in claims:
         return None
     return claims["sid"]
@@ -100,23 +120,33 @@ async def _validate_token_by_raw(gdb: AsyncSession, token: str) -> AuthToken | N
     return result.scalar_one_or_none()
 
 
-async def _validate_session(gdb: AsyncSession, session_id: int) -> AuthToken | None:
-    """Validate a session by ID (from JWT)."""
+async def _validate_session(
+    gdb: AsyncSession, session_id: int, nonce: str | None = None
+) -> AuthToken | None:
+    """Validate a session by ID (from JWT). Checks nonce if present."""
     if not session_id:
         return None
     result = await gdb.execute(select(AuthToken).where(AuthToken.id == session_id))
-    return result.scalar_one_or_none()
+    token = result.scalar_one_or_none()
+    if not token:
+        return None
+    # If the DB row has a nonce, the JWT must match it
+    if token.jwt_nonce and token.jwt_nonce != nonce:
+        return None
+    return token
 
 
 async def check_auth(request: Request, gdb: AsyncSession) -> bool:
     """Check if the current request is authenticated. Returns True if OK."""
     if not await _is_auth_enabled(gdb):
         return True
-    session_id = _get_current_session_id(request)
-    if not session_id:
+    claims = _get_jwt_claims(request)
+    if not claims or "sid" not in claims:
         return False
-    token = await _validate_session(gdb, session_id)
+    token = await _validate_session(gdb, claims["sid"], claims.get("nonce"))
     if not token:
+        return False
+    if token.expires_at and time.time() > token.expires_at:
         return False
     # Update last_seen and IP
     token.last_seen_at = time.time()
@@ -364,24 +394,72 @@ async def login_with_token(
     # Replace the raw login token with a new random value so the
     # original link token can never be reused even if leaked
     tok.token = secrets.token_urlsafe(48)
+    nonce = secrets.token_urlsafe(16)
+    tok.jwt_nonce = nonce
     await gdb.commit()
 
     # Issue a JWT containing the session ID — this is what goes in the cookie
-    jwt_token = _create_jwt(tok.id)
+    jwt_token = _create_jwt(tok.id, nonce)
+    _set_auth_cookie(response, request, jwt_token)
+    return LoginResponse(status="ok")
+
+
+def _is_secure(request: Request) -> bool:
     if PROXY_MODE:
-        is_secure = request.headers.get("x-forwarded-proto", "").lower() == "https"
-    else:
-        is_secure = TLS_ENABLED
+        return request.headers.get("x-forwarded-proto", "").lower() == "https"
+    return TLS_ENABLED
+
+
+def _set_auth_cookie(response: Response, request: Request, jwt_token: str) -> None:
     response.set_cookie(
         AUTH_COOKIE_NAME,
         jwt_token,
         max_age=AUTH_TTL,
         httponly=True,
         samesite="lax",
-        secure=is_secure,
+        secure=_is_secure(request),
         path="/",
     )
-    return LoginResponse(status="ok")
+
+
+@router.post("/renew")
+async def renew_session(
+    request: Request,
+    response: Response,
+    gdb: AsyncSession = Depends(get_global_session),
+):
+    """Renew the current session cookie if eligible."""
+    claims = _get_jwt_claims(request)
+    if not claims or "sid" not in claims:
+        raise HTTPException(401, "Not authenticated")
+
+    token = await _validate_session(gdb, claims["sid"], claims.get("nonce"))
+    if not token:
+        raise HTTPException(401, "Invalid session")
+
+    if token.expires_at and time.time() > token.expires_at:
+        raise HTTPException(401, "Session expired")
+
+    # Check cooldown — JWT must be at least AUTH_RENEW_COOLDOWN old
+    iat = claims.get("iat", 0)
+    now = time.time()
+    if now - iat < AUTH_RENEW_COOLDOWN:
+        eligible_at = iat + AUTH_RENEW_COOLDOWN
+        raise HTTPException(
+            400,
+            f"Too early to renew (eligible at {int(eligible_at)})",
+        )
+
+    # Rotate nonce — invalidates the old JWT immediately
+    nonce = secrets.token_urlsafe(16)
+    token.jwt_nonce = nonce
+    token.expires_at = now + AUTH_TTL
+    await gdb.commit()
+
+    jwt_token = _create_jwt(token.id, nonce)
+    _set_auth_cookie(response, request, jwt_token)
+    logger.info("Session %d renewed", token.id)
+    return {"status": "renewed"}
 
 
 @router.delete("/sessions/{session_id}")


### PR DESCRIPTION
## Summary

- **CIDR-based proxy trust**: `--proxy` now takes trusted CIDR(s) instead of a boolean, with custom middleware that validates client IPs against trusted networks before honoring `X-Forwarded-*` headers
- **Server-side auth login**: Login token flow handled entirely server-side with inline HTML confirmation page — no SPA assets required, eliminating the auth/assets chicken-and-egg problem
- **Per-request secure detection**: Proxy mode now uses `request.url.scheme` for correct behavior when serving both proxied and direct clients simultaneously
- **Cache hardening**: `no-store` for HTML, `immutable` for hashed assets — prevents stale `index.html` from referencing missing asset hashes
- **Auth cookie hardening**: 30-day TTL with renewal and nonce rotation (fixes #7)
- **Misc**: Align env var help text, clarify GUIDEBOOK_BROWSER_URL help, remove broken `dev` Justfile recipe