### PR TITLE
Use OS-appropriate data directory

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -151,7 +151,7 @@ jobs:
             'PORT="${GUIDEBOOK_PORT:-4280}"' \
             'URL="${GUIDEBOOK_BROWSER_URL:-}"' \
             'OPEN_BROWSER=true' \
-            'GLOBAL_DB="$HOME/.local/guidebook/__global.db"' \
+            'GLOBAL_DB="$HOME/Library/Application Support/guidebook/__global.db"' \
             'if [ -z "$URL" ] && [ -f "$GLOBAL_DB" ] && command -v sqlite3 >/dev/null 2>&1; then' \
             '    DB_URL=$(sqlite3 "$GLOBAL_DB" "SELECT value FROM settings WHERE key='"'"'browser_url_override'"'"'" 2>/dev/null)' \
             '    DB_OPEN=$(sqlite3 "$GLOBAL_DB" "SELECT value FROM settings WHERE key='"'"'open_browser_on_startup'"'"'" 2>/dev/null)' \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,10 @@ guidebook/
 
 ## Data Storage
 
-Database and config stored in `~/.local/guidebook/` (XDG-compatible). Created automatically on first run.
+Database and config stored in the OS-appropriate data directory. Created automatically on first run.
+- **Linux**: `$XDG_DATA_HOME/guidebook/` (defaults to `~/.local/share/guidebook/`)
+- **macOS**: `~/Library/Application Support/guidebook/`
+- **Windows**: `%APPDATA%\guidebook\`
 
 ## Key Commands
 

--- a/src/guidebook/db.py
+++ b/src/guidebook/db.py
@@ -15,7 +15,18 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 logger = logging.getLogger("guidebook")
 
-DB_DIR = Path.home() / ".local" / "guidebook"
+def _default_data_dir() -> Path:
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "guidebook"
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            return Path(appdata) / "guidebook"
+        return Path.home() / "AppData" / "Roaming" / "guidebook"
+    return Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share")) / "guidebook"
+
+
+DB_DIR = _default_data_dir()
 
 
 def _ensure_data_dir(path: Path) -> None:


### PR DESCRIPTION
## Summary
- Store database and config in OS-appropriate data directory instead of hardcoded path (fixes #12)
  - Linux: `$XDG_DATA_HOME/guidebook/` (defaults to `~/.local/share/guidebook/`)
  - macOS: `~/Library/Application Support/guidebook/`
  - Windows: `%APPDATA%\guidebook\`