### PR TITLE
Support mTLS client certificates (fixes #10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ for a single user accessing the app from one or a handful of trusted
 browsers — not for multi-tenant or public-facing use. It ships with
 strong security defaults: TLS and cookie-based authentication are enabled
 out of the box, sessions are locked to a single browser by default, and
-login links are one-time use with a short expiration window.
+login links are one-time use with a short expiration window. Optional
+mTLS client certificate authentication is available for an even stronger
+auth posture.
 
 Built with FastAPI, SQLite (SQLAlchemy), and Svelte. Forked from
 [rigbook](https://github.com/EnigmaCurry/rigbook), with all
@@ -14,7 +16,7 @@ tags) as a starting point — replace it with your own data model and UI.
 
 ## Features
 
-- **Personal by default**: TLS, single-session auth, and one-time login links out of the box
+- **Personal by default**: TLS, single-session auth, one-time login links, and optional mTLS client certificates
 - **Records**: Generic CRUD records (title, content, tags) — replace with your own data model
 - **Scratchpad**: Ephemeral shared notepad synced in real time across all connected clients via SSE
 - **Multi-database**: Multiple projects with separate SQLite databases and a database picker

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1154,7 +1154,7 @@
     {:else if page === "notifications"}
       <Notifications refreshTrigger={notifRefreshTrigger} on:countchange={() => fetchUnreadCount()} />
     {:else if page === "settings"}
-      <Settings databaseName={currentDatabase} pickerMode={pickerMode} initialTab={settingsTab} bind:highlightSection={settingsHighlight} {clientCount} {authRefreshTrigger} on:disconnect-others={async () => { const nonce = Math.random().toString(36).slice(2); disconnectNonce = nonce; try { await fetch("/api/events/disconnect-others", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ nonce }) }); } catch {} }} on:deleted={e => { if (e.detail.shutdown) { setShutdownState(); } else { stopAppServices(); databaseOpen = false; currentDatabase = ""; page = "picker"; applySystemTheme(); } }} on:setupcomplete={async () => { await fetchDatabaseRight(); await fetchSqlQueryEnabled(); navigate(isWide() ? "dual" : "records"); }} on:saved={async () => { fetchCustomHeader(); fetchDefaultPage(); applyTheme(); fetchPopupNotifEnabled(); await fetchDatabaseRight(); await fetchSqlQueryEnabled(); fetchShutdownMenuEnabled(); fetchUpdateCheck(); }} on:shutdown-pending={() => { shutdownPendingSince = Date.now(); }} on:shutdown={() => { setShutdownState(); }} />
+      <Settings databaseName={currentDatabase} pickerMode={pickerMode} initialTab={settingsTab} bind:highlightSection={settingsHighlight} {clientCount} {authRefreshTrigger} on:disconnect-others={async () => { const nonce = Math.random().toString(36).slice(2); disconnectNonce = nonce; try { await fetch("/api/events/disconnect-others", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ nonce }) }); } catch {} }} on:deleted={e => { if (e.detail.shutdown) { setShutdownState(); } else { stopAppServices(); databaseOpen = false; currentDatabase = ""; page = "picker"; applySystemTheme(); } }} on:setupcomplete={async () => { await fetchDatabaseRight(); await fetchSqlQueryEnabled(); navigate(isWide() ? "dual" : "records"); }} on:saved={async () => { fetchCustomHeader(); fetchDefaultPage(); applyTheme(); fetchPopupNotifEnabled(); await fetchDatabaseRight(); await fetchSqlQueryEnabled(); fetchUpdateCheck(); }} on:shutdown-pending={() => { shutdownPendingSince = Date.now(); }} on:shutdown={() => { setShutdownState(); }} />
     {:else if page === "scratchpad"}
       <Scratchpad />
     {:else if page === "about"}
