### PR TITLE
Media browsing, drag-and-drop, and UI improvements

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -65,6 +65,7 @@
   let recordAutoCreated = false;
   let databaseRight = false;
   let mediaSearchQuery = "";
+  let mediaSelectedTags = [];
   let mediaSelectedRecordId = null;
   let dualSplit = 50;
   let draggingSplit = false;
@@ -1128,13 +1129,13 @@
   {#if page === "dual"}
     <div class="dual-layout" class:dual-narrow={!wide} class:dragging={draggingSplit} class:dual-reversed={databaseRight}>
       <div class="dual-pane" style="flex: 0 0 {dualSplit}%">
-        <Records bind:this={recordsRef} showForm={dualShowForm || !!prefill || !!editId} {prefill} editId={editId} autoCreated={recordAutoCreated} bind:formDirty on:dropcreated={() => { recordAutoCreated = true; }} on:editchange={e => { editId = e.detail; dualShowForm = !!e.detail; }} on:navigate={e => { recordAutoCreated = false; if (e.detail === "records" || e.detail === "back") { prefill = null; editId = null; dualShowForm = false; if (!wide) navigate(dualRightPage); } else navigate(e.detail); }} on:prefillconsumed={() => prefill = null} on:searchchange={e => { mediaSearchQuery = e.detail; }} on:selectionchange={e => { mediaSelectedRecordId = e.detail; }} />
+        <Records bind:this={recordsRef} showForm={dualShowForm || !!prefill || !!editId} {prefill} editId={editId} autoCreated={recordAutoCreated} bind:formDirty on:dropcreated={() => { recordAutoCreated = true; }} on:editchange={e => { editId = e.detail; dualShowForm = !!e.detail; }} on:navigate={e => { recordAutoCreated = false; if (e.detail === "records" || e.detail === "back") { prefill = null; editId = null; dualShowForm = false; if (!wide) navigate(dualRightPage); } else navigate(e.detail); }} on:prefillconsumed={() => prefill = null} on:searchchange={e => { mediaSearchQuery = e.detail; }} on:selectionchange={e => { mediaSelectedRecordId = e.detail; }} on:tagchange={e => { mediaSelectedTags = e.detail; }} />
       </div>
       <!-- svelte-ignore a11y-no-static-element-interactions -->
       <div class="dual-divider" on:mousedown={onDividerDown} on:touchstart={onDividerDown}></div>
       <div class="dual-pane" style="flex: 1">
         {#if dualRightPage === "media"}
-          <Media searchQuery={mediaSearchQuery} selectedRecordId={editId || mediaSelectedRecordId} on:openrecord={e => { editId = e.detail; dualShowForm = true; }} />
+          <Media searchQuery={mediaSearchQuery} selectedTags={mediaSelectedTags} selectedRecordId={editId || mediaSelectedRecordId} on:openrecord={e => { editId = e.detail; dualShowForm = true; }} />
         {:else if dualRightPage === "notifications"}
           <Notifications refreshTrigger={notifRefreshTrigger} on:countchange={() => fetchUnreadCount()} />
         {/if}
@@ -1143,13 +1144,13 @@
   {:else}
     <div class="page-content">
     {#if page === "records"}
-      <Records bind:this={recordsRef} showForm={false} initialSearchQuery={mediaSearchQuery} on:dropcreated={e => { recordAutoCreated = true; }} on:editchange={e => { editId = e.detail; navigate("add"); window.location.hash = `/records/${e.detail}`; }} on:navigate={e => navigate(e.detail)} on:searchchange={e => { mediaSearchQuery = e.detail; }} on:selectionchange={e => { mediaSelectedRecordId = e.detail; }} />
+      <Records bind:this={recordsRef} showForm={false} initialSearchQuery={mediaSearchQuery} on:dropcreated={e => { recordAutoCreated = true; }} on:editchange={e => { editId = e.detail; navigate("add"); window.location.hash = `/records/${e.detail}`; }} on:navigate={e => navigate(e.detail)} on:searchchange={e => { mediaSearchQuery = e.detail; }} on:selectionchange={e => { mediaSelectedRecordId = e.detail; }} on:tagchange={e => { mediaSelectedTags = e.detail; }} />
     {:else if page === "add"}
-      <Records bind:this={recordsRef} showForm={true} editId={editId} {prefill} autoCreated={recordAutoCreated} bind:formDirty on:editchange={e => { editId = e.detail; window.location.hash = e.detail ? `/records/${e.detail}` : "/add"; }} on:navigate={e => { recordAutoCreated = false; navigate(e.detail); }} on:prefillconsumed={() => prefill = null} on:searchchange={e => { mediaSearchQuery = e.detail; }} on:selectionchange={e => { mediaSelectedRecordId = e.detail; }} />
+      <Records bind:this={recordsRef} showForm={true} editId={editId} {prefill} autoCreated={recordAutoCreated} bind:formDirty on:editchange={e => { editId = e.detail; window.location.hash = e.detail ? `/records/${e.detail}` : "/add"; }} on:navigate={e => { recordAutoCreated = false; navigate(e.detail); }} on:prefillconsumed={() => prefill = null} on:searchchange={e => { mediaSearchQuery = e.detail; }} on:selectionchange={e => { mediaSelectedRecordId = e.detail; }} on:tagchange={e => { mediaSelectedTags = e.detail; }} />
     {:else if page === "query"}
       <Query initialSql={querySql} />
     {:else if page === "media"}
-      <Media searchQuery={mediaSearchQuery} on:openrecord={e => { editId = e.detail; navigate("add"); window.location.hash = `/records/${e.detail}`; }} />
+      <Media searchQuery={mediaSearchQuery} selectedTags={mediaSelectedTags} on:openrecord={e => { editId = e.detail; navigate("add"); window.location.hash = `/records/${e.detail}`; }} />
     {:else if page === "notifications"}
       <Notifications refreshTrigger={notifRefreshTrigger} on:countchange={() => fetchUnreadCount()} />
     {:else if page === "settings"}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -90,6 +90,8 @@
     globalDragOver = false;
     globalDragCounter = 0;
     if (!databaseOpen || !e.dataTransfer?.files?.length) return;
+    // If dropped on the attachments section, Records already handled the upload
+    if (e.target.closest?.(".attachments-section")) return;
     const files = e.dataTransfer.files;
 
     // If Records component exists and has a form open, upload to it

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -80,7 +80,7 @@
       let pct = databaseRight
         ? 100 - ((clientX - rect.left) / rect.width) * 100
         : ((clientX - rect.left) / rect.width) * 100;
-      const minPx = 180;
+      const minPx = 200;
       const minPct = (minPx / rect.width) * 100;
       const lo = Math.max(minPct, 10);
       const hi = Math.min(100 - minPct, 90);

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1743,6 +1743,9 @@
   .dual-narrow .dual-divider {
     display: none;
   }
+  .dual-narrow .dual-pane:first-child {
+    flex: 1 1 100% !important;
+  }
   .dual-narrow .dual-pane:last-child {
     display: none;
   }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -68,6 +68,47 @@
   let mediaSelectedRecordId = null;
   let dualSplit = 50;
   let draggingSplit = false;
+  let globalDragOver = false;
+  let globalDragCounter = 0;
+
+  function onGlobalDragEnter(e) {
+    if (!e.dataTransfer?.types?.includes("Files")) return;
+    e.preventDefault();
+    globalDragCounter++;
+    globalDragOver = true;
+  }
+  function onGlobalDragOver(e) {
+    if (!e.dataTransfer?.types?.includes("Files")) return;
+    e.preventDefault();
+  }
+  function onGlobalDragLeave() {
+    globalDragCounter--;
+    if (globalDragCounter <= 0) { globalDragCounter = 0; globalDragOver = false; }
+  }
+  async function onGlobalDrop(e) {
+    e.preventDefault();
+    globalDragOver = false;
+    globalDragCounter = 0;
+    if (!databaseOpen || !e.dataTransfer?.files?.length) return;
+    const files = e.dataTransfer.files;
+
+    // If Records component exists and has a form open, upload to it
+    if (recordsRef) {
+      recordsRef.dropFiles(files);
+      return;
+    }
+
+    // Navigate to records page and create a new record with files
+    const isOnRecords = page === "dual" || page === "records" || page === "add";
+    if (!isOnRecords) {
+      navigate(wide ? "dual" : "records");
+      await tick();
+    }
+    // After navigation, recordsRef should be available
+    if (recordsRef) {
+      recordsRef.dropFiles(files);
+    }
+  }
 
   function onDividerDown(e) {
     e.preventDefault();
@@ -961,7 +1002,20 @@
   });
 </script>
 
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<svelte:body
+  on:dragenter={onGlobalDragEnter}
+  on:dragover={onGlobalDragOver}
+  on:dragleave={onGlobalDragLeave}
+  on:drop={onGlobalDrop}
+/>
+
 <main class:picker-mode={pickerMode && !databaseOpen} class:dual-mode={page === "dual"} class:records-mode={page === "records" || page === "add"} class:query-mode={page === "query"} class:scratchpad-mode={page === "scratchpad"} class:settings-mode={page === "settings"}>
+  {#if globalDragOver && databaseOpen}
+    <div class="global-drop-overlay">
+      <div class="global-drop-message">Drop files to attach</div>
+    </div>
+  {/if}
   {#if authBlocked}
     <div class="auth-blocked">
       <p>You need a login link from the owner to access this site.</p>
@@ -1912,4 +1966,22 @@
   }
 
   .popup-btn-go:hover { background: var(--accent-hover); }
+
+  .global-drop-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    border: 3px dashed var(--accent, #00ff88);
+  }
+
+  .global-drop-message {
+    color: var(--accent, #00ff88);
+    font-size: 1.5rem;
+    font-weight: bold;
+  }
 </style>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -40,8 +40,8 @@
     // Dual with subpage
     const dualMatch = hash.match(/^\/dual(?:\/(\w+))?$/);
     if (dualMatch) {
-      const sub = dualMatch[1] || "notifications";
-      return { page: "dual", editId: null, dualRight: DUAL_RIGHT_PAGES.has(sub) ? sub : "notifications" };
+      const sub = dualMatch[1] || "media";
+      return { page: "dual", editId: null, dualRight: DUAL_RIGHT_PAGES.has(sub) ? sub : "media" };
     }
     const recordMatch = hash.match(/^\/records\/(\d+)$/);
     if (recordMatch) return { page: isWide() ? "dual" : "add", editId: parseInt(recordMatch[1], 10), dualRight: null };
@@ -52,7 +52,7 @@
   let wide = typeof window !== "undefined" && window.innerWidth >= 1200;
   let _parsed = parseHash();
   let { page, editId } = _parsed;
-  let dualRightPage = _parsed.dualRight || "notifications";
+  let dualRightPage = _parsed.dualRight || "media";
   let previousPage = "records";
   let defaultPage = "records";
   let settingsTab = _parsed.settingsTab || null;
@@ -695,7 +695,8 @@
       const res = await fetch("/api/settings/default_page");
       if (res.ok) {
         const data = await res.json();
-        defaultPage = data.value || "records";
+        const v = data.value || "log";
+        defaultPage = v === "log" ? "records" : v;
       }
     } catch {}
   }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1023,6 +1023,7 @@
       {#if wide}
         <button class="add-btn dual-btn" class:active-nav={dualRightPage === "media"} on:click={() => { dualRightPage = "media"; navigate("media"); }} title="Records & Media">{#if dualRightPage === "media" && !databaseRight}<Icon icon={iconBook} width={14} />{/if}<Icon icon={iconCamera} width={18} />{#if dualRightPage === "media" && databaseRight}<Icon icon={iconBook} width={14} />{/if}</button>
         <button class="add-btn dual-btn" class:active-nav={dualRightPage === "notifications"} on:click={handleNotificationClick} title="Records & Notifications">{#if dualRightPage === "notifications" && !databaseRight}<Icon icon={iconBook} width={14} />{/if}{#if unreadCount > 0}<span class="notif-badge">{unreadCount > 99 ? "99+" : unreadCount}</span>{:else}<Icon icon={iconBell} width={18} />{/if}{#if dualRightPage === "notifications" && databaseRight}<Icon icon={iconBook} width={14} />{/if}</button>
+        <button class="add-btn" class:active-nav={page === "scratchpad"} on:click={() => navigate("scratchpad")} title="Scratchpad">💭</button>
       {:else}
         <button class="add-btn" on:click={() => navigate("records")} title="Records"><Icon icon={iconBook} width={18} /></button>
         <button class="add-btn" class:active-nav={page === "media"} on:click={() => navigate("media")} title="Media"><Icon icon={iconCamera} width={18} /></button>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -80,8 +80,12 @@
       let pct = databaseRight
         ? 100 - ((clientX - rect.left) / rect.width) * 100
         : ((clientX - rect.left) / rect.width) * 100;
-      if (pct < 10) pct = 10;
-      if (pct > 90) pct = 90;
+      const minPx = 180;
+      const minPct = (minPx / rect.width) * 100;
+      const lo = Math.max(minPct, 10);
+      const hi = Math.min(100 - minPct, 90);
+      if (pct < lo) pct = lo;
+      if (pct > hi) pct = hi;
       dualSplit = pct;
     };
     const onUp = () => {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1072,7 +1072,7 @@
       <div class="dual-divider" on:mousedown={onDividerDown} on:touchstart={onDividerDown}></div>
       <div class="dual-pane" style="flex: 1">
         {#if dualRightPage === "media"}
-          <Media searchQuery={mediaSearchQuery} selectedRecordId={editId || mediaSelectedRecordId} />
+          <Media searchQuery={mediaSearchQuery} selectedRecordId={editId || mediaSelectedRecordId} on:openrecord={e => { editId = e.detail; dualShowForm = true; }} />
         {:else if dualRightPage === "notifications"}
           <Notifications refreshTrigger={notifRefreshTrigger} on:countchange={() => fetchUnreadCount()} />
         {/if}
@@ -1087,7 +1087,7 @@
     {:else if page === "query"}
       <Query initialSql={querySql} />
     {:else if page === "media"}
-      <Media searchQuery={mediaSearchQuery} />
+      <Media searchQuery={mediaSearchQuery} on:openrecord={e => { editId = e.detail; navigate("add"); window.location.hash = `/records/${e.detail}`; }} />
     {:else if page === "notifications"}
       <Notifications refreshTrigger={notifRefreshTrigger} on:countchange={() => fetchUnreadCount()} />
     {:else if page === "settings"}

--- a/frontend/src/Media.svelte
+++ b/frontend/src/Media.svelte
@@ -1,5 +1,7 @@
 <script>
-  import { onMount, onDestroy } from "svelte";
+  import { onMount, onDestroy, createEventDispatcher } from "svelte";
+
+  const dispatch = createEventDispatcher();
 
   export let searchQuery = "";
   export let selectedRecordId = null;
@@ -76,8 +78,8 @@
       {#each displayMedia as item, i (item.id)}
         <!-- svelte-ignore a11y-click-events-have-key-events -->
         <!-- svelte-ignore a11y-no-static-element-interactions -->
-        <div class="media-card" on:click={() => openPreview(i)}>
-          <div class="media-thumb">
+        <div class="media-card">
+          <div class="media-thumb" on:click={() => openPreview(i)}>
             {#if item.content_type.startsWith("image/")}
               <img src={downloadUrl(item)} alt={item.filename} loading="lazy" />
             {:else if item.content_type.startsWith("video/")}
@@ -88,7 +90,7 @@
               <div class="audio-badge">&#9835;</div>
             {/if}
           </div>
-          <div class="media-label">
+          <div class="media-label" on:click={() => dispatch("openrecord", item.record_id)}>
             <span class="media-filename" title={item.filename}>{item.filename}</span>
             <span class="media-record-title" title={item.record_title}>{item.record_title}</span>
           </div>
@@ -164,7 +166,6 @@
     border: 1px solid var(--border, #3a3b3f);
     border-radius: 6px;
     overflow: hidden;
-    cursor: pointer;
     transition: border-color 0.15s;
   }
 
@@ -210,12 +211,21 @@
     color: var(--accent, #00ff88);
   }
 
+  .media-thumb {
+    cursor: pointer;
+  }
+
   .media-label {
     padding: 0.3rem 0.4rem;
     display: flex;
     flex-direction: column;
     gap: 0.1rem;
     min-width: 0;
+    cursor: pointer;
+  }
+
+  .media-label:hover {
+    background: var(--bg-input, #1a1b20);
   }
 
   .media-filename {

--- a/frontend/src/Media.svelte
+++ b/frontend/src/Media.svelte
@@ -102,6 +102,7 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="lightbox" on:click|self={() => { previewIndex = -1; }}>
+    <button class="lightbox-close" on:click|stopPropagation={() => { previewIndex = -1; }}>&times;</button>
     {#if displayMedia.length > 1}
       <button class="lightbox-arrow lightbox-prev" on:click|stopPropagation={previewPrev}>&lsaquo;</button>
     {/if}
@@ -295,6 +296,23 @@
   .lightbox-audio {
     width: 400px;
     max-width: 80vw;
+  }
+
+  .lightbox-close {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.75rem;
+    background: none;
+    border: none;
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 2.5rem;
+    cursor: pointer;
+    z-index: 10;
+    line-height: 1;
+  }
+
+  .lightbox-close:hover {
+    color: #fff;
   }
 
   .lightbox-arrow {

--- a/frontend/src/Media.svelte
+++ b/frontend/src/Media.svelte
@@ -86,7 +86,7 @@
   {#if loading && media.length === 0}
     <p class="status">Loading media...</p>
   {:else if displayMedia.length === 0}
-    <p class="status">{searchQuery || selectedRecordId ? "No media matches your filter." : "No media attachments yet."}</p>
+    <p class="status">{searchQuery || selectedRecordId || selectedTags.length > 0 || typeFilter !== "all" ? "No media attachments matching filters." : "No media attachments yet."}</p>
   {:else}
     <div class="media-grid">
       {#each displayMedia as item, i (item.id)}

--- a/frontend/src/Media.svelte
+++ b/frontend/src/Media.svelte
@@ -170,6 +170,7 @@
 
   .media-filter-bar {
     display: flex;
+    flex-wrap: wrap;
     justify-content: flex-end;
     gap: 0.25rem;
     padding: 0.25rem 0.25rem 0.5rem;

--- a/frontend/src/Media.svelte
+++ b/frontend/src/Media.svelte
@@ -10,6 +10,7 @@
   let loading = true;
   let previewIndex = -1;
   let eventSource = null;
+  let typeFilter = "all";
 
   $: displayMedia = selectedRecordId
     ? media.filter(m => m.record_id === selectedRecordId)
@@ -18,7 +19,7 @@
   $: previewItem = previewIndex >= 0 && previewIndex < displayMedia.length
     ? displayMedia[previewIndex] : null;
 
-  $: searchQuery, fetchMedia();
+  $: searchQuery, typeFilter, fetchMedia();
 
   function downloadUrl(item) {
     return `/api/records/${item.record_id}/attachments/${item.id}/download`;
@@ -33,8 +34,11 @@
   async function fetchMedia() {
     loading = true;
     try {
-      let url = "/api/media/";
-      if (searchQuery) url += `?q=${encodeURIComponent(searchQuery)}`;
+      const params = new URLSearchParams();
+      if (searchQuery) params.set("q", searchQuery);
+      if (typeFilter !== "all") params.set("type", typeFilter);
+      const qs = params.toString();
+      const url = "/api/media/" + (qs ? `?${qs}` : "");
       const res = await fetch(url);
       if (res.ok) media = await res.json();
     } catch {}
@@ -69,6 +73,14 @@
 </script>
 
 <div class="media-page">
+  <div class="media-filter-bar">
+    {#each [["all","All"],["image","Images"],["video","Video"],["audio","Audio"],["document","Document"]] as [value, label]}
+      <label class="filter-option" class:active={typeFilter === value}>
+        <input type="radio" name="typeFilter" {value} bind:group={typeFilter} />
+        {label}
+      </label>
+    {/each}
+  </div>
   {#if loading && media.length === 0}
     <p class="status">Loading media...</p>
   {:else if displayMedia.length === 0}
@@ -88,6 +100,8 @@
               <div class="play-badge">&#9654;</div>
             {:else if item.content_type.startsWith("audio/")}
               <div class="audio-badge">&#9835;</div>
+            {:else}
+              <div class="doc-badge">&#128196;</div>
             {/if}
           </div>
           <div class="media-label" on:click={() => dispatch("openrecord", item.record_id)}>
@@ -118,8 +132,14 @@
           <div class="lightbox-audio-name">{previewItem.filename}</div>
           <audio controls autoplay src={downloadUrl(previewItem)} class="lightbox-audio"></audio>
         </div>
-      {:else}
+      {:else if previewItem.content_type.startsWith("image/")}
         <img src={downloadUrl(previewItem)} alt={previewItem.filename} />
+      {:else}
+        <div class="lightbox-audio-wrap">
+          <div class="doc-badge lightbox-doc-icon">&#128196;</div>
+          <div class="lightbox-audio-name">{previewItem.filename}</div>
+          <a class="doc-download" href={downloadUrl(previewItem)} download={previewItem.filename}>Download</a>
+        </div>
       {/if}
       <div class="lightbox-caption">{previewItem.record_title} &mdash; {previewItem.filename} ({formatFileSize(previewItem.size)})</div>
     </div>
@@ -146,6 +166,60 @@
     min-height: 0;
     flex: 1;
     overflow: auto;
+  }
+
+  .media-filter-bar {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.25rem;
+    padding: 0.25rem 0.25rem 0.5rem;
+    flex-shrink: 0;
+  }
+
+  .filter-option {
+    cursor: pointer;
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    color: var(--text-muted, #888);
+    border: 1px solid transparent;
+    transition: all 0.15s;
+    user-select: none;
+  }
+
+  .filter-option input {
+    display: none;
+  }
+
+  .filter-option:hover {
+    color: var(--text, #eaeaea);
+  }
+
+  .filter-option.active {
+    color: var(--accent, #00ff88);
+    border-color: var(--accent, #00ff88);
+  }
+
+  .doc-badge {
+    font-size: 2.5rem;
+  }
+
+  .lightbox-doc-icon {
+    font-size: 4rem;
+  }
+
+  .doc-download {
+    color: var(--accent, #00ff88);
+    text-decoration: none;
+    padding: 0.4rem 1rem;
+    border: 1px solid var(--accent, #00ff88);
+    border-radius: 4px;
+    font-size: 0.85rem;
+  }
+
+  .doc-download:hover {
+    background: var(--accent, #00ff88);
+    color: var(--bg, #1a1b20);
   }
 
   .status {

--- a/frontend/src/Media.svelte
+++ b/frontend/src/Media.svelte
@@ -4,6 +4,7 @@
   const dispatch = createEventDispatcher();
 
   export let searchQuery = "";
+  export let selectedTags = [];
   export let selectedRecordId = null;
 
   let media = [];
@@ -19,7 +20,7 @@
   $: previewItem = previewIndex >= 0 && previewIndex < displayMedia.length
     ? displayMedia[previewIndex] : null;
 
-  $: searchQuery, typeFilter, fetchMedia();
+  $: searchQuery, selectedTags, typeFilter, fetchMedia();
 
   function downloadUrl(item) {
     return `/api/records/${item.record_id}/attachments/${item.id}/download`;
@@ -36,6 +37,7 @@
     try {
       const params = new URLSearchParams();
       if (searchQuery) params.set("q", searchQuery);
+      if (selectedTags.length > 0) params.set("tags", selectedTags.join(","));
       if (typeFilter !== "all") params.set("type", typeFilter);
       const qs = params.toString();
       const url = "/api/media/" + (qs ? `?${qs}` : "");

--- a/frontend/src/Records.svelte
+++ b/frontend/src/Records.svelte
@@ -341,6 +341,14 @@
     return false;
   }
 
+  export async function dropFiles(files) {
+    if (showForm && formId) {
+      uploadFiles(files);
+    } else {
+      await handlePageDrop_files(files);
+    }
+  }
+
   export function cancelIfClean() {
     if (showForm && !formDirty) {
       cancelForm();
@@ -626,15 +634,10 @@
   function onDocDrop(e) { resetAllDragState(); }
   function onDocDragEnd(e) { resetAllDragState(); }
 
-  async function handlePageDrop(e) {
-    e.preventDefault();
-    pageDragOver = false;
-    pageDragCounter = 0;
-    if (showForm || !e.dataTransfer?.files?.length) return;
-    const files = e.dataTransfer.files;
+  async function handlePageDrop_files(files) {
+    if (!files.length) return;
     const firstFileName = files[0].name.replace(/\.[^.]+$/, "") || "Untitled";
     try {
-      // Create the record
       const res = await fetch("/api/records/", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -643,7 +646,6 @@
       if (!res.ok) return;
       const record = await res.json();
 
-      // Upload attachments before opening the form (which may destroy this component)
       const fd = new FormData();
       for (const f of files) fd.append("files", f);
       await fetch(`/api/records/${record.id}/attachments/`, {
@@ -651,21 +653,24 @@
         body: fd,
       });
 
-      // Now open the edit form — this may navigate and destroy this component
       formAutoCreated = true;
       dispatch("dropcreated", record.id);
       editRecord(record);
     } catch {}
   }
+
+  async function handlePageDrop(e) {
+    e.preventDefault();
+    pageDragOver = false;
+    pageDragCounter = 0;
+    if (showForm || !e.dataTransfer?.files?.length) return;
+    await handlePageDrop_files(e.dataTransfer.files);
+  }
 </script>
 
 
 <!-- svelte-ignore a11y-no-static-element-interactions -->
-<div class="records-page" class:page-drag-active={pageDragOver && !showForm}
-     on:dragenter|preventDefault={() => { pageDragCounter++; if (!showForm) pageDragOver = true; }}
-     on:dragover|preventDefault
-     on:dragleave={() => { pageDragCounter--; if (pageDragCounter <= 0) { pageDragCounter = 0; pageDragOver = false; } }}
-     on:drop={handlePageDrop}>
+<div class="records-page">
   <div class="records-header">
     <div class="search-bar">
       <input
@@ -709,7 +714,7 @@
              on:dragenter|preventDefault={() => { attDragCounter++; dragOver = true; }}
              on:dragover|preventDefault
              on:dragleave={() => { attDragCounter--; if (attDragCounter <= 0) { attDragCounter = 0; dragOver = false; } }}
-             on:drop={handleDrop}>
+             on:drop|stopPropagation={handleDrop}>
           <label>Attachments</label>
           <div class="attachment-upload">
             <button class="attachment-choose-btn" on:click={() => fileInput.click()}>Choose files</button>

--- a/frontend/src/Records.svelte
+++ b/frontend/src/Records.svelte
@@ -32,6 +32,7 @@
   let attachmentError = "";
   let fileInput;
   let dragOver = false;
+  let attDragCounter = 0;
   let previewIndex = -1;
   let selectedTags = new Set();
 
@@ -358,10 +359,14 @@
   onMount(() => {
     fetchRecords();
     connectRecordsSSE();
+    document.addEventListener("drop", onDocDrop);
+    document.addEventListener("dragend", onDocDragEnd);
   });
 
   onDestroy(() => {
     if (recordsEventSource) recordsEventSource.close();
+    document.removeEventListener("drop", onDocDrop);
+    document.removeEventListener("dragend", onDocDragEnd);
   });
 
   async function fetchRecords() {
@@ -573,6 +578,7 @@
   function handleDrop(e) {
     e.preventDefault();
     dragOver = false;
+    attDragCounter = 0;
     if (e.dataTransfer?.files?.length) uploadFiles(e.dataTransfer.files);
   }
 
@@ -609,10 +615,21 @@
   }
 
   let pageDragOver = false;
+  let pageDragCounter = 0;
+
+  function resetAllDragState() {
+    pageDragOver = false;
+    pageDragCounter = 0;
+    dragOver = false;
+    attDragCounter = 0;
+  }
+  function onDocDrop(e) { resetAllDragState(); }
+  function onDocDragEnd(e) { resetAllDragState(); }
 
   async function handlePageDrop(e) {
     e.preventDefault();
     pageDragOver = false;
+    pageDragCounter = 0;
     if (showForm || !e.dataTransfer?.files?.length) return;
     const files = e.dataTransfer.files;
     const firstFileName = files[0].name.replace(/\.[^.]+$/, "") || "Untitled";
@@ -645,8 +662,9 @@
 
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <div class="records-page" class:page-drag-active={pageDragOver && !showForm}
-     on:dragover|preventDefault={() => { if (!showForm) pageDragOver = true; }}
-     on:dragleave|self={() => { pageDragOver = false; }}
+     on:dragenter|preventDefault={() => { pageDragCounter++; if (!showForm) pageDragOver = true; }}
+     on:dragover|preventDefault
+     on:dragleave={() => { pageDragCounter--; if (pageDragCounter <= 0) { pageDragCounter = 0; pageDragOver = false; } }}
      on:drop={handlePageDrop}>
   <div class="records-header">
     <div class="search-bar">
@@ -688,8 +706,9 @@
       {#if formId}
         <!-- svelte-ignore a11y-no-static-element-interactions -->
         <div class="attachments-section" class:drag-active={dragOver}
-             on:dragover|preventDefault={() => { dragOver = true; }}
-             on:dragleave={() => { dragOver = false; }}
+             on:dragenter|preventDefault={() => { attDragCounter++; dragOver = true; }}
+             on:dragover|preventDefault
+             on:dragleave={() => { attDragCounter--; if (attDragCounter <= 0) { attDragCounter = 0; dragOver = false; } }}
              on:drop={handleDrop}>
           <label>Attachments</label>
           <div class="attachment-upload">

--- a/frontend/src/Records.svelte
+++ b/frontend/src/Records.svelte
@@ -1147,23 +1147,27 @@
 
   .attachment-list {
     display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
+    flex-direction: row;
+    gap: 0.5rem;
     margin-top: 0.5rem;
-    max-height: 270px;
-    overflow-y: auto;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding-bottom: 0.25rem;
   }
 
   .attachment-item {
     display: flex;
     flex-direction: column;
-    gap: 0.4rem;
+    align-items: center;
+    gap: 0.25rem;
     font-size: 0.8rem;
+    flex-shrink: 0;
+    width: 80px;
   }
 
   .attachment-thumb {
-    max-height: 60px;
-    max-width: 80px;
+    width: 80px;
+    height: 60px;
     border-radius: 4px;
     object-fit: cover;
     cursor: pointer;
@@ -1277,9 +1281,11 @@
 
   .attachment-info {
     display: flex;
+    flex-direction: column;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.1rem;
     min-width: 0;
+    width: 100%;
   }
 
   .attachment-name {
@@ -1288,7 +1294,8 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    max-width: 200px;
+    max-width: 80px;
+    font-size: 0.65rem;
   }
 
   .attachment-name:hover {

--- a/frontend/src/Records.svelte
+++ b/frontend/src/Records.svelte
@@ -717,7 +717,8 @@
             <input bind:this={fileInput} type="file" multiple style="display:none" on:change={handleFileInput} />
           </div>
           {#if attachments.length > 0}
-            <div class="attachment-list">
+            <!-- svelte-ignore a11y-no-static-element-interactions -->
+            <div class="attachment-list" on:wheel|preventDefault={e => e.currentTarget.scrollLeft += e.deltaY}>
               {#each attachments as att (att.id)}
                 <div class="attachment-item">
                   {#if att.content_type.startsWith("image/")}

--- a/frontend/src/Records.svelte
+++ b/frontend/src/Records.svelte
@@ -640,6 +640,11 @@
              on:dragleave={() => { dragOver = false; }}
              on:drop={handleDrop}>
           <label>Attachments</label>
+          <div class="attachment-upload">
+            <button class="attachment-choose-btn" on:click={() => fileInput.click()}>Choose files</button>
+            <span class="drop-hint">or drag &amp; drop / paste</span>
+            <input bind:this={fileInput} type="file" multiple style="display:none" on:change={handleFileInput} />
+          </div>
           {#if attachments.length > 0}
             <div class="attachment-list">
               {#each attachments as att (att.id)}
@@ -666,11 +671,6 @@
               {/each}
             </div>
           {/if}
-          <div class="attachment-upload">
-            <button class="attachment-choose-btn" on:click={() => fileInput.click()}>Choose files</button>
-            <span class="drop-hint">or drag &amp; drop / paste</span>
-            <input bind:this={fileInput} type="file" multiple style="display:none" on:change={handleFileInput} />
-          </div>
           {#if uploadingFiles}
             <p class="status">Uploading...</p>
           {/if}
@@ -1048,7 +1048,9 @@
     display: flex;
     flex-direction: column;
     gap: 0.4rem;
-    margin-bottom: 0.5rem;
+    margin-top: 0.5rem;
+    max-height: 270px;
+    overflow-y: auto;
   }
 
   .attachment-item {

--- a/frontend/src/Records.svelte
+++ b/frontend/src/Records.svelte
@@ -33,6 +33,7 @@
   let fileInput;
   let dragOver = false;
   let previewIndex = -1;
+  let selectedTags = new Set();
 
   $: previewableAttachments = attachments.filter(a =>
     a.content_type.startsWith("image/") ||
@@ -213,8 +214,51 @@
     storageSet("logSortAsc", String(sortAsc));
   }
 
+  $: allTags = (() => {
+    const tagSet = new Set();
+    for (const r of records) {
+      if (r.tags) {
+        for (const t of r.tags.split(",")) {
+          const trimmed = t.trim();
+          if (trimmed) tagSet.add(trimmed);
+        }
+      }
+    }
+    return [...tagSet].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+  })();
+
+  // Clear selected tags that no longer exist in results
+  $: if (allTags) {
+    const tagSet = new Set(allTags);
+    for (const t of selectedTags) {
+      if (!tagSet.has(t)) selectedTags.delete(t);
+    }
+    selectedTags = selectedTags;
+  }
+
+  function toggleTag(tag) {
+    if (selectedTags.has(tag)) {
+      selectedTags.delete(tag);
+    } else {
+      selectedTags.add(tag);
+    }
+    selectedTags = selectedTags;
+    selectedIndex = -1;
+  }
+
   $: sortedRecords = (() => {
-    const sorted = [...records].sort((a, b) => {
+    let filtered = records;
+    if (selectedTags.size > 0) {
+      filtered = records.filter(r => {
+        if (!r.tags) return false;
+        const rTags = r.tags.split(",").map(t => t.trim());
+        for (const st of selectedTags) {
+          if (!rTags.includes(st)) return false;
+        }
+        return true;
+      });
+    }
+    const sorted = [...filtered].sort((a, b) => {
       let va = a[sortCol] ?? "";
       let vb = b[sortCol] ?? "";
       if (sortCol === "timestamp" || sortCol === "updated_at") {
@@ -617,6 +661,14 @@
     </div>
   </div>
 
+  {#if !showForm && allTags.length > 0}
+    <div class="tag-filter-bar">
+      {#each allTags as tag (tag)}
+        <button class="tag-chip" class:active={selectedTags.has(tag)} on:click={() => toggleTag(tag)}>{tag}</button>
+      {/each}
+    </div>
+  {/if}
+
   {#if showForm}
     <!-- svelte-ignore a11y-no-static-element-interactions -->
     <div class="record-form" on:keydown={e => { if (e.ctrlKey && e.key === "Enter") { e.preventDefault(); saveRecord(); } }} on:paste={handlePaste}>
@@ -821,6 +873,35 @@
     font-size: 0.85rem;
   }
 
+
+  .tag-filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .tag-chip {
+    padding: 0.15rem 0.5rem;
+    border: 1px solid var(--border, #3a3b3f);
+    border-radius: 12px;
+    background: transparent;
+    color: var(--text-dim, #888);
+    font-size: 0.75rem;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+  }
+
+  .tag-chip:hover {
+    border-color: var(--accent, #00ff88);
+    color: var(--text, #eaeaea);
+  }
+
+  .tag-chip.active {
+    background: var(--accent, #00ff88);
+    color: var(--bg, #1a1b1e);
+    border-color: var(--accent, #00ff88);
+  }
 
   .record-form {
     background: var(--bg-card, #24252b);

--- a/frontend/src/Records.svelte
+++ b/frontend/src/Records.svelte
@@ -714,7 +714,7 @@
              on:dragenter|preventDefault={() => { attDragCounter++; dragOver = true; }}
              on:dragover|preventDefault
              on:dragleave={() => { attDragCounter--; if (attDragCounter <= 0) { attDragCounter = 0; dragOver = false; } }}
-             on:drop|stopPropagation={handleDrop}>
+             on:drop={handleDrop}>
           <label>Attachments</label>
           <div class="attachment-upload">
             <button class="attachment-choose-btn" on:click={() => fileInput.click()}>Choose files</button>

--- a/frontend/src/Records.svelte
+++ b/frontend/src/Records.svelte
@@ -822,6 +822,7 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="lightbox" on:click|self={() => { previewIndex = -1; }}>
+    <button class="lightbox-close" on:click|stopPropagation={() => { previewIndex = -1; }}>&times;</button>
     {#if previewableAttachments.length > 1}
       <button class="lightbox-arrow lightbox-prev" on:click|stopPropagation={previewPrev}>&lsaquo;</button>
     {/if}
@@ -1238,6 +1239,23 @@
   .lightbox-audio {
     width: 400px;
     max-width: 80vw;
+  }
+
+  .lightbox-close {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.75rem;
+    background: none;
+    border: none;
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 2.5rem;
+    cursor: pointer;
+    z-index: 10;
+    line-height: 1;
+  }
+
+  .lightbox-close:hover {
+    color: #fff;
   }
 
   .lightbox-arrow {

--- a/frontend/src/Records.svelte
+++ b/frontend/src/Records.svelte
@@ -245,6 +245,7 @@
     }
     selectedTags = selectedTags;
     selectedIndex = -1;
+    dispatch("tagchange", [...selectedTags]);
   }
 
   $: sortedRecords = (() => {

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -1232,6 +1232,7 @@
       <label for="default_page">Home Page</label>
       <select id="default_page" bind:value={default_page} on:change={onDefaultPageChange}>
         <option value="log">Log</option>
+        <option value="media">Media</option>
         <option value="notifications">Notifications</option>
       </select>
     </div>

--- a/src/guidebook/routes/media.py
+++ b/src/guidebook/routes/media.py
@@ -59,6 +59,8 @@ async def list_media(
                 Record.title.ilike(pattern),
                 Record.content.ilike(pattern),
                 Record.tags.ilike(pattern),
+                Attachment.filename.ilike(pattern),
+                Attachment.content_type.ilike(pattern),
             )
         )
     stmt = stmt.order_by(Attachment.created_at.desc())

--- a/src/guidebook/routes/media.py
+++ b/src/guidebook/routes/media.py
@@ -43,6 +43,7 @@ class MediaItem(BaseModel):
 async def list_media(
     q: str | None = Query(None, description="Search query"),
     type: str | None = Query(None, description="Filter: image, video, audio, document"),
+    tags: str | None = Query(None, description="Comma-separated tags to filter by (AND)"),
     session: AsyncSession = Depends(get_session),
 ):
     stmt = (
@@ -62,6 +63,18 @@ async def list_media(
     else:
         # "all" — no content_type restriction, show every attachment
         pass
+    if tags:
+        for tag in tags.split(","):
+            tag = tag.strip()
+            if tag:
+                stmt = stmt.where(
+                    or_(
+                        Record.tags.ilike(f"{tag},%"),
+                        Record.tags.ilike(f"%, {tag},%"),
+                        Record.tags.ilike(f"%, {tag}"),
+                        Record.tags == tag,
+                    )
+                )
     if q and len(q) >= 2:
         pattern = f"%{q}%"
         stmt = stmt.where(

--- a/src/guidebook/routes/media.py
+++ b/src/guidebook/routes/media.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, field_serializer
-from sqlalchemy import or_, select
+from sqlalchemy import and_, not_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from guidebook.db import Attachment, Record, get_session
@@ -10,6 +10,17 @@ from guidebook.db import Attachment, Record, get_session
 router = APIRouter(prefix="/api/media", tags=["media"])
 
 MEDIA_TYPES = ("image/%", "video/%", "audio/%")
+
+TYPE_FILTERS = {
+    "image": [Attachment.content_type.like("image/%")],
+    "video": [Attachment.content_type.like("video/%")],
+    "audio": [Attachment.content_type.like("audio/%")],
+    "document": [
+        not_(Attachment.content_type.like("image/%")),
+        not_(Attachment.content_type.like("video/%")),
+        not_(Attachment.content_type.like("audio/%")),
+    ],
+}
 
 
 class MediaItem(BaseModel):
@@ -31,6 +42,7 @@ class MediaItem(BaseModel):
 @router.get("/", response_model=list[MediaItem])
 async def list_media(
     q: str | None = Query(None, description="Search query"),
+    type: str | None = Query(None, description="Filter: image, video, audio, document"),
     session: AsyncSession = Depends(get_session),
 ):
     stmt = (
@@ -44,14 +56,12 @@ async def list_media(
             Attachment.created_at,
         )
         .join(Record, Attachment.record_id == Record.id)
-        .where(
-            or_(
-                Attachment.content_type.like("image/%"),
-                Attachment.content_type.like("video/%"),
-                Attachment.content_type.like("audio/%"),
-            )
-        )
     )
+    if type and type in TYPE_FILTERS:
+        stmt = stmt.where(and_(*TYPE_FILTERS[type]))
+    else:
+        # "all" — no content_type restriction, show every attachment
+        pass
     if q and len(q) >= 2:
         pattern = f"%{q}%"
         stmt = stmt.where(

--- a/src/guidebook/routes/records.py
+++ b/src/guidebook/routes/records.py
@@ -141,12 +141,19 @@ async def list_records(
     stmt = select(Record)
     if q and len(q) >= 2:
         pattern = f"%{q}%"
-        stmt = stmt.where(
-            or_(
-                Record.title.ilike(pattern),
-                Record.content.ilike(pattern),
-                Record.tags.ilike(pattern),
+        stmt = (
+            stmt.outerjoin(Attachment, Attachment.record_id == Record.id)
+            .where(
+                or_(
+                    Record.title.ilike(pattern),
+                    Record.content.ilike(pattern),
+                    Record.tags.ilike(pattern),
+                    Record.uuid.ilike(pattern),
+                    Attachment.filename.ilike(pattern),
+                    Attachment.content_type.ilike(pattern),
+                )
             )
+            .distinct()
         )
     stmt = stmt.order_by(Record.timestamp.desc()).offset(offset).limit(limit)
     result = await session.execute(stmt)


### PR DESCRIPTION
## Summary

- Add media page with type filters (images/video/audio/document) and tag filtering synced from record log
- Add full-viewport drag-and-drop zone for file uploads with navigation to record log
- Add lightbox preview with close button for media cards and record attachments
- Improve attachment list with horizontal scroll layout and mouse wheel support
- Add clickable tag filter bar below search on record log
- Extend search to cover all record fields and attachment metadata
- Add scratchpad button to wide-mode button bar
- Add Media option to home page setting and default dual right pane to media
- Fix dual pane resizer minimum width, record log full-width in single-page view, and drag highlight cleanup