@@ -1673,10 +1673,6 @@
 
   .menu-item.close-database {
     color: var(--text-muted);
-  }
-
-  .menu-item.menu-shutdown {
-    color: var(--danger, #e74c3c);
   }
 
   .auth-blocked {

--- a/frontend/src/Records.svelte
+++ b/frontend/src/Records.svelte
@@ -716,6 +716,7 @@
              on:dragover|preventDefault
              on:dragleave={() => { attDragCounter--; if (attDragCounter <= 0) { attDragCounter = 0; dragOver = false; } }}
              on:drop={handleDrop}>
+          <!-- svelte-ignore a11y-label-has-associated-control -->
           <label>Attachments</label>
           <div class="attachment-upload">
             <button class="attachment-choose-btn" on:click={() => fileInput.click()}>Choose files</button>
@@ -738,6 +739,7 @@
                   {:else if att.content_type.startsWith("video/")}
                     <!-- svelte-ignore a11y-click-events-have-key-events -->
                     <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+                    <!-- svelte-ignore a11y-media-has-caption -->
                     <video preload="metadata" src={attDownloadUrl(att)} class="attachment-thumb" on:click={() => openPreview(att)}></video>
                   {/if}
                   <div class="attachment-info">
@@ -870,12 +872,6 @@
     min-height: 0;
     flex: 1;
     overflow: auto;
-  }
-
-  .records-page.page-drag-active {
-    outline: 2px dashed var(--accent, #00ff88);
-    outline-offset: -4px;
-    background: rgba(0, 255, 136, 0.03);
   }
 
   .records-header {

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -2317,8 +2317,8 @@
     justify-content: center;
   }
   .mtls-modal {
-    background: var(--bg-primary);
-    border: 1px solid var(--border-color);
+    background: var(--bg-card, var(--bg-primary, #24252b));
+    border: 1px solid var(--border, var(--border-color, #3a3b3f));
     border-radius: 8px;
     max-width: 480px;
     width: 90%;

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -2359,8 +2359,14 @@
   }
   .mtls-radio input[type="radio"] {
     margin: 0;
-    flex-shrink: 0;
+    flex: 0 0 auto;
+    width: 14px;
+    height: 14px;
     cursor: pointer;
+  }
+  .mtls-radio span {
+    flex: 1;
+    min-width: 0;
   }
   .mtls-radio input[type="radio"]:disabled {
     cursor: wait;

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -1558,37 +1558,19 @@
     {:else if mtlsProxyMode}
       <p class="hint">mTLS is unavailable in proxy mode. Configure mTLS at your reverse proxy instead.</p>
     {:else}
-      <p class="hint">
-        mTLS mode: <strong>{mtlsMode}</strong>
-        {#if mtlsMode === "disabled"}
-          — Client certificate authentication is not active.
-        {:else if mtlsMode === "optional"}
-          — Both cookie and client certificate authentication are accepted.
-        {:else if mtlsMode === "required"}
-          — Only client certificates are accepted. Cookie auth is disabled.
-        {/if}
-      </p>
-
-      <div class="setting-row" style="gap: 0.5rem; flex-wrap: wrap;">
-        {#if mtlsMode === "disabled"}
-          <button on:click={() => activateMtls("optional")} disabled={mtlsActivating}>
-            {mtlsActivating ? "Activating..." : "Enable mTLS (Optional)"}
-          </button>
-        {:else if mtlsMode === "optional"}
-          <button on:click={() => activateMtls("required")} disabled={mtlsActivating}>
-            {mtlsActivating ? "Activating..." : "Require mTLS Only"}
-          </button>
-          <button class="warning-btn" on:click={() => activateMtls("disabled")} disabled={mtlsActivating}>
-            Disable mTLS
-          </button>
-        {:else if mtlsMode === "required"}
-          <button class="warning-btn" on:click={() => activateMtls("optional")} disabled={mtlsActivating}>
-            Downgrade to Optional
-          </button>
-          <button class="danger-btn" on:click={() => activateMtls("disabled")} disabled={mtlsActivating}>
-            Disable mTLS
-          </button>
-        {/if}
+      <div class="mtls-radio-group">
+        <label class="mtls-radio">
+          <input type="radio" name="mtls-mode" value="disabled" checked={mtlsMode === "disabled"} disabled={mtlsActivating} on:change={() => activateMtls("disabled")} />
+          <span><strong>Disabled</strong> — cookie auth only</span>
+        </label>
+        <label class="mtls-radio">
+          <input type="radio" name="mtls-mode" value="optional" checked={mtlsMode === "optional"} disabled={mtlsActivating} on:change={() => activateMtls("optional")} />
+          <span><strong>Optional</strong> — both cookie and client certificate accepted</span>
+        </label>
+        <label class="mtls-radio">
+          <input type="radio" name="mtls-mode" value="required" checked={mtlsMode === "required"} disabled={mtlsActivating} on:change={() => activateMtls("required")} />
+          <span><strong>Enforced</strong> — only client certificates accepted</span>
+        </label>
       </div>
       <p class="hint" style="margin-top: 0.5rem; color: var(--warning-color, #e6a700);">Mode changes require a server restart to take effect.</p>
 
@@ -2345,5 +2327,26 @@
   }
   .session-revoked {
     opacity: 0.5;
+  }
+
+  /* mTLS radio group */
+  .mtls-radio-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  .mtls-radio {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.8rem;
+    cursor: pointer;
+  }
+  .mtls-radio input[type="radio"] {
+    margin: 0;
+    cursor: pointer;
+  }
+  .mtls-radio input[type="radio"]:disabled {
+    cursor: wait;
   }
 </style>

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -1590,9 +1590,7 @@
           </button>
         {/if}
       </div>
-      {#if mtlsMode !== "disabled"}
-        <p class="hint" style="margin-top: 0.5rem; color: var(--warning-color, #e6a700);">Mode changes require a server restart to take effect.</p>
-      {/if}
+      <p class="hint" style="margin-top: 0.5rem; color: var(--warning-color, #e6a700);">Mode changes require a server restart to take effect.</p>
 
       {#if mtlsMode !== "disabled" || mtlsCerts.length > 0}
         <h4 style="margin-top: 1rem; margin-bottom: 0.5rem;">Generate Client Certificate</h4>

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -2103,6 +2103,9 @@
     color: var(--text-dim);
     margin: 0;
   }
+  p.hint + .setting-row {
+    margin-top: 0.5rem;
+  }
 
   .danger-zone {
     border-color: #ff4444;

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -198,6 +198,22 @@
     location.reload();
   }
 
+  async function mtlsLogout() {
+    mtlsError = "";
+    try {
+      const res = await fetch("/api/auth/mtls/logout", { method: "POST" });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        mtlsError = data?.detail || "Failed to revoke certificate";
+        return;
+      }
+    } catch (e) {
+      mtlsError = e.message;
+      return;
+    }
+    await loadMtlsStatus();
+  }
+
   let copiedField = null;
   async function copyToClipboard(text, field) {
     try {
@@ -227,6 +243,7 @@
 
   $: if (authRefreshTrigger) { loadAuthSessions(); loadAuthStatus(); loadMtlsStatus(); }
   $: authAvailableSlots = authSlots === 0 ? Infinity : Math.max(0, authSlots - authSessions.filter(s => !s.is_transfer).length);
+  $: mtlsCurrentCert = mtlsCerts.find(c => c.is_current && !c.revoked_at);
 
   // mTLS
   let mtlsMode = "disabled";
@@ -1587,10 +1604,11 @@
         <h4 style="margin-top: 1rem; margin-bottom: 0.5rem;">Issued Certificates</h4>
         <div class="session-list">
           {#each mtlsCerts as cert (cert.id)}
-            <div class="session-item" class:session-revoked={cert.revoked_at}>
+            <div class="session-item" class:session-current={cert.is_current} class:session-revoked={cert.revoked_at}>
               <div class="session-info">
                 <span class="session-label">
                   {cert.label}
+                  {#if cert.is_current} <strong>(current)</strong>{/if}
                   {#if cert.revoked_at}<em style="color: var(--danger-color, #cc3333);"> (revoked)</em>{/if}
                 </span>
                 <span class="session-meta">
@@ -1599,7 +1617,7 @@
                   — Expires {formatAuthTime(cert.expires_at)}
                 </span>
               </div>
-              {#if !cert.revoked_at}
+              {#if !cert.revoked_at && !cert.is_current}
                 <button class="session-delete" on:click={() => revokeClientCert(cert.id)} title="Revoke this certificate">Revoke</button>
               {/if}
             </div>
@@ -1676,10 +1694,17 @@
 
   <section class="settings-section">
     <h3>Logout</h3>
-    <p class="hint">Log out of this browser session. You will need a new login link to access the server again.</p>
-    <div class="setting-row">
-      <button class="danger-btn" on:click={logoutSession}>Logout</button>
-    </div>
+    {#if mtlsCurrentCert}
+      <p class="hint">Revoke your current client certificate. You will need a new mTLS certificate to reconnect, or restart the server with <code style="font-size: 0.75rem; white-space: nowrap">--reset-auth</code> to revert to login link mode.</p>
+      <div class="setting-row">
+        <button class="danger-btn" on:click={mtlsLogout}>Revoke Certificate &amp; Logout</button>
+      </div>
+    {:else}
+      <p class="hint">Log out of this browser session. You will need a new login link to access the server again.</p>
+      <div class="setting-row">
+        <button class="danger-btn" on:click={logoutSession}>Logout</button>
+      </div>
+    {/if}
   </section>
 
   {#if authError}

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -1559,15 +1559,15 @@
       <p class="hint">mTLS is unavailable in proxy mode. Configure mTLS at your reverse proxy instead.</p>
     {:else}
       <div class="mtls-radio-group">
-        <label class="mtls-radio">
+        <label class="mtls-radio" class:active={mtlsMode === "disabled"}>
           <input type="radio" name="mtls-mode" value="disabled" checked={mtlsMode === "disabled"} disabled={mtlsActivating} on:change={() => activateMtls("disabled")} />
           <span><strong>Disabled</strong> — cookie auth only</span>
         </label>
-        <label class="mtls-radio">
+        <label class="mtls-radio" class:active={mtlsMode === "optional"}>
           <input type="radio" name="mtls-mode" value="optional" checked={mtlsMode === "optional"} disabled={mtlsActivating} on:change={() => activateMtls("optional")} />
           <span><strong>Optional</strong> — both cookie and client certificate accepted</span>
         </label>
-        <label class="mtls-radio">
+        <label class="mtls-radio" class:active={mtlsMode === "required"}>
           <input type="radio" name="mtls-mode" value="required" checked={mtlsMode === "required"} disabled={mtlsActivating} on:change={() => activateMtls("required")} />
           <span><strong>Enforced</strong> — only client certificates accepted</span>
         </label>
@@ -2333,17 +2333,33 @@
   .mtls-radio-group {
     display: flex;
     flex-direction: column;
-    gap: 0.4rem;
+    border: 1px solid var(--border, var(--border-color, #3a3b3f));
+    border-radius: 6px;
+    overflow: hidden;
   }
   .mtls-radio {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.6rem;
+    padding: 0.5rem 0.75rem;
     font-size: 0.8rem;
     cursor: pointer;
+    margin: 0;
+    border-bottom: 1px solid var(--border, var(--border-color, #3a3b3f));
+    transition: background 0.15s;
+  }
+  .mtls-radio:last-child {
+    border-bottom: none;
+  }
+  .mtls-radio:hover {
+    background: var(--bg-hover, rgba(255, 255, 255, 0.04));
+  }
+  .mtls-radio.active {
+    background: var(--bg-hover, rgba(255, 255, 255, 0.06));
   }
   .mtls-radio input[type="radio"] {
     margin: 0;
+    flex-shrink: 0;
     cursor: pointer;
   }
   .mtls-radio input[type="radio"]:disabled {

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -225,8 +225,110 @@
     return `in ${Math.floor(fdiff / 86400)}d`;
   }
 
-  $: if (authRefreshTrigger) { loadAuthSessions(); loadAuthStatus(); }
+  $: if (authRefreshTrigger) { loadAuthSessions(); loadAuthStatus(); loadMtlsStatus(); }
   $: authAvailableSlots = authSlots === 0 ? Infinity : Math.max(0, authSlots - authSessions.filter(s => !s.is_transfer).length);
+
+  // mTLS
+  let mtlsMode = "disabled";
+  let mtlsTlsEnabled = true;
+  let mtlsProxyMode = false;
+  let mtlsCaInitialized = false;
+  let mtlsCerts = [];
+  let mtlsGenerating = false;
+  let mtlsError = "";
+  let mtlsShowCertModal = false;
+  let mtlsCertDownloadToken = "";
+  let mtlsCertPassword = "";
+  let mtlsCertFingerprint = "";
+  let mtlsCertLabel = "";
+  let mtlsActivating = false;
+
+  async function loadMtlsStatus() {
+    try {
+      const res = await fetch("/api/auth/mtls/status");
+      if (res.ok) {
+        const data = await res.json();
+        mtlsMode = data.mode;
+        mtlsTlsEnabled = data.tls_enabled;
+        mtlsProxyMode = data.proxy_mode;
+        mtlsCaInitialized = data.ca_initialized;
+        mtlsCerts = data.certs;
+      }
+    } catch {}
+  }
+
+  async function generateClientCert() {
+    mtlsError = "";
+    mtlsGenerating = true;
+    try {
+      const res = await fetch("/api/auth/mtls/generate-cert", { method: "POST" });
+      if (res.ok) {
+        const data = await res.json();
+        mtlsCertDownloadToken = data.download_token;
+        mtlsCertPassword = data.password;
+        mtlsCertFingerprint = data.fingerprint;
+        mtlsCertLabel = data.label;
+        mtlsShowCertModal = true;
+      } else {
+        const data = await res.json().catch(() => null);
+        mtlsError = data?.detail || "Failed to generate certificate";
+      }
+    } catch (e) {
+      mtlsError = e.message;
+    }
+    mtlsGenerating = false;
+    await loadMtlsStatus();
+  }
+
+  function dismissCertModal() {
+    mtlsShowCertModal = false;
+    mtlsCertDownloadToken = "";
+    mtlsCertPassword = "";
+    mtlsCertFingerprint = "";
+    mtlsCertLabel = "";
+  }
+
+  function downloadCert() {
+    if (mtlsCertDownloadToken) {
+      window.open(`/api/auth/mtls/download/${mtlsCertDownloadToken}`, "_blank");
+    }
+  }
+
+  async function revokeClientCert(certId) {
+    mtlsError = "";
+    try {
+      const res = await fetch(`/api/auth/mtls/certs/${certId}`, { method: "DELETE" });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        mtlsError = data?.detail || "Failed to revoke certificate";
+      }
+    } catch (e) {
+      mtlsError = e.message;
+    }
+    await loadMtlsStatus();
+  }
+
+  async function activateMtls(mode) {
+    mtlsError = "";
+    mtlsActivating = true;
+    try {
+      const res = await fetch("/api/auth/mtls/activate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode }),
+      });
+      if (res.ok) {
+        await loadMtlsStatus();
+        await loadAuthStatus();
+      } else {
+        const data = await res.json().catch(() => null);
+        mtlsError = data?.detail || "Failed to activate mTLS";
+      }
+    } catch (e) {
+      mtlsError = e.message;
+    }
+    mtlsActivating = false;
+  }
 
   async function loadDbInfo() {
     try {
@@ -1051,6 +1153,7 @@
     fetchNoShutdown();
     loadAuthStatus();
     loadAuthSessions();
+    loadMtlsStatus();
   });
 
   onDestroy(() => {
@@ -1445,7 +1548,89 @@
   <div class="tab-scroll"><div class="tab-content" use:masonry>
   <section class="settings-section">
     <h3>Authentication</h3>
-    <p class="hint">Authentication is currently enforced. Only browsers with a valid session cookie can access the app. Use <code style="font-size: 0.75rem; white-space: nowrap">--disable-auth</code> at startup to turn authentication off.</p>
+    <p class="hint">Authentication is currently enforced. Only browsers with a valid session cookie{#if mtlsMode !== "disabled"} or mTLS client certificate{/if} can access the app. Use <code style="font-size: 0.75rem; white-space: nowrap">--disable-auth</code> at startup to turn authentication off.</p>
+  </section>
+
+  <section class="settings-section">
+    <h3>Client Certificates (mTLS)</h3>
+    {#if !mtlsTlsEnabled}
+      <p class="hint">mTLS is unavailable because TLS is disabled. Remove <code style="font-size: 0.75rem; white-space: nowrap">--no-tls</code> to enable.</p>
+    {:else if mtlsProxyMode}
+      <p class="hint">mTLS is unavailable in proxy mode. Configure mTLS at your reverse proxy instead.</p>
+    {:else}
+      <p class="hint">
+        mTLS mode: <strong>{mtlsMode}</strong>
+        {#if mtlsMode === "disabled"}
+          — Client certificate authentication is not active.
+        {:else if mtlsMode === "optional"}
+          — Both cookie and client certificate authentication are accepted.
+        {:else if mtlsMode === "required"}
+          — Only client certificates are accepted. Cookie auth is disabled.
+        {/if}
+      </p>
+
+      <div class="setting-row" style="gap: 0.5rem; flex-wrap: wrap;">
+        {#if mtlsMode === "disabled"}
+          <button on:click={() => activateMtls("optional")} disabled={mtlsActivating}>
+            {mtlsActivating ? "Activating..." : "Enable mTLS (Optional)"}
+          </button>
+        {:else if mtlsMode === "optional"}
+          <button on:click={() => activateMtls("required")} disabled={mtlsActivating}>
+            {mtlsActivating ? "Activating..." : "Require mTLS Only"}
+          </button>
+          <button class="warning-btn" on:click={() => activateMtls("disabled")} disabled={mtlsActivating}>
+            Disable mTLS
+          </button>
+        {:else if mtlsMode === "required"}
+          <button class="warning-btn" on:click={() => activateMtls("optional")} disabled={mtlsActivating}>
+            Downgrade to Optional
+          </button>
+          <button class="danger-btn" on:click={() => activateMtls("disabled")} disabled={mtlsActivating}>
+            Disable mTLS
+          </button>
+        {/if}
+      </div>
+      {#if mtlsMode !== "disabled"}
+        <p class="hint" style="margin-top: 0.5rem; color: var(--warning-color, #e6a700);">Mode changes require a server restart to take effect.</p>
+      {/if}
+
+      {#if mtlsMode !== "disabled" || mtlsCerts.length > 0}
+        <h4 style="margin-top: 1rem; margin-bottom: 0.5rem;">Generate Client Certificate</h4>
+        <div class="setting-row">
+          <button on:click={generateClientCert} disabled={mtlsGenerating}>
+            {mtlsGenerating ? "Generating..." : "Generate Client Certificate"}
+          </button>
+        </div>
+      {/if}
+
+      {#if mtlsCerts.length > 0}
+        <h4 style="margin-top: 1rem; margin-bottom: 0.5rem;">Issued Certificates</h4>
+        <div class="session-list">
+          {#each mtlsCerts as cert (cert.id)}
+            <div class="session-item" class:session-revoked={cert.revoked_at}>
+              <div class="session-info">
+                <span class="session-label">
+                  {cert.label}
+                  {#if cert.revoked_at}<em style="color: var(--danger-color, #cc3333);"> (revoked)</em>{/if}
+                </span>
+                <span class="session-meta">
+                  Fingerprint: {cert.fingerprint_sha256.slice(0, 16)}...
+                  — Issued {formatAuthTime(cert.issued_at)}
+                  — Expires {formatAuthTime(cert.expires_at)}
+                </span>
+              </div>
+              {#if !cert.revoked_at}
+                <button class="session-delete" on:click={() => revokeClientCert(cert.id)} title="Revoke this certificate">Revoke</button>
+              {/if}
+            </div>
+          {/each}
+        </div>
+      {/if}
+    {/if}
+
+    {#if mtlsError}
+      <p class="danger-error" style="margin-top: 0.5rem;">{mtlsError}</p>
+    {/if}
   </section>
 
 
@@ -1526,6 +1711,52 @@
   {/if}
 
 </div>
+
+{#if mtlsShowCertModal}
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<div class="mtls-modal-backdrop" on:click={dismissCertModal}>
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
+  <div class="mtls-modal" on:click|stopPropagation>
+    <div class="mtls-modal-header">
+      <h3>Client Certificate Generated</h3>
+      <button class="modal-close" on:click={dismissCertModal}>&times;</button>
+    </div>
+    <div class="mtls-modal-body">
+      <p style="color: var(--warning-color, #e6a700); font-weight: bold; margin-bottom: 1rem;">
+        This information will not be shown again. The download link is single-use.
+      </p>
+      <div style="margin-bottom: 1rem;">
+        <span style="font-size: 0.8rem; opacity: 0.7; display: block;">Label</span>
+        <div style="font-family: monospace;">{mtlsCertLabel}</div>
+      </div>
+      <div style="margin-bottom: 1rem;">
+        <span style="font-size: 0.8rem; opacity: 0.7; display: block;">Fingerprint (SHA-256)</span>
+        <div style="font-family: monospace; font-size: 0.8rem; word-break: break-all;">{mtlsCertFingerprint}</div>
+      </div>
+      <div style="margin-bottom: 1rem;">
+        <span style="font-size: 0.8rem; opacity: 0.7; display: block;">Import Password</span>
+        <div class="token-url-box">
+          <input type="text" value={mtlsCertPassword} readonly on:click={(e) => e.target.select()} />
+          <button class="copy-btn" class:copied={copiedField === 'mtls-pw'} on:click={() => copyToClipboard(mtlsCertPassword, 'mtls-pw')}>{copiedField === 'mtls-pw' ? 'Copied!' : 'Copy'}</button>
+        </div>
+      </div>
+      <div style="margin-bottom: 1rem;">
+        <button on:click={downloadCert} style="width: 100%;">Download .p12 Certificate</button>
+      </div>
+      <p class="hint">
+        1. Download the .p12 file above.<br>
+        2. Import it into your browser's certificate store using the password shown.<br>
+        3. When prompted by the server, select this certificate.
+      </p>
+    </div>
+    <div class="mtls-modal-footer">
+      <button on:click={dismissCertModal}>Done</button>
+    </div>
+  </div>
+</div>
+{/if}
 
 <style>
   .settings {
@@ -2070,5 +2301,48 @@
     background: var(--success-color, #2ea043);
     color: #fff;
     border-color: var(--success-color, #2ea043);
+  }
+
+  /* mTLS modal */
+  .mtls-modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    z-index: 100000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .mtls-modal {
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    max-width: 480px;
+    width: 90%;
+    max-height: 90vh;
+    overflow-y: auto;
+  }
+  .mtls-modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem;
+    border-bottom: 1px solid var(--border-color);
+  }
+  .mtls-modal-header h3 {
+    margin: 0;
+    font-size: 1rem;
+  }
+  .mtls-modal-body {
+    padding: 1rem;
+  }
+  .mtls-modal-footer {
+    padding: 1rem;
+    border-top: 1px solid var(--border-color);
+    display: flex;
+    justify-content: flex-end;
+  }
+  .session-revoked {
+    opacity: 0.5;
   }
 </style>

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -1602,7 +1602,7 @@
 
       {#if mtlsCerts.length > 0}
         <h4 style="margin-top: 1rem; margin-bottom: 0.5rem;">Issued Certificates</h4>
-        <div class="session-list">
+        <div class="session-list mtls-cert-list">
           {#each mtlsCerts as cert (cert.id)}
             <div class="session-item" class:session-current={cert.is_current} class:session-revoked={cert.revoked_at}>
               <div class="session-info">
@@ -2352,6 +2352,10 @@
   }
   .session-revoked {
     opacity: 0.5;
+  }
+  .mtls-cert-list {
+    max-height: 12rem;
+    overflow-y: auto;
   }
 
   /* mTLS radio group */

--- a/src/guidebook/db.py
+++ b/src/guidebook/db.py
@@ -358,15 +358,17 @@ GLOBAL_MIGRATIONS: list = []
 def _global_migration_1_client_certs(conn):
     """Create client_certs table for mTLS support."""
     conn.execute(
-        "CREATE TABLE IF NOT EXISTS client_certs ("
-        "id INTEGER PRIMARY KEY, "
-        "serial_number VARCHAR NOT NULL UNIQUE, "
-        "label VARCHAR NOT NULL DEFAULT '', "
-        "issued_at REAL NOT NULL, "
-        "expires_at REAL NOT NULL, "
-        "revoked_at REAL, "
-        "fingerprint_sha256 VARCHAR NOT NULL"
-        ")"
+        text(
+            "CREATE TABLE IF NOT EXISTS client_certs ("
+            "id INTEGER PRIMARY KEY, "
+            "serial_number VARCHAR NOT NULL UNIQUE, "
+            "label VARCHAR NOT NULL DEFAULT '', "
+            "issued_at REAL NOT NULL, "
+            "expires_at REAL NOT NULL, "
+            "revoked_at REAL, "
+            "fingerprint_sha256 VARCHAR NOT NULL"
+            ")"
+        )
     )
 
 

--- a/src/guidebook/db.py
+++ b/src/guidebook/db.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 logger = logging.getLogger("guidebook")
 
+
 def _default_data_dir() -> Path:
     if sys.platform == "darwin":
         return Path.home() / "Library" / "Application Support" / "guidebook"
@@ -23,7 +24,10 @@ def _default_data_dir() -> Path:
         if appdata:
             return Path(appdata) / "guidebook"
         return Path.home() / "AppData" / "Roaming" / "guidebook"
-    return Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share")) / "guidebook"
+    return (
+        Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
+        / "guidebook"
+    )
 
 
 DB_DIR = _default_data_dir()
@@ -220,6 +224,18 @@ class AuthToken(GlobalBase):
     jwt_nonce: Mapped[str | None] = mapped_column(String, nullable=True)
 
 
+class ClientCert(GlobalBase):
+    __tablename__ = "client_certs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    serial_number: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    label: Mapped[str] = mapped_column(String, nullable=False, default="")
+    issued_at: Mapped[float] = mapped_column(Float, nullable=False)
+    expires_at: Mapped[float] = mapped_column(Float, nullable=False)
+    revoked_at: Mapped[float | None] = mapped_column(Float, nullable=True)
+    fingerprint_sha256: Mapped[str] = mapped_column(String, nullable=False)
+
+
 class DatabaseLockError(Exception):
     """Raised when the database is already locked by another process."""
 
@@ -337,6 +353,24 @@ DATABASE_MIGRATIONS: list = []
 # --- Global DB migrations ---
 
 GLOBAL_MIGRATIONS: list = []
+
+
+def _global_migration_1_client_certs(conn):
+    """Create client_certs table for mTLS support."""
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS client_certs ("
+        "id INTEGER PRIMARY KEY, "
+        "serial_number VARCHAR NOT NULL UNIQUE, "
+        "label VARCHAR NOT NULL DEFAULT '', "
+        "issued_at REAL NOT NULL, "
+        "expires_at REAL NOT NULL, "
+        "revoked_at REAL, "
+        "fingerprint_sha256 VARCHAR NOT NULL"
+        ")"
+    )
+
+
+GLOBAL_MIGRATIONS.append(_global_migration_1_client_certs)
 
 
 class DatabaseManager:

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -48,6 +48,7 @@ from guidebook.routes.global_settings import router as global_settings_router
 from guidebook.routes.update import router as update_router
 from guidebook.routes.scratchpad import router as scratchpad_router
 from guidebook.routes.media import router as media_router
+from guidebook.routes.mtls import router as mtls_router
 from guidebook._build_info import BUILD_GITHUB_ACTIONS, BUILD_ORIGIN_REPO, GIT_SHA
 
 logger = logging.getLogger("guidebook")
@@ -161,6 +162,30 @@ def _rate_limit_429(retry_after: int) -> Response:
     )
 
 
+async def _check_mtls_auth(request: Request, gdb) -> bool:
+    """Check if request is authenticated via mTLS client certificate."""
+    peer_cert_der = request.scope.get("mtls_peer_cert_der")
+    if not peer_cert_der:
+        return False
+    try:
+        from cryptography.x509 import load_der_x509_certificate
+        from sqlalchemy import select
+
+        cert = load_der_x509_certificate(peer_cert_der)
+        serial_hex = format(cert.serial_number, "x")
+        from guidebook.db import ClientCert
+
+        result = await gdb.execute(
+            select(ClientCert).where(
+                ClientCert.serial_number == serial_hex,
+                ClientCert.revoked_at.is_(None),
+            )
+        )
+        return result.scalar_one_or_none() is not None
+    except Exception:
+        return False
+
+
 @app.middleware("http")
 async def http_middleware(request: Request, call_next):
     from guidebook.ratelimit import auth_limiter
@@ -183,7 +208,10 @@ async def http_middleware(request: Request, call_next):
 
         if db_manager._global_session_factory:
             async with db_manager._global_session_factory() as gdb:
-                ok = await check_auth(request, gdb)
+                # Try mTLS auth first, fall back to cookie auth
+                ok = await _check_mtls_auth(request, gdb) or await check_auth(
+                    request, gdb
+                )
                 if not ok:
                     from fastapi.responses import JSONResponse
 
@@ -240,7 +268,9 @@ async def http_middleware(request: Request, call_next):
             from guidebook.routes.auth import check_auth
 
             async with db_manager._global_session_factory() as gdb:
-                ok = await check_auth(request, gdb)
+                ok = await _check_mtls_auth(request, gdb) or await check_auth(
+                    request, gdb
+                )
                 if not ok:
                     from fastapi.responses import HTMLResponse
 
@@ -497,6 +527,7 @@ app.include_router(query_router)
 app.include_router(update_router)
 app.include_router(scratchpad_router)
 app.include_router(media_router)
+app.include_router(mtls_router)
 app.include_router(sse_router)
 
 static_dir = _resource_path("static")
@@ -887,9 +918,18 @@ environment variables (overridden by command line options):
                 "INSERT INTO auth_tokens (token, label, created_at, last_seen_at, expires_at, is_transfer) VALUES (?, ?, ?, ?, ?, ?)",
                 (token_str, "Login link", now, None, None, 0),
             )
+            # Reset mTLS state
+            try:
+                conn.execute("DELETE FROM client_certs")
+            except sqlite3.OperationalError:
+                pass  # table may not exist yet
+            for k in ("mtls_mode", "ca_cert_pem", "ca_key_pem"):
+                conn.execute("DELETE FROM settings WHERE key = ?", (k,))
             conn.commit()
             os.environ["_GUIDEBOOK_RESET_AUTH_TOKEN"] = token_str
-            print("Auth reset: all sessions cleared, new login token generated.")
+            print(
+                "Auth reset: all sessions and mTLS state cleared, new login token generated."
+            )
 
         # Ensure JWT signing secret exists
         row = conn.execute(
@@ -1024,6 +1064,8 @@ environment variables (overridden by command line options):
 
     ssl_kwargs = {}
     if not no_tls:
+        import ssl as _ssl
+
         from guidebook.db import META_DB_PATH
         from guidebook.tls import ensure_tls_cert, write_tls_temp_files
 
@@ -1031,6 +1073,69 @@ environment variables (overridden by command line options):
         certfile, keyfile = write_tls_temp_files(cert_pem, key_pem)
         ssl_kwargs = {"ssl_certfile": certfile, "ssl_keyfile": keyfile}
         logger.info("TLS enabled (self-signed certificate)")
+
+        # mTLS configuration
+        import sqlite3 as _sq
+
+        _mconn = _sq.connect(str(META_DB_PATH))
+        _mrow = _mconn.execute(
+            "SELECT value FROM settings WHERE key = 'mtls_mode'"
+        ).fetchone()
+        _mtls_mode = _mrow[0] if _mrow and _mrow[0] else "disabled"
+        _mconn.close()
+
+        if _mtls_mode in ("optional", "required"):
+            from guidebook.tls import (
+                ensure_ca_cert,
+                generate_crl,
+                write_ca_temp_file,
+            )
+
+            ca_cert_pem, ca_key_pem = ensure_ca_cert(str(META_DB_PATH))
+            ca_certfile = write_ca_temp_file(ca_cert_pem)
+            ssl_kwargs["ssl_ca_certs"] = ca_certfile
+            ssl_kwargs["ssl_cert_reqs"] = (
+                _ssl.CERT_REQUIRED if _mtls_mode == "required" else _ssl.CERT_OPTIONAL
+            )
+
+            # Build CRL from revoked certs
+            _cconn = _sq.connect(str(META_DB_PATH))
+            _revoked = _cconn.execute(
+                "SELECT serial_number, revoked_at FROM client_certs WHERE revoked_at IS NOT NULL"
+            ).fetchall()
+            _cconn.close()
+            if _revoked:
+                import datetime
+
+                revoked_serials = [
+                    (
+                        int(s, 16),
+                        datetime.datetime.fromtimestamp(t, tz=datetime.timezone.utc),
+                    )
+                    for s, t in _revoked
+                ]
+                crl_pem = generate_crl(ca_cert_pem, ca_key_pem, revoked_serials)
+                # Append CRL to the CA certs file so ssl context loads it
+                with open(ca_certfile, "a") as f:
+                    f.write("\n")
+                    f.write(crl_pem)
+
+            logger.info("mTLS enabled (mode: %s)", _mtls_mode)
+
+            # Monkey-patch uvicorn to inject peer cert into ASGI scope
+            from uvicorn.protocols.http.httptools_impl import HttpToolsProtocol
+
+            _orig_on_message_begin = HttpToolsProtocol.on_message_begin
+
+            def _patched_on_message_begin(self):
+                _orig_on_message_begin(self)
+                ssl_obj = self.transport.get_extra_info("ssl_object")
+                if ssl_obj:
+                    peer_cert_der = ssl_obj.getpeercert(binary_form=True)
+                    if peer_cert_der:
+                        self.scope["mtls_peer_cert_der"] = peer_cert_der
+
+            HttpToolsProtocol.on_message_begin = _patched_on_message_begin
 
     server_app = app
     if proxy_mode:

--- a/src/guidebook/routes/auth.py
+++ b/src/guidebook/routes/auth.py
@@ -161,6 +161,9 @@ class AuthStatusResponse(BaseModel):
     slots: int
     session_count: int
     allow_transfer: bool
+    tls_enabled: bool
+    proxy_mode: bool
+    mtls_mode: str
 
 
 @router.get("/status")
@@ -177,12 +180,16 @@ async def auth_status(
     if not enabled:
         authenticated = True  # no auth needed
     count = await _token_count(gdb)
+    mtls_mode = await _get_setting(gdb, "mtls_mode") or "disabled"
     return AuthStatusResponse(
         enabled=enabled,
         authenticated=authenticated,
         slots=AUTH_SLOTS,
         session_count=count,
         allow_transfer=ALLOW_TRANSFER,
+        tls_enabled=TLS_ENABLED,
+        proxy_mode=PROXY_MODE,
+        mtls_mode=mtls_mode,
     )
 
 

--- a/src/guidebook/routes/mtls.py
+++ b/src/guidebook/routes/mtls.py
@@ -1,0 +1,261 @@
+"""mTLS client certificate management endpoints."""
+
+import logging
+import secrets
+import time
+from dataclasses import dataclass
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from guidebook.db import ClientCert, GlobalSetting, get_global_session
+
+logger = logging.getLogger("guidebook")
+
+router = APIRouter(prefix="/api/auth/mtls", tags=["mtls"])
+
+PENDING_DOWNLOAD_TTL = 600  # 10 minutes
+
+
+@dataclass
+class PendingDownload:
+    p12_bytes: bytes
+    password: str
+    created_at: float
+    expires_at: float
+
+
+# In-memory only — .p12 bytes and passwords never touch disk or DB
+_pending_downloads: dict[str, PendingDownload] = {}
+
+
+def _cleanup_expired() -> None:
+    """Remove expired pending downloads."""
+    now = time.time()
+    expired = [k for k, v in _pending_downloads.items() if v.expires_at < now]
+    for k in expired:
+        del _pending_downloads[k]
+
+
+async def _get_setting(gdb: AsyncSession, key: str) -> str | None:
+    row = (
+        await gdb.execute(select(GlobalSetting).where(GlobalSetting.key == key))
+    ).scalar_one_or_none()
+    return row.value if row else None
+
+
+async def _set_setting(gdb: AsyncSession, key: str, value: str) -> None:
+    from sqlalchemy.dialects.sqlite import insert
+
+    stmt = insert(GlobalSetting).values(key=key, value=value)
+    stmt = stmt.on_conflict_do_update(index_elements=["key"], set_={"value": value})
+    await gdb.execute(stmt)
+
+
+class MtlsStatusResponse(BaseModel):
+    mode: str
+    ca_initialized: bool
+    tls_enabled: bool
+    proxy_mode: bool
+    certs: list[dict]
+
+
+@router.get("/status")
+async def mtls_status(
+    gdb: AsyncSession = Depends(get_global_session),
+):
+    from guidebook.routes.auth import TLS_ENABLED, PROXY_MODE
+
+    mode = await _get_setting(gdb, "mtls_mode") or "disabled"
+    ca_cert = await _get_setting(gdb, "ca_cert_pem")
+
+    result = await gdb.execute(select(ClientCert).order_by(ClientCert.issued_at.desc()))
+    certs = [
+        {
+            "id": c.id,
+            "serial_number": c.serial_number,
+            "label": c.label,
+            "issued_at": c.issued_at,
+            "expires_at": c.expires_at,
+            "revoked_at": c.revoked_at,
+            "fingerprint_sha256": c.fingerprint_sha256,
+        }
+        for c in result.scalars().all()
+    ]
+
+    return MtlsStatusResponse(
+        mode=mode,
+        ca_initialized=bool(ca_cert),
+        tls_enabled=TLS_ENABLED,
+        proxy_mode=PROXY_MODE,
+        certs=certs,
+    )
+
+
+class GenerateCertResponse(BaseModel):
+    download_token: str
+    password: str
+    fingerprint: str
+    label: str
+
+
+@router.post("/generate-cert")
+async def generate_cert(
+    request: Request,
+    gdb: AsyncSession = Depends(get_global_session),
+):
+    """Generate a client certificate. Returns download token and password (shown once)."""
+    from guidebook.routes.auth import TLS_ENABLED, PROXY_MODE
+
+    if not TLS_ENABLED:
+        raise HTTPException(400, "TLS is not enabled. mTLS requires TLS.")
+    if PROXY_MODE:
+        raise HTTPException(400, "mTLS is not available in proxy mode.")
+
+    from guidebook.db import META_DB_PATH
+    from guidebook.tls import ensure_ca_cert, generate_client_cert
+
+    ca_cert_pem, ca_key_pem = ensure_ca_cert(str(META_DB_PATH))
+
+    # Count active (non-revoked) certs
+    result = await gdb.execute(
+        select(ClientCert).where(ClientCert.revoked_at.is_(None))
+    )
+    active_count = len(result.scalars().all())
+    label = f"client-{active_count + 1}"
+
+    p12_bytes, password, serial_hex, fingerprint = generate_client_cert(
+        ca_cert_pem, ca_key_pem, label
+    )
+
+    # Store cert metadata in DB (no private key material)
+    now = time.time()
+    from guidebook.tls import CERT_VALIDITY_DAYS
+
+    gdb.add(
+        ClientCert(
+            serial_number=serial_hex,
+            label=label,
+            issued_at=now,
+            expires_at=now + CERT_VALIDITY_DAYS * 86400,
+            fingerprint_sha256=fingerprint,
+        )
+    )
+    await gdb.commit()
+
+    # Store .p12 in memory only (never touches DB or disk)
+    _cleanup_expired()
+    download_token = secrets.token_urlsafe(48)
+    _pending_downloads[download_token] = PendingDownload(
+        p12_bytes=p12_bytes,
+        password=password,
+        created_at=now,
+        expires_at=now + PENDING_DOWNLOAD_TTL,
+    )
+
+    logger.info(
+        "Generated client certificate: %s (fingerprint: %s...)", label, fingerprint[:16]
+    )
+    return GenerateCertResponse(
+        download_token=download_token,
+        password=password,
+        fingerprint=fingerprint,
+        label=label,
+    )
+
+
+@router.get("/download/{download_token}")
+async def download_cert(download_token: str):
+    """Single-use .p12 download. Returns 410 if already downloaded or expired."""
+    _cleanup_expired()
+
+    pending = _pending_downloads.pop(download_token, None)
+    if not pending:
+        raise HTTPException(410, "Download link expired or already used.")
+
+    if time.time() > pending.expires_at:
+        raise HTTPException(410, "Download link expired.")
+
+    return Response(
+        content=pending.p12_bytes,
+        media_type="application/x-pkcs12",
+        headers={
+            "Content-Disposition": 'attachment; filename="guidebook-client.p12"',
+            "Cache-Control": "no-store",
+        },
+    )
+
+
+@router.get("/certs")
+async def list_certs(
+    gdb: AsyncSession = Depends(get_global_session),
+):
+    """List all issued client certificates."""
+    result = await gdb.execute(select(ClientCert).order_by(ClientCert.issued_at.desc()))
+    return [
+        {
+            "id": c.id,
+            "serial_number": c.serial_number,
+            "label": c.label,
+            "issued_at": c.issued_at,
+            "expires_at": c.expires_at,
+            "revoked_at": c.revoked_at,
+            "fingerprint_sha256": c.fingerprint_sha256,
+        }
+        for c in result.scalars().all()
+    ]
+
+
+@router.delete("/certs/{cert_id}")
+async def revoke_cert(
+    cert_id: int,
+    gdb: AsyncSession = Depends(get_global_session),
+):
+    """Revoke a client certificate."""
+    result = await gdb.execute(select(ClientCert).where(ClientCert.id == cert_id))
+    cert = result.scalar_one_or_none()
+    if not cert:
+        raise HTTPException(404, "Certificate not found.")
+    if cert.revoked_at:
+        raise HTTPException(400, "Certificate is already revoked.")
+
+    cert.revoked_at = time.time()
+    await gdb.commit()
+    logger.info(
+        "Revoked client certificate: %s (serial: %s)", cert.label, cert.serial_number
+    )
+    return {"status": "revoked", "id": cert_id, "restart_required": True}
+
+
+class ActivateRequest(BaseModel):
+    mode: str
+
+
+@router.post("/activate")
+async def activate_mtls(
+    body: ActivateRequest,
+    gdb: AsyncSession = Depends(get_global_session),
+):
+    """Set mTLS mode. Requires server restart to take effect."""
+    from guidebook.routes.auth import TLS_ENABLED, PROXY_MODE
+
+    if not TLS_ENABLED:
+        raise HTTPException(400, "TLS is not enabled. mTLS requires TLS.")
+    if PROXY_MODE:
+        raise HTTPException(400, "mTLS is not available in proxy mode.")
+    if body.mode not in ("disabled", "optional", "required"):
+        raise HTTPException(400, f"Invalid mode: {body.mode}")
+
+    if body.mode != "disabled":
+        # Ensure CA exists
+        from guidebook.db import META_DB_PATH
+        from guidebook.tls import ensure_ca_cert
+
+        ensure_ca_cert(str(META_DB_PATH))
+
+    await _set_setting(gdb, "mtls_mode", body.mode)
+    await gdb.commit()
+    logger.info("mTLS mode set to: %s (restart required)", body.mode)
+    return {"status": "ok", "mode": body.mode, "restart_required": True}

--- a/src/guidebook/routes/mtls.py
+++ b/src/guidebook/routes/mtls.py
@@ -62,14 +62,30 @@ class MtlsStatusResponse(BaseModel):
     certs: list[dict]
 
 
+def _get_peer_cert_serial(request: Request) -> str | None:
+    """Extract the serial number (hex) of the client cert from the TLS connection."""
+    peer_cert_der = request.scope.get("mtls_peer_cert_der")
+    if not peer_cert_der:
+        return None
+    try:
+        from cryptography.x509 import load_der_x509_certificate
+
+        cert = load_der_x509_certificate(peer_cert_der)
+        return format(cert.serial_number, "x")
+    except Exception:
+        return None
+
+
 @router.get("/status")
 async def mtls_status(
+    request: Request,
     gdb: AsyncSession = Depends(get_global_session),
 ):
     from guidebook.routes.auth import TLS_ENABLED, PROXY_MODE
 
     mode = await _get_setting(gdb, "mtls_mode") or "disabled"
     ca_cert = await _get_setting(gdb, "ca_cert_pem")
+    current_serial = _get_peer_cert_serial(request)
 
     result = await gdb.execute(select(ClientCert).order_by(ClientCert.issued_at.desc()))
     certs = [
@@ -81,6 +97,8 @@ async def mtls_status(
             "expires_at": c.expires_at,
             "revoked_at": c.revoked_at,
             "fingerprint_sha256": c.fingerprint_sha256,
+            "is_current": current_serial is not None
+            and c.serial_number == current_serial,
         }
         for c in result.scalars().all()
     ]
@@ -259,3 +277,33 @@ async def activate_mtls(
     await gdb.commit()
     logger.info("mTLS mode set to: %s (restart required)", body.mode)
     return {"status": "ok", "mode": body.mode, "restart_required": True}
+
+
+@router.post("/logout")
+async def mtls_logout(
+    request: Request,
+    gdb: AsyncSession = Depends(get_global_session),
+):
+    """Revoke the client certificate used for the current connection."""
+    current_serial = _get_peer_cert_serial(request)
+    if not current_serial:
+        raise HTTPException(400, "No client certificate detected on this connection.")
+
+    result = await gdb.execute(
+        select(ClientCert).where(
+            ClientCert.serial_number == current_serial,
+            ClientCert.revoked_at.is_(None),
+        )
+    )
+    cert = result.scalar_one_or_none()
+    if not cert:
+        raise HTTPException(404, "Current certificate not found or already revoked.")
+
+    cert.revoked_at = time.time()
+    await gdb.commit()
+    logger.info(
+        "mTLS logout: revoked current certificate %s (serial: %s)",
+        cert.label,
+        cert.serial_number,
+    )
+    return {"status": "revoked", "restart_required": True}

--- a/src/guidebook/tls.py
+++ b/src/guidebook/tls.py
@@ -2,6 +2,7 @@ import atexit
 import datetime
 import logging
 import os
+import secrets
 import sqlite3
 import tempfile
 
@@ -20,9 +21,11 @@ def generate_self_signed_cert() -> tuple[str, str]:
 
     key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
 
-    subject = issuer = x509.Name([
-        x509.NameAttribute(NameOID.COMMON_NAME, "guidebook"),
-    ])
+    subject = issuer = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COMMON_NAME, "guidebook"),
+        ]
+    )
 
     now = datetime.datetime.now(datetime.timezone.utc)
     cert = (
@@ -34,11 +37,13 @@ def generate_self_signed_cert() -> tuple[str, str]:
         .not_valid_before(now)
         .not_valid_after(now + datetime.timedelta(days=CERT_VALIDITY_DAYS))
         .add_extension(
-            x509.SubjectAlternativeName([
-                x509.DNSName("localhost"),
-                x509.IPAddress(ipaddress.IPv4Address("127.0.0.1")),
-                x509.IPAddress(ipaddress.IPv6Address("::1")),
-            ]),
+            x509.SubjectAlternativeName(
+                [
+                    x509.DNSName("localhost"),
+                    x509.IPAddress(ipaddress.IPv4Address("127.0.0.1")),
+                    x509.IPAddress(ipaddress.IPv6Address("::1")),
+                ]
+            ),
             critical=False,
         )
         .sign(key, hashes.SHA256())
@@ -52,6 +57,193 @@ def generate_self_signed_cert() -> tuple[str, str]:
     ).decode()
 
     return cert_pem, key_pem
+
+
+def generate_ca_cert() -> tuple[str, str]:
+    """Generate a CA certificate and key for signing client certs. Returns (cert_pem, key_pem)."""
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+    subject = issuer = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COMMON_NAME, "guidebook-ca"),
+        ]
+    )
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=CERT_VALIDITY_DAYS))
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=0),
+            critical=True,
+        )
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=False,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=True,
+                crl_sign=True,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .sign(key, hashes.SHA256())
+    )
+
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    ).decode()
+
+    return cert_pem, key_pem
+
+
+def ensure_ca_cert(meta_db_path: str) -> tuple[str, str]:
+    """Load or generate CA cert/key from the global database. Returns (cert_pem, key_pem)."""
+    os.makedirs(os.path.dirname(meta_db_path), exist_ok=True)
+    conn = sqlite3.connect(meta_db_path)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS settings "
+        "(id INTEGER NOT NULL PRIMARY KEY, key VARCHAR NOT NULL UNIQUE, value VARCHAR)"
+    )
+
+    row_cert = conn.execute(
+        "SELECT value FROM settings WHERE key = 'ca_cert_pem'"
+    ).fetchone()
+    row_key = conn.execute(
+        "SELECT value FROM settings WHERE key = 'ca_key_pem'"
+    ).fetchone()
+
+    if row_cert and row_key and row_cert[0] and row_key[0]:
+        conn.close()
+        logger.info("Loaded CA certificate from database")
+        return row_cert[0], row_key[0]
+
+    logger.info("Generating new CA certificate (valid %d days)", CERT_VALIDITY_DAYS)
+    cert_pem, key_pem = generate_ca_cert()
+    conn.execute(
+        "INSERT OR REPLACE INTO settings (key, value) VALUES ('ca_cert_pem', ?)",
+        (cert_pem,),
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO settings (key, value) VALUES ('ca_key_pem', ?)",
+        (key_pem,),
+    )
+    conn.commit()
+    conn.close()
+    return cert_pem, key_pem
+
+
+def generate_client_cert(
+    ca_cert_pem: str, ca_key_pem: str, label: str
+) -> tuple[bytes, str, str, str]:
+    """Generate a client certificate signed by the CA, bundled as PKCS#12.
+
+    Returns (p12_bytes, password, serial_hex, fingerprint_sha256).
+    """
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.hazmat.primitives.serialization import (
+        pkcs12,
+        BestAvailableEncryption,
+    )
+    from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+    ca_cert = x509.load_pem_x509_certificate(ca_cert_pem.encode())
+    ca_key = serialization.load_pem_private_key(ca_key_pem.encode(), password=None)
+
+    client_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    serial = x509.random_serial_number()
+    client_cert = (
+        x509.CertificateBuilder()
+        .subject_name(
+            x509.Name(
+                [
+                    x509.NameAttribute(
+                        NameOID.COMMON_NAME, f"guidebook-client-{label}"
+                    ),
+                ]
+            )
+        )
+        .issuer_name(ca_cert.subject)
+        .public_key(client_key.public_key())
+        .serial_number(serial)
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=CERT_VALIDITY_DAYS))
+        .add_extension(
+            x509.ExtendedKeyUsage([ExtendedKeyUsageOID.CLIENT_AUTH]),
+            critical=True,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+
+    password = secrets.token_urlsafe(24)
+    p12_bytes = pkcs12.serialize_key_and_certificates(
+        name=b"guidebook-client",
+        key=client_key,
+        cert=client_cert,
+        cas=[ca_cert],
+        encryption_algorithm=BestAvailableEncryption(password.encode()),
+    )
+
+    fingerprint = client_cert.fingerprint(hashes.SHA256()).hex()
+    serial_hex = format(serial, "x")
+
+    return p12_bytes, password, serial_hex, fingerprint
+
+
+def generate_crl(
+    ca_cert_pem: str,
+    ca_key_pem: str,
+    revoked_serials: list[tuple[int, datetime.datetime]],
+) -> str:
+    """Generate a PEM-encoded CRL containing revoked serial numbers.
+
+    revoked_serials is a list of (serial_number_int, revocation_datetime).
+    Returns CRL as PEM string.
+    """
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+
+    ca_cert = x509.load_pem_x509_certificate(ca_cert_pem.encode())
+    ca_key = serialization.load_pem_private_key(ca_key_pem.encode(), password=None)
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    builder = x509.CertificateRevocationListBuilder()
+    builder = builder.issuer_name(ca_cert.subject)
+    builder = builder.last_update(now)
+    builder = builder.next_update(now + datetime.timedelta(days=CERT_VALIDITY_DAYS))
+
+    for serial_int, revoked_at in revoked_serials:
+        revoked_cert = (
+            x509.RevokedCertificateBuilder()
+            .serial_number(serial_int)
+            .revocation_date(revoked_at)
+            .build()
+        )
+        builder = builder.add_revoked_certificate(revoked_cert)
+
+    crl = builder.sign(ca_key, hashes.SHA256())
+    return crl.public_bytes(serialization.Encoding.PEM).decode()
 
 
 def ensure_tls_cert(meta_db_path: str) -> tuple[str, str]:
@@ -75,7 +267,9 @@ def ensure_tls_cert(meta_db_path: str) -> tuple[str, str]:
         logger.info("Loaded TLS certificate from database")
         return row_cert[0], row_key[0]
 
-    logger.info("Generating new self-signed TLS certificate (valid %d days)", CERT_VALIDITY_DAYS)
+    logger.info(
+        "Generating new self-signed TLS certificate (valid %d days)", CERT_VALIDITY_DAYS
+    )
     cert_pem, key_pem = generate_self_signed_cert()
     conn.execute(
         "INSERT OR REPLACE INTO settings (key, value) VALUES ('tls_cert_pem', ?)",
@@ -119,3 +313,39 @@ def write_tls_temp_files(cert_pem: str, key_pem: str) -> tuple[str, str]:
 
     atexit.register(cleanup)
     return cert_file.name, key_file.name
+
+
+def write_ca_temp_file(ca_cert_pem: str) -> str:
+    """Write CA cert PEM to a temp file for uvicorn ssl_ca_certs. Returns path."""
+    ca_file = tempfile.NamedTemporaryFile(
+        delete=False, suffix=".pem", prefix="guidebook_ca_"
+    )
+    ca_file.write(ca_cert_pem.encode())
+    ca_file.close()
+
+    def cleanup():
+        try:
+            os.unlink(ca_file.name)
+        except OSError:
+            pass
+
+    atexit.register(cleanup)
+    return ca_file.name
+
+
+def write_crl_temp_file(crl_pem: str) -> str:
+    """Write CRL PEM to a temp file. Returns path."""
+    crl_file = tempfile.NamedTemporaryFile(
+        delete=False, suffix=".pem", prefix="guidebook_crl_"
+    )
+    crl_file.write(crl_pem.encode())
+    crl_file.close()
+
+    def cleanup():
+        try:
+            os.unlink(crl_file.name)
+        except OSError:
+            pass
+
+    atexit.register(cleanup)
+    return crl_file.name


### PR DESCRIPTION
## Summary

- Add mTLS client certificate authentication as an optional upgrade from cookie-based auth
- Server acts as its own CA, generates PKCS#12 (.p12) client certs with one-time ephemeral download
- Three modes: disabled (default), optional (both cookie and cert), enforced (cert only)
- Client cert list shows current cert, revocation support, CRL enforcement
- Logout revokes current cert when connected via mTLS
- `--reset-auth` clears all mTLS state (CA, certs, mode)
- Settings UI with radio group for mode selection, cert generation modal, issued cert list
- Fix all pre-existing frontend build warnings
- Add spacing between hint text and action buttons across Settings

## Commits

- acd0f80 Support mTLS client certificates as auth upgrade (fixes #10)
- 70f94fc Fix migration to use text() for SQLAlchemy compatibility
- 96b448a Add spacing between hint text and action buttons
- d35f95a Fix all build warnings and modal background transparency
- 9961a3f Show restart notice for mTLS even when disabled
- 290a614 Replace mTLS mode buttons with radio group
- 6d2aa36 Style mTLS radio group as a cohesive bordered card
- 16ab208 Fix mTLS radio button column width
- a69867a Show current mTLS cert, revoke via Logout, update logout text for mTLS mode
- fd961e8 Make issued certificates list scrollable after ~3 items
- 17bdc03 Update README to mention optional mTLS support