### PR TITLE
mTLS authentication and CA management

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -557,6 +557,7 @@
     eventSource.addEventListener("clients", (e) => {
       const data = JSON.parse(e.data);
       clientCount = data.count;
+      authRefreshTrigger++;
     });
     eventSource.addEventListener("disconnect", (e) => {
       const data = JSON.parse(e.data);

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -202,8 +202,7 @@
 
   async function tryRenewSession() {
     try {
-      const res = await fetch("/api/auth/renew", { method: "POST" });
-      if (res.status === 401) location.reload();
+      await fetch("/api/auth/renew", { method: "POST" });
     } catch {}
   }
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -556,8 +556,11 @@
     });
     eventSource.addEventListener("clients", (e) => {
       const data = JSON.parse(e.data);
+      const prev = clientCount;
       clientCount = data.count;
-      authRefreshTrigger++;
+      if (data.count !== prev) {
+        authRefreshTrigger++;
+      }
     });
     eventSource.addEventListener("disconnect", (e) => {
       const data = JSON.parse(e.data);

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -2402,7 +2402,7 @@
     color: #111;
   }
   .auth-badge.cookie {
-    background: var(--text-dim, #888);
+    background: var(--accent, #00ff88);
     color: #111;
   }
   .mtls-cert-list {

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -254,7 +254,7 @@
     return ua.length > 30 ? ua.slice(0, 30) + "..." : ua;
   }
 
-  $: if (authRefreshTrigger) { loadAuthSessions(); loadAuthStatus(); loadMtlsStatus(); }
+  $: if (authRefreshTrigger) { loadAuthSessions(); loadAuthStatus(); loadMtlsStatus(); authTokenUrl = ""; authTransferUrl = ""; }
   $: activeCertCount = mtlsCerts.filter(c => !c.revoked_at).length;
   $: authAvailableSlots = authSlots === 0 ? Infinity : Math.max(0, authSlots - authSessions.filter(s => !s.is_transfer).length - activeCertCount);
   $: mtlsCurrentCert = mtlsCerts.find(c => c.is_current && !c.revoked_at);

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -2306,8 +2306,8 @@
     cursor: pointer;
     flex-shrink: 0;
   }
-  .session-delete:hover {
-    background: #ff4444;
+  .session-delete:hover:not(:disabled) {
+    background: #ff4444 !important;
     color: #fff;
     border-color: #ff4444;
   }

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -1653,7 +1653,7 @@
               <span class="session-label">
                 <span class="auth-badge mtls">mTLS</span>
                 {cert.label}
-                {#if cert.is_current} <strong>(current)</strong>{/if}
+                {#if cert.is_current} <strong>(you)</strong>{/if}
               </span>
               <span class="session-meta">
                 Fingerprint: {cert.fingerprint_sha256.slice(0, 16)}...
@@ -1672,7 +1672,7 @@
               <span class="session-label">
                 <span class="auth-badge cookie">cookie</span>
                 {session.label}
-                {#if session.is_current && !mtlsCurrentCert} <strong>(current)</strong>{/if}
+                {#if session.is_current && !mtlsCurrentCert} <strong>(you)</strong>{/if}
                 {#if session.is_transfer} <em>(transfer pending)</em>{/if}
               </span>
               <span class="session-meta">{#if session.user_agent}{shortUserAgent(session.user_agent)} — {/if}Created {formatAuthTime(session.created_at)}{#if session.last_seen_at} — last seen {formatAuthTime(session.last_seen_at)}{:else} — never used{/if}{#if session.last_ip} — IP {session.last_ip}{/if}{#if session.expires_at} — expires {formatAuthTime(session.expires_at)}{/if}</span>

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -242,7 +242,8 @@
   }
 
   $: if (authRefreshTrigger) { loadAuthSessions(); loadAuthStatus(); loadMtlsStatus(); }
-  $: authAvailableSlots = authSlots === 0 ? Infinity : Math.max(0, authSlots - authSessions.filter(s => !s.is_transfer).length);
+  $: activeCertCount = mtlsCerts.filter(c => !c.revoked_at).length;
+  $: authAvailableSlots = authSlots === 0 ? Infinity : Math.max(0, authSlots - authSessions.filter(s => !s.is_transfer).length - activeCertCount);
   $: mtlsCurrentCert = mtlsCerts.find(c => c.is_current && !c.revoked_at);
 
   // mTLS
@@ -1594,8 +1595,8 @@
       {#if mtlsMode !== "disabled" || mtlsCerts.length > 0}
         <h4 style="margin-top: 1rem; margin-bottom: 0.5rem;">Generate Client Certificate</h4>
         <div class="setting-row">
-          <button on:click={generateClientCert} disabled={mtlsGenerating}>
-            {mtlsGenerating ? "Generating..." : "Generate Client Certificate"}
+          <button on:click={generateClientCert} disabled={mtlsGenerating || (authSlots > 0 && authAvailableSlots <= 0)}>
+            {mtlsGenerating ? "Generating..." : authSlots > 0 && authAvailableSlots <= 0 ? `No slots available (${authSlots} used)` : "Generate Client Certificate"}
           </button>
         </div>
       {/if}

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -273,10 +273,12 @@
   let mtlsGenerating = false;
   let mtlsError = "";
   let mtlsShowCertModal = false;
+  let mtlsCertGenerated = false;
   let mtlsCertDownloadToken = "";
   let mtlsCertPassword = "";
   let mtlsCertFingerprint = "";
   let mtlsCertLabel = "";
+  let mtlsCertLabelInput = "";
   let mtlsActivating = false;
 
   async function loadMtlsStatus() {
@@ -294,18 +296,32 @@
     } catch {}
   }
 
+  function openCertModal() {
+    mtlsCertGenerated = false;
+    mtlsCertLabelInput = `client-${mtlsCerts.filter(c => !c.revoked_at).length + 1}`;
+    mtlsCertDownloadToken = "";
+    mtlsCertPassword = "";
+    mtlsCertFingerprint = "";
+    mtlsCertLabel = "";
+    mtlsShowCertModal = true;
+  }
+
   async function generateClientCert() {
     mtlsError = "";
     mtlsGenerating = true;
     try {
-      const res = await fetch("/api/auth/mtls/generate-cert", { method: "POST" });
+      const res = await fetch("/api/auth/mtls/generate-cert", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ label: mtlsCertLabelInput }),
+      });
       if (res.ok) {
         const data = await res.json();
         mtlsCertDownloadToken = data.download_token;
         mtlsCertPassword = data.password;
         mtlsCertFingerprint = data.fingerprint;
         mtlsCertLabel = data.label;
-        mtlsShowCertModal = true;
+        mtlsCertGenerated = true;
       } else {
         const data = await res.json().catch(() => null);
         mtlsError = data?.detail || "Failed to generate certificate";
@@ -319,10 +335,12 @@
 
   function dismissCertModal() {
     mtlsShowCertModal = false;
+    mtlsCertGenerated = false;
     mtlsCertDownloadToken = "";
     mtlsCertPassword = "";
     mtlsCertFingerprint = "";
     mtlsCertLabel = "";
+    mtlsCertLabelInput = "";
   }
 
   function downloadCert() {
@@ -1614,8 +1632,8 @@
       {#if mtlsMode !== "disabled" || mtlsCerts.length > 0}
         <h4 style="margin-top: 1rem; margin-bottom: 0.5rem;">Generate Client Certificate</h4>
         <div class="setting-row">
-          <button on:click={generateClientCert} disabled={mtlsGenerating || (authSlots > 0 && authAvailableSlots <= 0 && !authSessions.some(s => s.is_current))}>
-            {mtlsGenerating ? "Generating..." : authSlots > 0 && authAvailableSlots <= 0 && !authSessions.some(s => s.is_current) ? `No slots available (${authSlots} used)` : "Generate Client Certificate"}
+          <button on:click={openCertModal} disabled={authSlots > 0 && authAvailableSlots <= 0 && !authSessions.some(s => s.is_current)}>
+            {authSlots > 0 && authAvailableSlots <= 0 && !authSessions.some(s => s.is_current) ? `No slots available (${authSlots} used)` : "Generate Client Certificate"}
           </button>
         </div>
       {/if}
@@ -1805,41 +1823,61 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="mtls-modal" on:click|stopPropagation>
-    <div class="mtls-modal-header">
-      <h3>Client Certificate Generated</h3>
-      <button class="modal-close" on:click={dismissCertModal}>&times;</button>
-    </div>
-    <div class="mtls-modal-body">
-      <p style="color: var(--warning-color, #e6a700); font-weight: bold; margin-bottom: 1rem;">
-        This information will not be shown again. The download link is single-use.
-      </p>
-      <div style="margin-bottom: 1rem;">
-        <span style="font-size: 0.8rem; opacity: 0.7; display: block;">Label</span>
-        <div style="font-family: monospace;">{mtlsCertLabel}</div>
+    {#if !mtlsCertGenerated}
+      <div class="mtls-modal-header">
+        <h3>Generate Client Certificate</h3>
+        <button class="modal-close" on:click={dismissCertModal}>&times;</button>
       </div>
-      <div style="margin-bottom: 1rem;">
-        <span style="font-size: 0.8rem; opacity: 0.7; display: block;">Fingerprint (SHA-256)</span>
-        <div style="font-family: monospace; font-size: 0.8rem; word-break: break-all;">{mtlsCertFingerprint}</div>
-      </div>
-      <div style="margin-bottom: 1rem;">
-        <span style="font-size: 0.8rem; opacity: 0.7; display: block;">Import Password</span>
-        <div class="token-url-box">
-          <input type="text" value={mtlsCertPassword} readonly on:click={(e) => e.target.select()} />
-          <button class="copy-btn" class:copied={copiedField === 'mtls-pw'} on:click={() => copyToClipboard(mtlsCertPassword, 'mtls-pw')}>{copiedField === 'mtls-pw' ? 'Copied!' : 'Copy'}</button>
+      <div class="mtls-modal-body">
+        <div style="margin-bottom: 1rem;">
+          <span style="font-size: 0.8rem; opacity: 0.7; display: block; margin-bottom: 0.3rem;">Label</span>
+          <input type="text" bind:value={mtlsCertLabelInput} placeholder="client-1" style="width: 100%; box-sizing: border-box;" />
         </div>
+        <p class="hint">Choose a name to identify this certificate (e.g. browser name, device, or person).</p>
       </div>
-      <div style="margin-bottom: 1rem;">
-        <button on:click={downloadCert} style="width: 100%;">Download .p12 Certificate</button>
+      <div class="mtls-modal-footer">
+        <button on:click={dismissCertModal} style="margin-right: auto;">Cancel</button>
+        <button on:click={generateClientCert} disabled={mtlsGenerating || !mtlsCertLabelInput.trim()}>
+          {mtlsGenerating ? "Generating..." : "Generate"}
+        </button>
       </div>
-      <p class="hint">
-        1. Download the .p12 file above.<br>
-        2. Import it into your browser's certificate store using the password shown.<br>
-        3. When prompted by the server, select this certificate.
-      </p>
-    </div>
-    <div class="mtls-modal-footer">
-      <button on:click={dismissCertModal}>Done</button>
-    </div>
+    {:else}
+      <div class="mtls-modal-header">
+        <h3>Client Certificate Generated</h3>
+        <button class="modal-close" on:click={dismissCertModal}>&times;</button>
+      </div>
+      <div class="mtls-modal-body">
+        <p style="color: var(--warning-color, #e6a700); font-weight: bold; margin-bottom: 1rem;">
+          This information will not be shown again. The download link is single-use.
+        </p>
+        <div style="margin-bottom: 1rem;">
+          <span style="font-size: 0.8rem; opacity: 0.7; display: block;">Label</span>
+          <div style="font-family: monospace;">{mtlsCertLabel}</div>
+        </div>
+        <div style="margin-bottom: 1rem;">
+          <span style="font-size: 0.8rem; opacity: 0.7; display: block;">Fingerprint (SHA-256)</span>
+          <div style="font-family: monospace; font-size: 0.8rem; word-break: break-all;">{mtlsCertFingerprint}</div>
+        </div>
+        <div style="margin-bottom: 1rem;">
+          <span style="font-size: 0.8rem; opacity: 0.7; display: block;">Import Password</span>
+          <div class="token-url-box">
+            <input type="text" value={mtlsCertPassword} readonly on:click={(e) => e.target.select()} />
+            <button class="copy-btn" class:copied={copiedField === 'mtls-pw'} on:click={() => copyToClipboard(mtlsCertPassword, 'mtls-pw')}>{copiedField === 'mtls-pw' ? 'Copied!' : 'Copy'}</button>
+          </div>
+        </div>
+        <div style="margin-bottom: 1rem;">
+          <button on:click={downloadCert} style="width: 100%;">Download .p12 Certificate</button>
+        </div>
+        <p class="hint">
+          1. Download the .p12 file above.<br>
+          2. Import it into your browser's certificate store using the password shown.<br>
+          3. When prompted by the server, select this certificate.
+        </p>
+      </div>
+      <div class="mtls-modal-footer">
+        <button on:click={dismissCertModal}>Done</button>
+      </div>
+    {/if}
   </div>
 </div>
 {/if}

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -1616,7 +1616,7 @@
   <div class="tab-scroll"><div class="tab-content" use:masonry>
   <section class="settings-section">
     <h3>Authentication</h3>
-    <p class="hint">Authentication is currently enforced. Only browsers with a valid session cookie{#if mtlsMode !== "disabled"} or mTLS client certificate{/if} can access the app. Use <code style="font-size: 0.75rem; white-space: nowrap">--disable-auth</code> at startup to turn authentication off.</p>
+    <p class="hint">{#if mtlsMode === "required"}Authentication is currently enforced with mTLS certificates only.{:else if mtlsMode === "disabled"}Authentication is currently enforced with session cookies only.{:else}Authentication is currently enforced with session cookies and/or mTLS certificates.{/if} Use <code style="font-size: 0.75rem; white-space: nowrap">--disable-auth</code> at startup to turn authentication off completely.</p>
   </section>
 
   <section class="settings-section">

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -2307,8 +2307,9 @@
     flex-shrink: 0;
   }
   .session-delete:hover {
-    background: var(--btn-secondary-hover, #444);
-    color: var(--text, #eee);
+    background: #ff4444;
+    color: #fff;
+    border-color: #ff4444;
   }
   .token-url-box {
     display: flex;

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -258,6 +258,10 @@
   $: activeCertCount = mtlsCerts.filter(c => !c.revoked_at).length;
   $: authAvailableSlots = authSlots === 0 ? Infinity : Math.max(0, authSlots - authSessions.filter(s => !s.is_transfer).length - activeCertCount);
   $: mtlsCurrentCert = mtlsCerts.find(c => c.is_current && !c.revoked_at);
+  $: connectedCerts = mtlsCerts.filter(c => !c.revoked_at && c.is_connected);
+  $: inactiveCerts = mtlsCerts.filter(c => !c.revoked_at && !c.is_connected);
+  $: connectedSessions = authSessions.filter(s => s.is_connected);
+  $: inactiveSessions = authSessions.filter(s => !s.is_connected);
 
   // mTLS
   let mtlsMode = "disabled";
@@ -1642,12 +1646,10 @@
 
 
   <section class="settings-section">
-    <h3>Active Clients</h3>
-    {#if authSessions.length === 0 && mtlsCerts.filter(c => !c.revoked_at).length === 0}
-      <p class="hint">No active clients.</p>
-    {:else}
+    <h3>Clients</h3>
+    {#if connectedCerts.length > 0 || connectedSessions.length > 0}
       <div class="session-list">
-        {#each mtlsCerts.filter(c => !c.revoked_at) as cert (cert.serial_number)}
+        {#each connectedCerts as cert (cert.serial_number)}
           <div class="session-item" class:session-current={cert.is_current}>
             <div class="session-info">
               <span class="session-label">
@@ -1658,7 +1660,6 @@
               <span class="session-meta">
                 Fingerprint: {cert.fingerprint_sha256.slice(0, 16)}...
                 — Issued {formatAuthTime(cert.issued_at)}
-                — Expires {formatAuthTime(cert.expires_at)}
               </span>
             </div>
             {#if !cert.is_current}
@@ -1666,16 +1667,15 @@
             {/if}
           </div>
         {/each}
-        {#each authSessions as session (session.id)}
+        {#each connectedSessions as session (session.id)}
           <div class="session-item" class:session-current={session.is_current}>
             <div class="session-info">
               <span class="session-label">
                 <span class="auth-badge cookie">cookie</span>
                 {shortUserAgent(session.user_agent) || "Unknown browser"}{#if session.last_ip} — {session.last_ip}{/if}
                 {#if session.is_current && !mtlsCurrentCert} <strong>(you)</strong>{/if}
-                {#if session.is_transfer} <em>(transfer pending)</em>{/if}
               </span>
-              <span class="session-meta">Created {formatAuthTime(session.created_at)}{#if session.last_seen_at} — last seen {formatAuthTime(session.last_seen_at)}{:else} — never used{/if}{#if session.expires_at} — expires {formatAuthTime(session.expires_at)}{/if}</span>
+              <span class="session-meta">Created {formatAuthTime(session.created_at)}{#if session.last_seen_at} — last seen {formatAuthTime(session.last_seen_at)}{/if}{#if session.expires_at} — expires {formatAuthTime(session.expires_at)}{/if}</span>
             </div>
             {#if !session.is_current || mtlsCurrentCert}
               <button class="session-delete" on:click={() => deleteSession(session.id)} title="Revoke this session">Revoke</button>
@@ -1683,6 +1683,44 @@
           </div>
         {/each}
       </div>
+    {/if}
+
+    {#if inactiveCerts.length > 0 || inactiveSessions.length > 0}
+      <h4 style="margin-top: 0.75rem; margin-bottom: 0.4rem; font-size: 0.8rem; color: var(--text-dim);">Inactive</h4>
+      <div class="session-list">
+        {#each inactiveCerts as cert (cert.serial_number)}
+          <div class="session-item">
+            <div class="session-info">
+              <span class="session-label">
+                <span class="auth-badge mtls">mTLS</span>
+                {cert.label}
+              </span>
+              <span class="session-meta">
+                Fingerprint: {cert.fingerprint_sha256.slice(0, 16)}...
+                — Issued {formatAuthTime(cert.issued_at)}
+              </span>
+            </div>
+            <button class="session-delete" on:click={() => revokeClientCert(cert.id)} title="Revoke this certificate">Revoke</button>
+          </div>
+        {/each}
+        {#each inactiveSessions as session (session.id)}
+          <div class="session-item">
+            <div class="session-info">
+              <span class="session-label">
+                <span class="auth-badge cookie">cookie</span>
+                {shortUserAgent(session.user_agent) || "Unknown browser"}{#if session.last_ip} — {session.last_ip}{/if}
+                {#if session.is_transfer} <em>(invited)</em>{/if}
+              </span>
+              <span class="session-meta">{#if session.last_seen_at}Last seen {formatAuthTime(session.last_seen_at)}{:else}Never connected{/if}{#if session.expires_at} — expires {formatAuthTime(session.expires_at)}{/if}</span>
+            </div>
+            <button class="session-delete" on:click={() => deleteSession(session.id)} title="Revoke this session">Revoke</button>
+          </div>
+        {/each}
+      </div>
+    {/if}
+
+    {#if connectedCerts.length === 0 && connectedSessions.length === 0 && inactiveCerts.length === 0 && inactiveSessions.length === 0}
+      <p class="hint">No clients.</p>
     {/if}
   </section>
 

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -1601,16 +1601,15 @@
         </div>
       {/if}
 
-      {#if mtlsCerts.length > 0}
-        <h4 style="margin-top: 1rem; margin-bottom: 0.5rem;">Issued Certificates</h4>
+      {#if mtlsCerts.filter(c => !c.revoked_at).length > 0}
+        <h4 style="margin-top: 1rem; margin-bottom: 0.5rem;">Active Certificates</h4>
         <div class="session-list mtls-cert-list">
-          {#each mtlsCerts as cert (cert.id)}
-            <div class="session-item" class:session-current={cert.is_current} class:session-revoked={cert.revoked_at}>
+          {#each mtlsCerts.filter(c => !c.revoked_at) as cert (cert.id)}
+            <div class="session-item" class:session-current={cert.is_current}>
               <div class="session-info">
                 <span class="session-label">
                   {cert.label}
                   {#if cert.is_current} <strong>(current)</strong>{/if}
-                  {#if cert.revoked_at}<em style="color: var(--danger-color, #cc3333);"> (revoked)</em>{/if}
                 </span>
                 <span class="session-meta">
                   Fingerprint: {cert.fingerprint_sha256.slice(0, 16)}...
@@ -1618,12 +1617,32 @@
                   — Expires {formatAuthTime(cert.expires_at)}
                 </span>
               </div>
-              {#if !cert.revoked_at && !cert.is_current}
+              {#if !cert.is_current}
                 <button class="session-delete" on:click={() => revokeClientCert(cert.id)} title="Revoke this certificate">Revoke</button>
               {/if}
             </div>
           {/each}
         </div>
+      {/if}
+
+      {#if mtlsCerts.filter(c => c.revoked_at).length > 0}
+        <details class="mtls-revoked-accordion" style="margin-top: 0.75rem;">
+          <summary>Revoked Certificates ({mtlsCerts.filter(c => c.revoked_at).length})</summary>
+          <div class="session-list mtls-cert-list">
+            {#each mtlsCerts.filter(c => c.revoked_at) as cert (cert.id)}
+              <div class="session-item session-revoked">
+                <div class="session-info">
+                  <span class="session-label">{cert.label}</span>
+                  <span class="session-meta">
+                    Fingerprint: {cert.fingerprint_sha256.slice(0, 16)}...
+                    — Issued {formatAuthTime(cert.issued_at)}
+                    — Revoked {formatAuthTime(cert.revoked_at)}
+                  </span>
+                </div>
+              </div>
+            {/each}
+          </div>
+        </details>
       {/if}
     {/if}
 
@@ -2357,6 +2376,20 @@
   .mtls-cert-list {
     max-height: 12rem;
     overflow-y: auto;
+  }
+  .mtls-revoked-accordion {
+    font-size: 0.8rem;
+  }
+  .mtls-revoked-accordion summary {
+    cursor: pointer;
+    color: var(--text-dim);
+    user-select: none;
+  }
+  .mtls-revoked-accordion summary:hover {
+    color: var(--text);
+  }
+  .mtls-revoked-accordion .session-list {
+    margin-top: 0.4rem;
   }
 
   /* mTLS radio group */

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -1616,7 +1616,11 @@
   <div class="tab-scroll"><div class="tab-content" use:masonry>
   <section class="settings-section">
     <h3>Authentication</h3>
+    {#if !authEnabled}
+    <p class="hint" style="color: var(--error-color, #e74c3c); font-weight: bold;">⚠ Authentication is disabled via <code style="font-size: 0.75rem; white-space: nowrap">--disable-auth</code>. Anyone can access this app without credentials.</p>
+    {:else}
     <p class="hint">{#if mtlsMode === "required"}Authentication is currently enforced with mTLS certificates only.{:else if mtlsMode === "disabled"}Authentication is currently enforced with session cookies only.{:else}Authentication is currently enforced with session cookies and/or mTLS certificates.{/if} Use <code style="font-size: 0.75rem; white-space: nowrap">--disable-auth</code> at startup to turn authentication off completely.</p>
+    {/if}
   </section>
 
   <section class="settings-section">

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -1595,8 +1595,8 @@
       {#if mtlsMode !== "disabled" || mtlsCerts.length > 0}
         <h4 style="margin-top: 1rem; margin-bottom: 0.5rem;">Generate Client Certificate</h4>
         <div class="setting-row">
-          <button on:click={generateClientCert} disabled={mtlsGenerating || (authSlots > 0 && authAvailableSlots <= 0)}>
-            {mtlsGenerating ? "Generating..." : authSlots > 0 && authAvailableSlots <= 0 ? `No slots available (${authSlots} used)` : "Generate Client Certificate"}
+          <button on:click={generateClientCert} disabled={mtlsGenerating || (authSlots > 0 && authAvailableSlots <= 0 && !authSessions.some(s => s.is_current))}>
+            {mtlsGenerating ? "Generating..." : authSlots > 0 && authAvailableSlots <= 0 && !authSessions.some(s => s.is_current) ? `No slots available (${authSlots} used)` : "Generate Client Certificate"}
           </button>
         </div>
       {/if}

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -2299,15 +2299,16 @@
   .session-delete {
     font-size: 0.75rem;
     padding: 0.2rem 0.5rem;
-    background: #ff4444;
-    color: #fff;
-    border: none;
+    background: var(--btn-secondary, #333);
+    color: var(--text-dim, #888);
+    border: 1px solid var(--border, #3a3b3f);
     border-radius: 3px;
     cursor: pointer;
     flex-shrink: 0;
   }
   .session-delete:hover {
-    background: #cc3333;
+    background: var(--btn-secondary-hover, #444);
+    color: var(--text, #eee);
   }
   .token-url-box {
     display: flex;

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -268,6 +268,7 @@
   let mtlsTlsEnabled = true;
   let mtlsProxyMode = false;
   let mtlsCaInitialized = false;
+  let mtlsCaFingerprint = null;
   let mtlsCerts = [];
   let mtlsGenerating = false;
   let mtlsError = "";
@@ -287,6 +288,7 @@
         mtlsTlsEnabled = data.tls_enabled;
         mtlsProxyMode = data.proxy_mode;
         mtlsCaInitialized = data.ca_initialized;
+        mtlsCaFingerprint = data.ca_fingerprint;
         mtlsCerts = data.certs;
       }
     } catch {}
@@ -1637,6 +1639,10 @@
           </div>
         </details>
       {/if}
+    {/if}
+
+    {#if mtlsCaFingerprint}
+      <p class="hint" style="margin-top: 0.75rem;">CA fingerprint (SHA-256): <code style="font-size: 0.65rem; word-break: break-all;">{mtlsCaFingerprint}</code></p>
     {/if}
 
     {#if mtlsError}

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -1822,7 +1822,7 @@
   <section class="settings-section">
     <h3>Logout</h3>
     {#if mtlsCurrentCert}
-      <p class="hint">Revoke your current client certificate. You will need a new mTLS certificate to reconnect, or restart the server with <code style="font-size: 0.75rem; white-space: nowrap">--reset-auth</code> to revert to login link mode.</p>
+      <p class="hint">Revoke your current client certificate. You will need a new mTLS certificate to reconnect. Otherwise you may restart the server with <code style="font-size: 0.75rem; white-space: nowrap">--reset-auth</code> to setup auth again from scratch.</p>
       <div class="setting-row">
         <button class="danger-btn" on:click={mtlsLogout}>Revoke Certificate &amp; Logout</button>
       </div>

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -1671,11 +1671,11 @@
             <div class="session-info">
               <span class="session-label">
                 <span class="auth-badge cookie">cookie</span>
-                {session.label}
+                {shortUserAgent(session.user_agent) || "Unknown browser"}{#if session.last_ip} — {session.last_ip}{/if}
                 {#if session.is_current && !mtlsCurrentCert} <strong>(you)</strong>{/if}
                 {#if session.is_transfer} <em>(transfer pending)</em>{/if}
               </span>
-              <span class="session-meta">{#if session.user_agent}{shortUserAgent(session.user_agent)} — {/if}Created {formatAuthTime(session.created_at)}{#if session.last_seen_at} — last seen {formatAuthTime(session.last_seen_at)}{:else} — never used{/if}{#if session.last_ip} — IP {session.last_ip}{/if}{#if session.expires_at} — expires {formatAuthTime(session.expires_at)}{/if}</span>
+              <span class="session-meta">Created {formatAuthTime(session.created_at)}{#if session.last_seen_at} — last seen {formatAuthTime(session.last_seen_at)}{:else} — never used{/if}{#if session.expires_at} — expires {formatAuthTime(session.expires_at)}{/if}</span>
             </div>
             {#if !session.is_current || mtlsCurrentCert}
               <button class="session-delete" on:click={() => deleteSession(session.id)} title="Revoke this session">Revoke</button>

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -1623,6 +1623,7 @@
     {/if}
   </section>
 
+  {#if authEnabled}
   <section class="settings-section">
     <h3>Client Certificates (mTLS)</h3>
     {#if !mtlsTlsEnabled}
@@ -1688,7 +1689,6 @@
       <p class="danger-error" style="margin-top: 0.5rem;">{mtlsError}</p>
     {/if}
   </section>
-
 
   <section class="settings-section">
     <h3>Clients</h3>
@@ -1837,6 +1837,7 @@
       </div>
     {/if}
   </section>
+  {/if}
 
   {#if authError}
     <section class="settings-section">

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -1765,6 +1765,7 @@
     {/if}
   </section>
 
+  {#if mtlsMode !== "required"}
   <section class="settings-section">
     <h3>Generate Login Link</h3>
     <p class="hint">Generate a one-time login URL to share with another browser.</p>
@@ -1797,8 +1798,9 @@
       <p class="hint">Share this link with the new browser. It expires in 5 minutes and is consumed on first use.</p>
     {/if}
   </section>
+  {/if}
 
-  {#if authAllowTransfer}
+  {#if authAllowTransfer && mtlsMode !== "required"}
   <section class="settings-section">
     <h3>Transfer Session</h3>
     <p class="hint">Move your current session to a new browser. Your current session will be logged out as soon as the new browser logs in.</p>

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -1642,7 +1642,11 @@
     {/if}
 
     {#if mtlsCaFingerprint}
-      <p class="hint" style="margin-top: 0.75rem;">CA fingerprint (SHA-256): <code style="font-size: 0.65rem; word-break: break-all;">{mtlsCaFingerprint}</code></p>
+      <div class="mtls-ca-box">
+        <span class="mtls-ca-label">Certificate Authority</span>
+        <span class="mtls-ca-fingerprint">SHA-256: {mtlsCaFingerprint}</span>
+        <a href="/api/auth/mtls/ca.pem" download="guidebook-ca.pem" class="mtls-ca-download">Download CA Certificate</a>
+      </div>
     {/if}
 
     {#if mtlsError}
@@ -2455,6 +2459,36 @@
     max-height: 12rem;
     overflow-y: auto;
   }
+  .mtls-ca-box {
+    margin-top: 0.75rem;
+    padding: 0.6rem 0.75rem;
+    border: 1px solid var(--border, var(--border-color, #3a3b3f));
+    border-radius: 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+  .mtls-ca-label {
+    font-size: 0.75rem;
+    font-weight: bold;
+    color: var(--text-dim);
+  }
+  .mtls-ca-fingerprint {
+    font-size: 0.65rem;
+    font-family: monospace;
+    word-break: break-all;
+    color: var(--text-dim);
+  }
+  .mtls-ca-download {
+    font-size: 0.75rem;
+    color: var(--accent, #00ff88);
+    text-decoration: none;
+    margin-top: 0.2rem;
+  }
+  .mtls-ca-download:hover {
+    text-decoration: underline;
+  }
+
   .mtls-revoked-accordion {
     font-size: 0.8rem;
   }

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -211,7 +211,7 @@
       mtlsError = e.message;
       return;
     }
-    await loadMtlsStatus();
+    location.reload();
   }
 
   let copiedField = null;

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -136,12 +136,25 @@
     } catch {}
   }
 
+  let authShowLinkForm = false;
+  let authLinkLabelInput = "";
+
+  function openLoginLinkForm() {
+    authShowLinkForm = true;
+    authLinkLabelInput = `session-${authSessions.filter(s => !s.is_transfer).length + 1}`;
+    authTokenUrl = "";
+  }
+
   async function generateLoginToken() {
     authError = "";
     authGenerating = true;
     authTokenUrl = "";
     try {
-      const res = await fetch("/api/auth/generate-token", { method: "POST" });
+      const res = await fetch("/api/auth/generate-token", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ label: authLinkLabelInput }),
+      });
       if (res.ok) {
         const data = await res.json();
         authTokenUrl = data.login_url;
@@ -254,7 +267,7 @@
     return ua.length > 30 ? ua.slice(0, 30) + "..." : ua;
   }
 
-  $: if (authRefreshTrigger) { loadAuthSessions(); loadAuthStatus(); loadMtlsStatus(); authTokenUrl = ""; authTransferUrl = ""; }
+  $: if (authRefreshTrigger) { loadAuthSessions(); loadAuthStatus(); loadMtlsStatus(); authTokenUrl = ""; authTransferUrl = ""; authShowLinkForm = false; }
   $: activeCertCount = mtlsCerts.filter(c => !c.revoked_at).length;
   $: authAvailableSlots = authSlots === 0 ? Infinity : Math.max(0, authSlots - authSessions.filter(s => !s.is_transfer).length - activeCertCount);
   $: mtlsCurrentCert = mtlsCerts.find(c => c.is_current && !c.revoked_at);
@@ -1755,15 +1768,28 @@
   <section class="settings-section">
     <h3>Generate Login Link</h3>
     <p class="hint">Generate a one-time login URL to share with another browser.</p>
-    <div class="setting-row">
-      <button on:click={generateLoginToken} disabled={authGenerating || (authSlots > 0 && authAvailableSlots <= 0)}>
-        {authGenerating ? "Generating..." : authSlots > 0 && authAvailableSlots <= 0 ? `No slots available (${authSlots}/${authSlots} used)` : "Generate Login Link"}
-      </button>
-    </div>
-    {#if authSlots > 0 && authAvailableSlots <= 0}
-      <p class="hint">Pass <code style="font-size: 0.75rem; white-space: nowrap">--auth-slots X</code> at startup to allow more concurrent sessions.</p>
-    {/if}
-    {#if authTokenUrl}
+    {#if !authShowLinkForm && !authTokenUrl}
+      <div class="setting-row">
+        <button on:click={openLoginLinkForm} disabled={authSlots > 0 && authAvailableSlots <= 0}>
+          {authSlots > 0 && authAvailableSlots <= 0 ? `No slots available (${authSlots}/${authSlots} used)` : "Generate Login Link"}
+        </button>
+      </div>
+      {#if authSlots > 0 && authAvailableSlots <= 0}
+        <p class="hint">Pass <code style="font-size: 0.75rem; white-space: nowrap">--auth-slots X</code> at startup to allow more concurrent sessions.</p>
+      {/if}
+    {:else if !authTokenUrl}
+      <div style="margin-top: 0.5rem;">
+        <span style="font-size: 0.8rem; opacity: 0.7; display: block; margin-bottom: 0.3rem;">Label</span>
+        <input type="text" bind:value={authLinkLabelInput} placeholder="session-1" style="width: 100%; box-sizing: border-box; margin-bottom: 0.5rem;" />
+        <p class="hint" style="margin-bottom: 0.5rem;">Choose a name to identify this session (e.g. browser, device, or person).</p>
+        <div class="setting-row" style="gap: 0.5rem;">
+          <button on:click={() => { authShowLinkForm = false; }} style="margin-right: auto;">Cancel</button>
+          <button on:click={generateLoginToken} disabled={authGenerating || !authLinkLabelInput.trim()}>
+            {authGenerating ? "Generating..." : "Generate"}
+          </button>
+        </div>
+      </div>
+    {:else}
       <div class="token-url-box">
         <input type="text" value={authTokenUrl} readonly on:click={(e) => e.target.select()} />
         <button class="copy-btn" class:copied={copiedField === 'token'} on:click={() => copyToClipboard(authTokenUrl, 'token')}>{copiedField === 'token' ? 'Copied!' : 'Copy'}</button>

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -241,6 +241,19 @@
     return `in ${Math.floor(fdiff / 86400)}d`;
   }
 
+  function shortUserAgent(ua) {
+    if (!ua) return "";
+    // Extract browser name from user agent
+    if (ua.includes("Firefox/")) return "Firefox";
+    if (ua.includes("Edg/")) return "Edge";
+    if (ua.includes("OPR/") || ua.includes("Opera")) return "Opera";
+    if (ua.includes("Chrome/") && ua.includes("Safari/")) return "Chrome";
+    if (ua.includes("Safari/") && !ua.includes("Chrome/")) return "Safari";
+    if (ua.includes("curl/")) return "curl";
+    // Fallback: first 30 chars
+    return ua.length > 30 ? ua.slice(0, 30) + "..." : ua;
+  }
+
   $: if (authRefreshTrigger) { loadAuthSessions(); loadAuthStatus(); loadMtlsStatus(); }
   $: activeCertCount = mtlsCerts.filter(c => !c.revoked_at).length;
   $: authAvailableSlots = authSlots === 0 ? Infinity : Math.max(0, authSlots - authSessions.filter(s => !s.is_transfer).length - activeCertCount);
@@ -1662,7 +1675,7 @@
                 {#if session.is_current && !mtlsCurrentCert} <strong>(current)</strong>{/if}
                 {#if session.is_transfer} <em>(transfer pending)</em>{/if}
               </span>
-              <span class="session-meta">Created {formatAuthTime(session.created_at)}{#if session.last_seen_at} — last seen {formatAuthTime(session.last_seen_at)}{:else} — never used{/if}{#if session.last_ip} — IP {session.last_ip}{/if}{#if session.expires_at} — expires {formatAuthTime(session.expires_at)}{/if}</span>
+              <span class="session-meta">{#if session.user_agent}{shortUserAgent(session.user_agent)} — {/if}Created {formatAuthTime(session.created_at)}{#if session.last_seen_at} — last seen {formatAuthTime(session.last_seen_at)}{:else} — never used{/if}{#if session.last_ip} — IP {session.last_ip}{/if}{#if session.expires_at} — expires {formatAuthTime(session.expires_at)}{/if}</span>
             </div>
             {#if !session.is_current || mtlsCurrentCert}
               <button class="session-delete" on:click={() => deleteSession(session.id)} title="Revoke this session">Revoke</button>

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -1601,30 +1601,6 @@
         </div>
       {/if}
 
-      {#if mtlsCerts.filter(c => !c.revoked_at).length > 0}
-        <h4 style="margin-top: 1rem; margin-bottom: 0.5rem;">Active Certificates</h4>
-        <div class="session-list mtls-cert-list">
-          {#each mtlsCerts.filter(c => !c.revoked_at) as cert (cert.id)}
-            <div class="session-item" class:session-current={cert.is_current}>
-              <div class="session-info">
-                <span class="session-label">
-                  {cert.label}
-                  {#if cert.is_current} <strong>(current)</strong>{/if}
-                </span>
-                <span class="session-meta">
-                  Fingerprint: {cert.fingerprint_sha256.slice(0, 16)}...
-                  — Issued {formatAuthTime(cert.issued_at)}
-                  — Expires {formatAuthTime(cert.expires_at)}
-                </span>
-              </div>
-              {#if !cert.is_current}
-                <button class="session-delete" on:click={() => revokeClientCert(cert.id)} title="Revoke this certificate">Revoke</button>
-              {/if}
-            </div>
-          {/each}
-        </div>
-      {/if}
-
       {#if mtlsCerts.filter(c => c.revoked_at).length > 0}
         <details class="mtls-revoked-accordion" style="margin-top: 0.75rem;">
           <summary>Revoked Certificates ({mtlsCerts.filter(c => c.revoked_at).length})</summary>
@@ -1653,18 +1629,42 @@
 
 
   <section class="settings-section">
-    <h3>Active Sessions</h3>
-    {#if authSessions.length === 0}
-      <p class="hint">No active sessions.</p>
+    <h3>Active Clients</h3>
+    {#if authSessions.length === 0 && mtlsCerts.filter(c => !c.revoked_at).length === 0}
+      <p class="hint">No active clients.</p>
     {:else}
       <div class="session-list">
+        {#each mtlsCerts.filter(c => !c.revoked_at) as cert (cert.serial_number)}
+          <div class="session-item" class:session-current={cert.is_current}>
+            <div class="session-info">
+              <span class="session-label">
+                <span class="auth-badge mtls">mTLS</span>
+                {cert.label}
+                {#if cert.is_current} <strong>(current)</strong>{/if}
+              </span>
+              <span class="session-meta">
+                Fingerprint: {cert.fingerprint_sha256.slice(0, 16)}...
+                — Issued {formatAuthTime(cert.issued_at)}
+                — Expires {formatAuthTime(cert.expires_at)}
+              </span>
+            </div>
+            {#if !cert.is_current}
+              <button class="session-delete" on:click={() => revokeClientCert(cert.id)} title="Revoke this certificate">Revoke</button>
+            {/if}
+          </div>
+        {/each}
         {#each authSessions as session (session.id)}
           <div class="session-item" class:session-current={session.is_current}>
             <div class="session-info">
-              <span class="session-label">{session.label}{#if session.is_current} <strong>(current)</strong>{/if}{#if session.is_transfer} <em>(transfer pending)</em>{/if}</span>
+              <span class="session-label">
+                <span class="auth-badge cookie">cookie</span>
+                {session.label}
+                {#if session.is_current && !mtlsCurrentCert} <strong>(current)</strong>{/if}
+                {#if session.is_transfer} <em>(transfer pending)</em>{/if}
+              </span>
               <span class="session-meta">Created {formatAuthTime(session.created_at)}{#if session.last_seen_at} — last seen {formatAuthTime(session.last_seen_at)}{:else} — never used{/if}{#if session.last_ip} — IP {session.last_ip}{/if}{#if session.expires_at} — expires {formatAuthTime(session.expires_at)}{/if}</span>
             </div>
-            {#if !session.is_current}
+            {#if !session.is_current || mtlsCurrentCert}
               <button class="session-delete" on:click={() => deleteSession(session.id)} title="Revoke this session">Revoke</button>
             {/if}
           </div>
@@ -2372,6 +2372,25 @@
   }
   .session-revoked {
     opacity: 0.5;
+  }
+  .auth-badge {
+    display: inline-block;
+    font-size: 0.6rem;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    padding: 0.1rem 0.35rem;
+    border-radius: 3px;
+    vertical-align: middle;
+    margin-right: 0.3rem;
+  }
+  .auth-badge.mtls {
+    background: var(--accent, #00ff88);
+    color: #111;
+  }
+  .auth-badge.cookie {
+    background: var(--text-dim, #888);
+    color: #111;
   }
   .mtls-cert-list {
     max-height: 12rem;

--- a/src/guidebook/db.py
+++ b/src/guidebook/db.py
@@ -234,6 +234,7 @@ class ClientCert(GlobalBase):
     expires_at: Mapped[float] = mapped_column(Float, nullable=False)
     revoked_at: Mapped[float | None] = mapped_column(Float, nullable=True)
     fingerprint_sha256: Mapped[str] = mapped_column(String, nullable=False)
+    pending_session_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
 
 class DatabaseLockError(Exception):
@@ -373,6 +374,17 @@ def _global_migration_1_client_certs(conn):
 
 
 GLOBAL_MIGRATIONS.append(_global_migration_1_client_certs)
+
+
+def _global_migration_2_client_certs_pending_session(conn):
+    """Add pending_session_id column to client_certs for upgrade state tracking."""
+    try:
+        conn.execute(text("ALTER TABLE client_certs ADD COLUMN pending_session_id INTEGER"))
+    except Exception:
+        pass  # column may already exist
+
+
+GLOBAL_MIGRATIONS.append(_global_migration_2_client_certs_pending_session)
 
 
 class DatabaseManager:

--- a/src/guidebook/db.py
+++ b/src/guidebook/db.py
@@ -222,6 +222,7 @@ class AuthToken(GlobalBase):
     last_ip: Mapped[str | None] = mapped_column(String, nullable=True)
     is_transfer: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     jwt_nonce: Mapped[str | None] = mapped_column(String, nullable=True)
+    user_agent: Mapped[str | None] = mapped_column(String, nullable=True)
 
 
 class ClientCert(GlobalBase):

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -127,8 +127,12 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="Guidebook", version=version("guidebook"), lifespan=lifespan)
 
 
-# Paths that bypass auth checking
-_AUTH_EXEMPT_PREFIXES = ("/api/auth/",)
+# Paths that bypass auth checking (login flow only, not management endpoints)
+_AUTH_EXEMPT_PATHS = {
+    "/api/auth/status",
+    "/api/auth/check-token",
+    "/api/auth/login",
+}
 
 
 _INLINE_STYLE = (
@@ -200,9 +204,7 @@ async def http_middleware(request: Request, call_next):
             return _rate_limit_429(retry_after)
 
     # Auth check for API routes
-    if path.startswith("/api/") and not any(
-        path.startswith(p) for p in _AUTH_EXEMPT_PREFIXES
-    ):
+    if path.startswith("/api/") and path not in _AUTH_EXEMPT_PATHS:
         from guidebook.routes.auth import check_auth, MTLS_MODE
         from guidebook.db import db_manager
 

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -1172,7 +1172,9 @@ environment variables (overridden by command line options):
         _mconn.close()
         _auth_module.MTLS_MODE = _mtls_mode
 
-        if _mtls_mode in ("optional", "required"):
+        if _mtls_mode in ("optional", "required") and not (
+            _auth_module.DISABLE_AUTH or _auth_module._env_disable_auth()
+        ):
             from guidebook.tls import (
                 ensure_ca_cert,
                 generate_crl,

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -232,12 +232,15 @@ async def http_middleware(request: Request, call_next):
 
     # Auth check for API routes
     if path.startswith("/api/") and path not in _AUTH_EXEMPT_PATHS:
-        from guidebook.routes.auth import check_auth, MTLS_MODE
+        from guidebook.routes.auth import check_auth, MTLS_MODE, _is_auth_enabled
         from guidebook.db import db_manager
 
         if db_manager._global_session_factory:
             async with db_manager._global_session_factory() as gdb:
-                if MTLS_MODE == "required":
+                auth_enabled = await _is_auth_enabled(gdb)
+                if not auth_enabled:
+                    ok = True
+                elif MTLS_MODE == "required":
                     # mTLS enforced: only client certs accepted, no cookie fallback
                     ok = await _check_mtls_auth(request, gdb)
                 else:

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -968,7 +968,7 @@ environment variables (overridden by command line options):
                 conn.execute("DELETE FROM client_certs")
             except sqlite3.OperationalError:
                 pass  # table may not exist yet
-            for k in ("mtls_mode", "ca_cert_pem", "ca_key_pem"):
+            for k in ("mtls_mode", "ca_cert_pem", "ca_key_pem", "tls_cert_pem", "tls_key_pem"):
                 conn.execute("DELETE FROM settings WHERE key = ?", (k,))
             conn.commit()
             os.environ["_GUIDEBOOK_RESET_AUTH_TOKEN"] = token_str

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -298,10 +298,13 @@ async def http_middleware(request: Request, call_next):
 
         # Auth check for non-API routes (HTML pages and static assets)
         if db_manager._global_session_factory:
-            from guidebook.routes.auth import check_auth, MTLS_MODE
+            from guidebook.routes.auth import check_auth, MTLS_MODE, _is_auth_enabled
 
             async with db_manager._global_session_factory() as gdb:
-                if MTLS_MODE == "required":
+                auth_enabled = await _is_auth_enabled(gdb)
+                if not auth_enabled:
+                    ok = True
+                elif MTLS_MODE == "required":
                     ok = await _check_mtls_auth(request, gdb)
                 else:
                     ok = await _check_mtls_auth(request, gdb) or await check_auth(

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -1112,12 +1112,13 @@ environment variables (overridden by command line options):
         import ssl as _ssl
 
         from guidebook.db import META_DB_PATH
-        from guidebook.tls import ensure_tls_cert, write_tls_temp_files
+        from guidebook.tls import ensure_ca_cert, ensure_tls_cert, write_tls_temp_files
 
+        ensure_ca_cert(str(META_DB_PATH))
         cert_pem, key_pem = ensure_tls_cert(str(META_DB_PATH))
         certfile, keyfile = write_tls_temp_files(cert_pem, key_pem)
         ssl_kwargs = {"ssl_certfile": certfile, "ssl_keyfile": keyfile}
-        logger.info("TLS enabled (self-signed certificate)")
+        logger.info("TLS enabled (CA-signed certificate)")
 
         # mTLS configuration
         import sqlite3 as _sq

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -203,15 +203,19 @@ async def http_middleware(request: Request, call_next):
     if path.startswith("/api/") and not any(
         path.startswith(p) for p in _AUTH_EXEMPT_PREFIXES
     ):
-        from guidebook.routes.auth import check_auth
+        from guidebook.routes.auth import check_auth, MTLS_MODE
         from guidebook.db import db_manager
 
         if db_manager._global_session_factory:
             async with db_manager._global_session_factory() as gdb:
-                # Try mTLS auth first, fall back to cookie auth
-                ok = await _check_mtls_auth(request, gdb) or await check_auth(
-                    request, gdb
-                )
+                if MTLS_MODE == "required":
+                    # mTLS enforced: only client certs accepted, no cookie fallback
+                    ok = await _check_mtls_auth(request, gdb)
+                else:
+                    # Try mTLS auth first, fall back to cookie auth
+                    ok = await _check_mtls_auth(request, gdb) or await check_auth(
+                        request, gdb
+                    )
                 if not ok:
                     from fastapi.responses import JSONResponse
 
@@ -265,12 +269,15 @@ async def http_middleware(request: Request, call_next):
 
         # Auth check for non-API routes (HTML pages and static assets)
         if db_manager._global_session_factory:
-            from guidebook.routes.auth import check_auth
+            from guidebook.routes.auth import check_auth, MTLS_MODE
 
             async with db_manager._global_session_factory() as gdb:
-                ok = await _check_mtls_auth(request, gdb) or await check_auth(
-                    request, gdb
-                )
+                if MTLS_MODE == "required":
+                    ok = await _check_mtls_auth(request, gdb)
+                else:
+                    ok = await _check_mtls_auth(request, gdb) or await check_auth(
+                        request, gdb
+                    )
                 if not ok:
                     from fastapi.responses import HTMLResponse
 
@@ -1083,6 +1090,7 @@ environment variables (overridden by command line options):
         ).fetchone()
         _mtls_mode = _mrow[0] if _mrow and _mrow[0] else "disabled"
         _mconn.close()
+        _auth_module.MTLS_MODE = _mtls_mode
 
         if _mtls_mode in ("optional", "required"):
             from guidebook.tls import (

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -939,7 +939,7 @@ environment variables (overridden by command line options):
             "created_at REAL NOT NULL, last_seen_at REAL, expires_at REAL, last_ip TEXT, "
             "is_transfer INTEGER NOT NULL DEFAULT 0)"
         )
-        for col in ("expires_at REAL", "last_ip TEXT", "jwt_nonce TEXT"):
+        for col in ("expires_at REAL", "last_ip TEXT", "jwt_nonce TEXT", "user_agent TEXT"):
             try:
                 conn.execute(f"ALTER TABLE auth_tokens ADD COLUMN {col}")
             except sqlite3.OperationalError:

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -223,8 +223,8 @@ async def http_middleware(request: Request, call_next):
     path = request.url.path
     client_ip = request.client.host if request.client else "unknown"
 
-    # Rate limit: auth endpoints (check prior failures)
-    if path.startswith("/api/auth/"):
+    # Rate limit: login endpoints only (check prior failures)
+    if path in ("/api/auth/login", "/api/auth/check-token"):
         allowed, retry_after = auth_limiter.check(client_ip)
         if not allowed:
             return _rate_limit_429(retry_after)
@@ -330,8 +330,8 @@ async def http_middleware(request: Request, call_next):
 
     response: Response = await call_next(request)
 
-    # Record auth failures for rate limiting (successful logins don't count)
-    if path.startswith("/api/auth/") and response.status_code == 401:
+    # Record auth failures for rate limiting (only login attempts, not general 401s)
+    if path in ("/api/auth/login", "/api/auth/check-token") and response.status_code == 401:
         auth_limiter.record(client_ip)
 
     if path.startswith("/api/"):

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -127,11 +127,12 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="Guidebook", version=version("guidebook"), lifespan=lifespan)
 
 
-# Paths that bypass auth checking (login flow only, not management endpoints)
+# Paths that bypass auth checking (login flow + session renewal)
 _AUTH_EXEMPT_PATHS = {
     "/api/auth/status",
     "/api/auth/check-token",
     "/api/auth/login",
+    "/api/auth/renew",
 }
 
 

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -167,7 +167,11 @@ def _rate_limit_429(retry_after: int) -> Response:
 
 
 async def _check_mtls_auth(request: Request, gdb) -> bool:
-    """Check if request is authenticated via mTLS client certificate."""
+    """Check if request is authenticated via mTLS client certificate.
+
+    If the cert has a pending_session_id (upgrade from cookie), revoke that
+    session on first use and clear the pending flag.
+    """
     peer_cert_der = request.scope.get("mtls_peer_cert_der")
     if not peer_cert_der:
         return False
@@ -177,7 +181,7 @@ async def _check_mtls_auth(request: Request, gdb) -> bool:
 
         cert = load_der_x509_certificate(peer_cert_der)
         serial_hex = format(cert.serial_number, "x")
-        from guidebook.db import ClientCert
+        from guidebook.db import AuthToken, ClientCert
 
         result = await gdb.execute(
             select(ClientCert).where(
@@ -185,7 +189,29 @@ async def _check_mtls_auth(request: Request, gdb) -> bool:
                 ClientCert.revoked_at.is_(None),
             )
         )
-        return result.scalar_one_or_none() is not None
+        client_cert = result.scalar_one_or_none()
+        if client_cert is None:
+            return False
+
+        # Complete the cookie-to-mTLS upgrade: revoke the old session
+        if client_cert.pending_session_id is not None:
+            old_session = (
+                await gdb.execute(
+                    select(AuthToken).where(
+                        AuthToken.id == client_cert.pending_session_id
+                    )
+                )
+            ).scalar_one_or_none()
+            if old_session:
+                await gdb.delete(old_session)
+            client_cert.pending_session_id = None
+            await gdb.commit()
+            logger.info(
+                "mTLS upgrade complete: revoked cookie session for cert %s",
+                client_cert.label,
+            )
+
+        return True
     except Exception:
         return False
 

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -283,6 +283,16 @@ async def http_middleware(request: Request, call_next):
                 if not ok:
                     from fastapi.responses import HTMLResponse
 
+                    if MTLS_MODE == "required":
+                        return HTMLResponse(
+                            status_code=401,
+                            content=_inline_page(
+                                "<p>You need a valid mTLS client certificate to access this site.</p>"
+                                '<p class="dim">Ask the owner to generate a new client certificate for you, '
+                                "or restart the server with "
+                                "<code style='white-space:nowrap'>--reset-auth</code> to revert to login link mode.</p>"
+                            ),
+                        )
                     return HTMLResponse(
                         status_code=401,
                         content=_inline_page(

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -317,7 +317,7 @@ async def http_middleware(request: Request, call_next):
                                 "<p>You need a valid mTLS client certificate to access this site.</p>"
                                 '<p class="dim">Ask the owner to generate a new client certificate for you, '
                                 "or restart the server with "
-                                "<code style='white-space:nowrap'>--reset-auth</code> to revert to login link mode.</p>"
+                                "<code style='white-space:nowrap'>--reset-auth</code> to setup auth again from scratch.</p>"
                             ),
                         )
                     return HTMLResponse(

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -803,7 +803,7 @@ environment variables (overridden by command line options):
     parser.add_argument(
         "--reset-auth",
         action="store_true",
-        help="Reset all auth sessions and generate a new login link",
+        help="Reset all auth: sessions, CA, certificates, mTLS state, and generate a new login link",
     )
     parser.add_argument(
         "--auth-slots",
@@ -951,6 +951,34 @@ environment variables (overridden by command line options):
         )
 
         if args.reset_auth:
+            # Count what will be destroyed
+            session_count = conn.execute("SELECT COUNT(*) FROM auth_tokens").fetchone()[0]
+            try:
+                cert_count = conn.execute("SELECT COUNT(*) FROM client_certs").fetchone()[0]
+            except sqlite3.OperationalError:
+                cert_count = 0
+            ca_exists = bool(
+                conn.execute("SELECT 1 FROM settings WHERE key = 'ca_cert_pem'").fetchone()
+            )
+
+            print("--reset-auth will perform the following actions:")
+            print(f"  - Delete all cookie sessions ({session_count})")
+            print("  - Invalidate all JWTs (regenerate signing secret)")
+            if ca_exists:
+                print("  - Delete the Certificate Authority (CA)")
+            if cert_count:
+                print(f"  - Delete all client certificates ({cert_count})")
+            print("  - Delete server TLS certificate (will be regenerated)")
+            print("  - Reset mTLS mode to default")
+            print("  - Generate a new login link")
+            try:
+                answer = input("\nProceed? [y/N] ").strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                answer = ""
+            if answer not in ("y", "yes"):
+                print("Aborted.")
+                sys.exit(0)
+
             conn.execute("DELETE FROM auth_tokens")
             # Regenerate JWT secret on auth reset to invalidate all JWTs
             jwt_secret = secrets.token_urlsafe(64)
@@ -974,7 +1002,7 @@ environment variables (overridden by command line options):
             conn.commit()
             os.environ["_GUIDEBOOK_RESET_AUTH_TOKEN"] = token_str
             print(
-                "Auth reset: all sessions and mTLS state cleared, new login token generated."
+                "\nAuth reset complete: all sessions, CA, certificates, and mTLS state cleared."
             )
 
         # If mTLS is enforced, cookie sessions are useless — clear them

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -977,6 +977,18 @@ environment variables (overridden by command line options):
                 "Auth reset: all sessions and mTLS state cleared, new login token generated."
             )
 
+        # If mTLS is enforced, cookie sessions are useless — clear them
+        _mtls_row = conn.execute(
+            "SELECT value FROM settings WHERE key = 'mtls_mode'"
+        ).fetchone()
+        if _mtls_row and _mtls_row[0] == "required":
+            deleted = conn.execute("DELETE FROM auth_tokens").rowcount
+            if deleted:
+                conn.commit()
+                logger.info(
+                    "mTLS enforced: revoked %d cookie session(s) on startup", deleted
+                )
+
         # Ensure JWT signing secret exists
         row = conn.execute(
             "SELECT value FROM settings WHERE key = ?", ("auth_jwt_secret",)

--- a/src/guidebook/ratelimit.py
+++ b/src/guidebook/ratelimit.py
@@ -60,5 +60,5 @@ class RateLimiter:
         dq.append(now)
 
 
-# Auth: 5 failed attempts per 5-minute window
-auth_limiter = RateLimiter(max_requests=5, window_seconds=300)
+# Auth: 20 failed attempts per 5-minute window
+auth_limiter = RateLimiter(max_requests=20, window_seconds=300)

--- a/src/guidebook/routes/auth.py
+++ b/src/guidebook/routes/auth.py
@@ -30,6 +30,7 @@ AUTH_RENEW_COOLDOWN: int = AUTH_RENEW_COOLDOWN_DEFAULT  # --auth-renew-cooldown
 ALLOW_TRANSFER: bool = False  # --allow-transfer
 PROXY_MODE: bool = False  # --proxy
 TLS_ENABLED: bool = True  # True unless --no-tls
+MTLS_MODE: str = "disabled"  # "disabled", "optional", "required"
 
 
 def parse_duration(value: str) -> int:

--- a/src/guidebook/routes/auth.py
+++ b/src/guidebook/routes/auth.py
@@ -252,6 +252,8 @@ async def generate_token(
     gdb: AsyncSession = Depends(get_global_session),
 ):
     """Generate a login token for a new session. Auth enforced by middleware."""
+    if MTLS_MODE == "required":
+        raise HTTPException(400, "Login links are disabled in mTLS enforced mode. Use client certificates instead.")
     enabled = await _is_auth_enabled(gdb)
     if not enabled:
         raise HTTPException(400, "Authentication is not enabled")
@@ -290,6 +292,8 @@ async def transfer_session(
 ):
     """Generate a transfer token — logs out current session when new one logs in.
     Auth enforced by middleware."""
+    if MTLS_MODE == "required":
+        raise HTTPException(400, "Session transfer is disabled in mTLS enforced mode.")
     if not ALLOW_TRANSFER:
         raise HTTPException(
             400,

--- a/src/guidebook/routes/auth.py
+++ b/src/guidebook/routes/auth.py
@@ -510,6 +510,8 @@ async def renew_session(
     gdb: AsyncSession = Depends(get_global_session),
 ):
     """Renew the current session cookie if eligible."""
+    if not await _is_auth_enabled(gdb):
+        return {"status": "ok", "reason": "auth disabled"}
     claims = _get_jwt_claims(request)
     if not claims or "sid" not in claims:
         raise HTTPException(401, "Not authenticated")

--- a/src/guidebook/routes/auth.py
+++ b/src/guidebook/routes/auth.py
@@ -236,6 +236,10 @@ async def list_sessions(
     return sessions
 
 
+class GenerateTokenRequest(BaseModel):
+    label: str | None = None
+
+
 class GenerateTokenResponse(BaseModel):
     token: str
     login_url: str
@@ -244,6 +248,7 @@ class GenerateTokenResponse(BaseModel):
 @router.post("/generate-token")
 async def generate_token(
     request: Request,
+    body: GenerateTokenRequest,
     gdb: AsyncSession = Depends(get_global_session),
 ):
     """Generate a login token for a new session. Auth enforced by middleware."""
@@ -259,11 +264,12 @@ async def generate_token(
             f"All {AUTH_SLOTS} session slot(s) are in use. Remove a session first.",
         )
 
+    label = body.label.strip() if body.label else "Invited session"
     token_str = secrets.token_urlsafe(48)
     gdb.add(
         AuthToken(
             token=token_str,
-            label="Invited session",
+            label=label,
             created_at=time.time(),
             last_seen_at=None,
             is_transfer=0,
@@ -370,7 +376,6 @@ async def login_with_token(
         # Transfer token: find the original session that created us and revoke it
         # The transfer token itself becomes the new permanent session
         tok.is_transfer = 0
-        tok.label = "Transferred session"
         tok.last_seen_at = now
 
         # Delete all other non-transfer tokens (the old session)
@@ -386,7 +391,6 @@ async def login_with_token(
     else:
         # Regular login token — just activate it
         tok.last_seen_at = now
-        tok.label = "Logged in session"
         await gdb.commit()
         try:
             await create_notification(
@@ -446,7 +450,6 @@ async def server_side_login(
 
     if tok.is_transfer:
         tok.is_transfer = 0
-        tok.label = "Transferred session"
         tok.last_seen_at = now
         result = await gdb.execute(
             select(AuthToken).where(AuthToken.id != tok.id, AuthToken.is_transfer == 0)
@@ -458,7 +461,6 @@ async def server_side_login(
         logger.info("Session transferred to new browser")
     else:
         tok.last_seen_at = now
-        tok.label = "Logged in session"
         await gdb.commit()
         try:
             await create_notification(

--- a/src/guidebook/routes/auth.py
+++ b/src/guidebook/routes/auth.py
@@ -203,6 +203,7 @@ class SessionResponse(BaseModel):
     last_ip: str | None
     is_current: bool
     is_transfer: bool
+    user_agent: str | None
 
 
 @router.get("/sessions")
@@ -224,6 +225,7 @@ async def list_sessions(
                 last_ip=tok.last_ip,
                 is_current=tok.id == current_session_id,
                 is_transfer=tok.is_transfer == 1,
+                user_agent=tok.user_agent,
             )
         )
     return sessions
@@ -368,6 +370,8 @@ async def login_with_token(
     now = time.time()
     tok.expires_at = now + AUTH_TTL
 
+    tok.user_agent = request.headers.get("user-agent", "")
+
     if tok.is_transfer:
         # Transfer token: find the original session that created us and revoke it
         # The transfer token itself becomes the new permanent session
@@ -444,6 +448,7 @@ async def server_side_login(
 
     now = time.time()
     tok.expires_at = now + AUTH_TTL
+    tok.user_agent = request.headers.get("user-agent", "")
 
     if tok.is_transfer:
         tok.is_transfer = 0

--- a/src/guidebook/routes/auth.py
+++ b/src/guidebook/routes/auth.py
@@ -204,6 +204,7 @@ class SessionResponse(BaseModel):
     is_current: bool
     is_transfer: bool
     user_agent: str | None
+    is_connected: bool
 
 
 @router.get("/sessions")
@@ -211,7 +212,10 @@ async def list_sessions(
     request: Request,
     gdb: AsyncSession = Depends(get_global_session),
 ):
+    from guidebook.sse import connected_session_ids
+
     current_session_id = _get_current_session_id(request)
+    active_sids = connected_session_ids()
     result = await gdb.execute(select(AuthToken).order_by(AuthToken.created_at))
     sessions = []
     for tok in result.scalars().all():
@@ -226,6 +230,7 @@ async def list_sessions(
                 is_current=tok.id == current_session_id,
                 is_transfer=tok.is_transfer == 1,
                 user_agent=tok.user_agent,
+                is_connected=tok.id in active_sids,
             )
         )
     return sessions

--- a/src/guidebook/routes/auth.py
+++ b/src/guidebook/routes/auth.py
@@ -247,8 +247,10 @@ async def generate_token(
         raise HTTPException(400, "Authentication is not enabled")
 
     # Check current user is authenticated
-    current_sid = _get_current_session_id(request)
-    if not current_sid or not await _validate_session(gdb, current_sid):
+    claims = _get_jwt_claims(request)
+    if not claims or "sid" not in claims:
+        raise HTTPException(401, "Not authenticated")
+    if not await _validate_session(gdb, claims["sid"], claims.get("nonce")):
         raise HTTPException(401, "Not authenticated")
 
     # Check slot availability
@@ -292,10 +294,10 @@ async def transfer_session(
     if not enabled:
         raise HTTPException(400, "Authentication is not enabled")
 
-    current_sid = _get_current_session_id(request)
-    if not current_sid:
+    claims = _get_jwt_claims(request)
+    if not claims or "sid" not in claims:
         raise HTTPException(401, "Not authenticated")
-    current_tok = await _validate_session(gdb, current_sid)
+    current_tok = await _validate_session(gdb, claims["sid"], claims.get("nonce"))
     if not current_tok:
         raise HTTPException(401, "Not authenticated")
 
@@ -574,9 +576,9 @@ async def logout(
     gdb: AsyncSession = Depends(get_global_session),
 ):
     """Log out the current session."""
-    session_id = _get_current_session_id(request)
-    if session_id:
-        tok = await _validate_session(gdb, session_id)
+    claims = _get_jwt_claims(request)
+    if claims and "sid" in claims:
+        tok = await _validate_session(gdb, claims["sid"], claims.get("nonce"))
         if tok:
             await gdb.delete(tok)
             await gdb.commit()

--- a/src/guidebook/routes/auth.py
+++ b/src/guidebook/routes/auth.py
@@ -241,17 +241,10 @@ async def generate_token(
     request: Request,
     gdb: AsyncSession = Depends(get_global_session),
 ):
-    """Generate a login token for a new session."""
+    """Generate a login token for a new session. Auth enforced by middleware."""
     enabled = await _is_auth_enabled(gdb)
     if not enabled:
         raise HTTPException(400, "Authentication is not enabled")
-
-    # Check current user is authenticated
-    claims = _get_jwt_claims(request)
-    if not claims or "sid" not in claims:
-        raise HTTPException(401, "Not authenticated")
-    if not await _validate_session(gdb, claims["sid"], claims.get("nonce")):
-        raise HTTPException(401, "Not authenticated")
 
     # Check slot availability
     count = await _token_count(gdb)
@@ -284,7 +277,8 @@ async def transfer_session(
     request: Request,
     gdb: AsyncSession = Depends(get_global_session),
 ):
-    """Generate a transfer token — logs out current session when new one logs in."""
+    """Generate a transfer token — logs out current session when new one logs in.
+    Auth enforced by middleware."""
     if not ALLOW_TRANSFER:
         raise HTTPException(
             400,
@@ -293,13 +287,6 @@ async def transfer_session(
     enabled = await _is_auth_enabled(gdb)
     if not enabled:
         raise HTTPException(400, "Authentication is not enabled")
-
-    claims = _get_jwt_claims(request)
-    if not claims or "sid" not in claims:
-        raise HTTPException(401, "Not authenticated")
-    current_tok = await _validate_session(gdb, claims["sid"], claims.get("nonce"))
-    if not current_tok:
-        raise HTTPException(401, "Not authenticated")
 
     token_str = secrets.token_urlsafe(48)
     gdb.add(
@@ -575,10 +562,13 @@ async def logout(
     response: Response,
     gdb: AsyncSession = Depends(get_global_session),
 ):
-    """Log out the current session."""
-    claims = _get_jwt_claims(request)
-    if claims and "sid" in claims:
-        tok = await _validate_session(gdb, claims["sid"], claims.get("nonce"))
+    """Log out the current session. Auth enforced by middleware."""
+    session_id = _get_current_session_id(request)
+    if session_id:
+        result = await gdb.execute(
+            select(AuthToken).where(AuthToken.id == session_id)
+        )
+        tok = result.scalar_one_or_none()
         if tok:
             await gdb.delete(tok)
             await gdb.commit()

--- a/src/guidebook/routes/mtls.py
+++ b/src/guidebook/routes/mtls.py
@@ -23,6 +23,7 @@ PENDING_DOWNLOAD_TTL = 600  # 10 minutes
 class PendingDownload:
     p12_bytes: bytes
     password: str
+    label: str
     created_at: float
     expires_at: float
 
@@ -234,6 +235,7 @@ async def generate_cert(
     _pending_downloads[download_token] = PendingDownload(
         p12_bytes=p12_bytes,
         password=password,
+        label=label,
         created_at=now,
         expires_at=now + PENDING_DOWNLOAD_TTL,
     )
@@ -261,11 +263,17 @@ async def download_cert(download_token: str):
     if time.time() > pending.expires_at:
         raise HTTPException(410, "Download link expired.")
 
+    # Sanitize label for filename
+    safe_label = "".join(
+        c if c.isalnum() or c in "-_" else "-" for c in pending.label
+    ).strip("-")
+    filename = f"guidebook-{safe_label}.p12" if safe_label else "guidebook-client.p12"
+
     return Response(
         content=pending.p12_bytes,
         media_type="application/x-pkcs12",
         headers={
-            "Content-Disposition": 'attachment; filename="guidebook-client.p12"',
+            "Content-Disposition": f'attachment; filename="{filename}"',
             "Cache-Control": "no-store",
         },
     )

--- a/src/guidebook/routes/mtls.py
+++ b/src/guidebook/routes/mtls.py
@@ -16,6 +16,14 @@ logger = logging.getLogger("guidebook")
 
 router = APIRouter(prefix="/api/auth/mtls", tags=["mtls"])
 
+
+def _check_auth_enabled():
+    """Raise 403 if authentication is disabled via --disable-auth."""
+    from guidebook.routes.auth import DISABLE_AUTH, _env_disable_auth
+
+    if DISABLE_AUTH or _env_disable_auth():
+        raise HTTPException(403, "Authentication is disabled. Certificate management is unavailable.")
+
 PENDING_DOWNLOAD_TTL = 600  # 10 minutes
 
 
@@ -134,6 +142,7 @@ async def download_ca_cert(
     gdb: AsyncSession = Depends(get_global_session),
 ):
     """Download the CA public certificate in PEM format."""
+    _check_auth_enabled()
     ca_cert_pem = await _get_setting(gdb, "ca_cert_pem")
     if not ca_cert_pem:
         raise HTTPException(404, "CA certificate not found.")
@@ -165,6 +174,7 @@ async def generate_cert(
     gdb: AsyncSession = Depends(get_global_session),
 ):
     """Generate a client certificate. Returns download token and password (shown once)."""
+    _check_auth_enabled()
     from guidebook.routes.auth import TLS_ENABLED, PROXY_MODE
 
     if not TLS_ENABLED:
@@ -305,6 +315,7 @@ async def revoke_cert(
     gdb: AsyncSession = Depends(get_global_session),
 ):
     """Revoke a client certificate."""
+    _check_auth_enabled()
     result = await gdb.execute(select(ClientCert).where(ClientCert.id == cert_id))
     cert = result.scalar_one_or_none()
     if not cert:
@@ -330,6 +341,7 @@ async def activate_mtls(
     gdb: AsyncSession = Depends(get_global_session),
 ):
     """Set mTLS mode. Requires server restart to take effect."""
+    _check_auth_enabled()
     from guidebook.routes.auth import TLS_ENABLED, PROXY_MODE
 
     if not TLS_ENABLED:
@@ -352,6 +364,7 @@ async def mtls_logout(
     gdb: AsyncSession = Depends(get_global_session),
 ):
     """Revoke the client certificate and clear the cookie session."""
+    _check_auth_enabled()
     current_serial = _get_peer_cert_serial(request)
     if not current_serial:
         raise HTTPException(400, "No client certificate detected on this connection.")

--- a/src/guidebook/routes/mtls.py
+++ b/src/guidebook/routes/mtls.py
@@ -132,6 +132,8 @@ async def generate_cert(
     if PROXY_MODE:
         raise HTTPException(400, "mTLS is not available in proxy mode.")
 
+    from guidebook.routes.auth import AUTH_SLOTS, _token_count
+
     from guidebook.db import META_DB_PATH
     from guidebook.tls import ensure_ca_cert, generate_client_cert
 
@@ -141,8 +143,19 @@ async def generate_cert(
     result = await gdb.execute(
         select(ClientCert).where(ClientCert.revoked_at.is_(None))
     )
-    active_count = len(result.scalars().all())
-    label = f"client-{active_count + 1}"
+    active_certs = result.scalars().all()
+    active_cert_count = len(active_certs)
+
+    # Check slot availability (sessions + certs share the same slots)
+    session_count = await _token_count(gdb)
+    total_used = session_count + active_cert_count
+    if AUTH_SLOTS > 0 and total_used >= AUTH_SLOTS:
+        raise HTTPException(
+            400,
+            f"All {AUTH_SLOTS} slot(s) are in use ({session_count} session(s), {active_cert_count} cert(s)). Revoke a session or certificate first.",
+        )
+
+    label = f"client-{active_cert_count + 1}"
 
     p12_bytes, password, serial_hex, fingerprint = generate_client_cert(
         ca_cert_pem, ca_key_pem, label

--- a/src/guidebook/routes/mtls.py
+++ b/src/guidebook/routes/mtls.py
@@ -282,9 +282,10 @@ async def activate_mtls(
 @router.post("/logout")
 async def mtls_logout(
     request: Request,
+    response: Response,
     gdb: AsyncSession = Depends(get_global_session),
 ):
-    """Revoke the client certificate used for the current connection."""
+    """Revoke the client certificate and clear the cookie session."""
     current_serial = _get_peer_cert_serial(request)
     if not current_serial:
         raise HTTPException(400, "No client certificate detected on this connection.")
@@ -300,9 +301,24 @@ async def mtls_logout(
         raise HTTPException(404, "Current certificate not found or already revoked.")
 
     cert.revoked_at = time.time()
+
+    # Also clear the cookie session so the user is fully logged out
+    from guidebook.routes.auth import (
+        AUTH_COOKIE_NAME,
+        _get_current_session_id,
+        _validate_session,
+    )
+
+    session_id = _get_current_session_id(request)
+    if session_id:
+        tok = await _validate_session(gdb, session_id)
+        if tok:
+            await gdb.delete(tok)
+
     await gdb.commit()
+    response.delete_cookie(AUTH_COOKIE_NAME, path="/")
     logger.info(
-        "mTLS logout: revoked current certificate %s (serial: %s)",
+        "mTLS logout: revoked certificate %s and cleared session (serial: %s)",
         cert.label,
         cert.serial_number,
     )

--- a/src/guidebook/routes/mtls.py
+++ b/src/guidebook/routes/mtls.py
@@ -82,10 +82,12 @@ async def mtls_status(
     gdb: AsyncSession = Depends(get_global_session),
 ):
     from guidebook.routes.auth import TLS_ENABLED, PROXY_MODE
+    from guidebook.sse import connected_cert_serials
 
     mode = await _get_setting(gdb, "mtls_mode") or "disabled"
     ca_cert = await _get_setting(gdb, "ca_cert_pem")
     current_serial = _get_peer_cert_serial(request)
+    active_serials = connected_cert_serials()
 
     result = await gdb.execute(select(ClientCert).order_by(ClientCert.issued_at.desc()))
     certs = [
@@ -99,6 +101,7 @@ async def mtls_status(
             "fingerprint_sha256": c.fingerprint_sha256,
             "is_current": current_serial is not None
             and c.serial_number == current_serial,
+            "is_connected": c.serial_number in active_serials,
         }
         for c in result.scalars().all()
     ]

--- a/src/guidebook/routes/mtls.py
+++ b/src/guidebook/routes/mtls.py
@@ -128,6 +128,24 @@ async def mtls_status(
     )
 
 
+@router.get("/ca.pem")
+async def download_ca_cert(
+    gdb: AsyncSession = Depends(get_global_session),
+):
+    """Download the CA public certificate in PEM format."""
+    ca_cert_pem = await _get_setting(gdb, "ca_cert_pem")
+    if not ca_cert_pem:
+        raise HTTPException(404, "CA certificate not found.")
+    return Response(
+        content=ca_cert_pem,
+        media_type="application/x-pem-file",
+        headers={
+            "Content-Disposition": 'attachment; filename="guidebook-ca.pem"',
+            "Cache-Control": "no-store",
+        },
+    )
+
+
 class GenerateCertResponse(BaseModel):
     download_token: str
     password: str

--- a/src/guidebook/routes/mtls.py
+++ b/src/guidebook/routes/mtls.py
@@ -57,6 +57,7 @@ async def _set_setting(gdb: AsyncSession, key: str, value: str) -> None:
 class MtlsStatusResponse(BaseModel):
     mode: str
     ca_initialized: bool
+    ca_fingerprint: str | None
     tls_enabled: bool
     proxy_mode: bool
     certs: list[dict]
@@ -85,8 +86,19 @@ async def mtls_status(
     from guidebook.sse import connected_cert_serials
 
     mode = await _get_setting(gdb, "mtls_mode") or "disabled"
-    ca_cert = await _get_setting(gdb, "ca_cert_pem")
+    ca_cert_pem = await _get_setting(gdb, "ca_cert_pem")
     current_serial = _get_peer_cert_serial(request)
+
+    ca_fingerprint = None
+    if ca_cert_pem:
+        try:
+            from cryptography import x509
+            from cryptography.hazmat.primitives import hashes
+
+            ca_cert = x509.load_pem_x509_certificate(ca_cert_pem.encode())
+            ca_fingerprint = ca_cert.fingerprint(hashes.SHA256()).hex()
+        except Exception:
+            pass
     active_serials = connected_cert_serials()
 
     result = await gdb.execute(select(ClientCert).order_by(ClientCert.issued_at.desc()))
@@ -108,7 +120,8 @@ async def mtls_status(
 
     return MtlsStatusResponse(
         mode=mode,
-        ca_initialized=bool(ca_cert),
+        ca_initialized=bool(ca_cert_pem),
+        ca_fingerprint=ca_fingerprint,
         tls_enabled=TLS_ENABLED,
         proxy_mode=PROXY_MODE,
         certs=certs,

--- a/src/guidebook/routes/mtls.py
+++ b/src/guidebook/routes/mtls.py
@@ -308,13 +308,6 @@ async def activate_mtls(
     if body.mode not in ("disabled", "optional", "required"):
         raise HTTPException(400, f"Invalid mode: {body.mode}")
 
-    if body.mode != "disabled":
-        # Ensure CA exists
-        from guidebook.db import META_DB_PATH
-        from guidebook.tls import ensure_ca_cert
-
-        ensure_ca_cert(str(META_DB_PATH))
-
     await _set_setting(gdb, "mtls_mode", body.mode)
     await gdb.commit()
     logger.info("mTLS mode set to: %s (restart required)", body.mode)

--- a/src/guidebook/routes/mtls.py
+++ b/src/guidebook/routes/mtls.py
@@ -134,9 +134,8 @@ async def generate_cert(
 
     from guidebook.routes.auth import (
         AUTH_SLOTS,
-        _get_jwt_claims,
+        _get_current_session_id,
         _token_count,
-        _validate_session,
     )
 
     from guidebook.db import META_DB_PATH
@@ -144,7 +143,7 @@ async def generate_cert(
 
     ca_cert_pem, ca_key_pem = ensure_ca_cert(str(META_DB_PATH))
 
-    # Count active (non-revoked) certs
+    # Count active (non-revoked) certs (exclude pending-upgrade certs from count)
     result = await gdb.execute(
         select(ClientCert).where(ClientCert.revoked_at.is_(None))
     )
@@ -152,28 +151,21 @@ async def generate_cert(
     active_cert_count = len(active_certs)
 
     # Check slot availability (sessions + certs share the same slots)
-    # If slots are full but the current user has a cookie session, revoke it
-    # to make room — this is the cookie-to-mTLS upgrade path
     session_count = await _token_count(gdb)
     total_used = session_count + active_cert_count
-    if AUTH_SLOTS > 0 and total_used >= AUTH_SLOTS:
-        claims = _get_jwt_claims(request)
-        if claims and "sid" in claims:
-            tok = await _validate_session(
-                gdb, claims["sid"], claims.get("nonce")
-            )
-            if tok:
-                await gdb.delete(tok)
-                await gdb.flush()
-                session_count -= 1
-                total_used -= 1
-                logger.info("Revoked cookie session to make room for client cert")
+    pending_session_id = None
 
     if AUTH_SLOTS > 0 and total_used >= AUTH_SLOTS:
-        raise HTTPException(
-            400,
-            f"All {AUTH_SLOTS} slot(s) are in use ({session_count} session(s), {active_cert_count} cert(s)). Revoke a session or certificate first.",
-        )
+        # If the user has a cookie session, allow the upgrade — the session
+        # will be revoked when the new cert is first used (state machine)
+        current_sid = _get_current_session_id(request)
+        if current_sid:
+            pending_session_id = current_sid
+        else:
+            raise HTTPException(
+                400,
+                f"All {AUTH_SLOTS} slot(s) are in use ({session_count} session(s), {active_cert_count} cert(s)). Revoke a session or certificate first.",
+            )
 
     label = f"client-{active_cert_count + 1}"
 
@@ -192,6 +184,7 @@ async def generate_cert(
             issued_at=now,
             expires_at=now + CERT_VALIDITY_DAYS * 86400,
             fingerprint_sha256=fingerprint,
+            pending_session_id=pending_session_id,
         )
     )
     await gdb.commit()

--- a/src/guidebook/routes/mtls.py
+++ b/src/guidebook/routes/mtls.py
@@ -132,7 +132,12 @@ async def generate_cert(
     if PROXY_MODE:
         raise HTTPException(400, "mTLS is not available in proxy mode.")
 
-    from guidebook.routes.auth import AUTH_SLOTS, _token_count
+    from guidebook.routes.auth import (
+        AUTH_SLOTS,
+        _get_current_session_id,
+        _token_count,
+        _validate_session,
+    )
 
     from guidebook.db import META_DB_PATH
     from guidebook.tls import ensure_ca_cert, generate_client_cert
@@ -147,8 +152,21 @@ async def generate_cert(
     active_cert_count = len(active_certs)
 
     # Check slot availability (sessions + certs share the same slots)
+    # If slots are full but the current user has a cookie session, revoke it
+    # to make room — this is the cookie-to-mTLS upgrade path
     session_count = await _token_count(gdb)
     total_used = session_count + active_cert_count
+    if AUTH_SLOTS > 0 and total_used >= AUTH_SLOTS:
+        current_sid = _get_current_session_id(request)
+        if current_sid:
+            tok = await _validate_session(gdb, current_sid)
+            if tok:
+                await gdb.delete(tok)
+                await gdb.flush()
+                session_count -= 1
+                total_used -= 1
+                logger.info("Revoked cookie session to make room for client cert")
+
     if AUTH_SLOTS > 0 and total_used >= AUTH_SLOTS:
         raise HTTPException(
             400,

--- a/src/guidebook/routes/mtls.py
+++ b/src/guidebook/routes/mtls.py
@@ -146,6 +146,10 @@ async def download_ca_cert(
     )
 
 
+class GenerateCertRequest(BaseModel):
+    label: str | None = None
+
+
 class GenerateCertResponse(BaseModel):
     download_token: str
     password: str
@@ -156,6 +160,7 @@ class GenerateCertResponse(BaseModel):
 @router.post("/generate-cert")
 async def generate_cert(
     request: Request,
+    body: GenerateCertRequest,
     gdb: AsyncSession = Depends(get_global_session),
 ):
     """Generate a client certificate. Returns download token and password (shown once)."""
@@ -201,7 +206,7 @@ async def generate_cert(
                 f"All {AUTH_SLOTS} slot(s) are in use ({session_count} session(s), {active_cert_count} cert(s)). Revoke a session or certificate first.",
             )
 
-    label = f"client-{active_cert_count + 1}"
+    label = body.label.strip() if body.label else f"client-{active_cert_count + 1}"
 
     p12_bytes, password, serial_hex, fingerprint = generate_client_cert(
         ca_cert_pem, ca_key_pem, label

--- a/src/guidebook/routes/mtls.py
+++ b/src/guidebook/routes/mtls.py
@@ -134,7 +134,7 @@ async def generate_cert(
 
     from guidebook.routes.auth import (
         AUTH_SLOTS,
-        _get_current_session_id,
+        _get_jwt_claims,
         _token_count,
         _validate_session,
     )
@@ -157,9 +157,11 @@ async def generate_cert(
     session_count = await _token_count(gdb)
     total_used = session_count + active_cert_count
     if AUTH_SLOTS > 0 and total_used >= AUTH_SLOTS:
-        current_sid = _get_current_session_id(request)
-        if current_sid:
-            tok = await _validate_session(gdb, current_sid)
+        claims = _get_jwt_claims(request)
+        if claims and "sid" in claims:
+            tok = await _validate_session(
+                gdb, claims["sid"], claims.get("nonce")
+            )
             if tok:
                 await gdb.delete(tok)
                 await gdb.flush()

--- a/src/guidebook/sse.py
+++ b/src/guidebook/sse.py
@@ -27,6 +27,20 @@ _on_disconnect_callbacks: list[Callable[[], None]] = []
 _ever_had_client: bool = False
 _auto_shutdown_task: asyncio.Task | None = None
 
+# Track which auth sessions and certs are connected via SSE
+_connected_session_ids: dict[int, int] = {}  # session_id -> refcount
+_connected_cert_serials: dict[str, int] = {}  # serial_hex -> refcount
+
+
+def connected_session_ids() -> set[int]:
+    """Return set of auth session IDs with active SSE connections."""
+    return {k for k, v in _connected_session_ids.items() if v > 0}
+
+
+def connected_cert_serials() -> set[str]:
+    """Return set of client cert serial numbers with active SSE connections."""
+    return {k for k, v in _connected_cert_serials.items() if v > 0}
+
 AUTO_SHUTDOWN_DELAY_DEFAULT = 300  # seconds
 _auto_shutdown_delay: int = AUTO_SHUTDOWN_DELAY_DEFAULT
 
@@ -180,6 +194,35 @@ async def event_stream(request: Request):
     queue: asyncio.Queue[str] = asyncio.Queue(maxsize=64)
     _subscribers.append(queue)
     _ever_had_client = True
+
+    # Track which auth identity owns this SSE connection
+    _sse_session_id = None
+    _sse_cert_serial = None
+    try:
+        from guidebook.routes.auth import _get_current_session_id
+
+        _sse_session_id = _get_current_session_id(request)
+    except Exception:
+        pass
+    try:
+        peer_cert_der = request.scope.get("mtls_peer_cert_der")
+        if peer_cert_der:
+            from cryptography.x509 import load_der_x509_certificate
+
+            cert = load_der_x509_certificate(peer_cert_der)
+            _sse_cert_serial = format(cert.serial_number, "x")
+    except Exception:
+        pass
+
+    if _sse_session_id is not None:
+        _connected_session_ids[_sse_session_id] = (
+            _connected_session_ids.get(_sse_session_id, 0) + 1
+        )
+    if _sse_cert_serial is not None:
+        _connected_cert_serials[_sse_cert_serial] = (
+            _connected_cert_serials.get(_sse_cert_serial, 0) + 1
+        )
+
     logger.info(
         "SSE client    connected from %s (total: %d)", client_addr, len(_subscribers)
     )
@@ -197,6 +240,15 @@ async def event_stream(request: Request):
         finally:
             if queue in _subscribers:
                 _subscribers.remove(queue)
+            # Untrack auth identity
+            if _sse_session_id is not None and _sse_session_id in _connected_session_ids:
+                _connected_session_ids[_sse_session_id] -= 1
+                if _connected_session_ids[_sse_session_id] <= 0:
+                    del _connected_session_ids[_sse_session_id]
+            if _sse_cert_serial is not None and _sse_cert_serial in _connected_cert_serials:
+                _connected_cert_serials[_sse_cert_serial] -= 1
+                if _connected_cert_serials[_sse_cert_serial] <= 0:
+                    del _connected_cert_serials[_sse_cert_serial]
             if len(_subscribers) == 0:
                 _last_client_disconnected_at = time.time()
             logger.info(

--- a/src/guidebook/tls.py
+++ b/src/guidebook/tls.py
@@ -170,15 +170,16 @@ def generate_client_cert(
 ) -> tuple[bytes, str, str, str]:
     """Generate a client certificate signed by the CA, bundled as PKCS#12.
 
+    Uses legacy 3DES+SHA1 encryption for maximum browser compatibility
+    (Firefox's NSS library does not support AES-256-CBC PKCS#12 files).
+
     Returns (p12_bytes, password, serial_hex, fingerprint_sha256).
     """
+    import subprocess
+
     from cryptography import x509
     from cryptography.hazmat.primitives import hashes, serialization
     from cryptography.hazmat.primitives.asymmetric import rsa
-    from cryptography.hazmat.primitives.serialization import (
-        pkcs12,
-        BestAvailableEncryption,
-    )
     from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
 
     ca_cert = x509.load_pem_x509_certificate(ca_cert_pem.encode())
@@ -211,17 +212,78 @@ def generate_client_cert(
         .sign(ca_key, hashes.SHA256())
     )
 
-    password = secrets.token_urlsafe(24)
-    p12_bytes = pkcs12.serialize_key_and_certificates(
-        name=b"guidebook-client",
-        key=client_key,
-        cert=client_cert,
-        cas=[ca_cert],
-        encryption_algorithm=BestAvailableEncryption(password.encode()),
-    )
-
     fingerprint = client_cert.fingerprint(hashes.SHA256()).hex()
     serial_hex = format(serial, "x")
+
+    # Build PKCS#12 with legacy 3DES+SHA1 via openssl for browser compatibility
+    password = secrets.token_urlsafe(24)
+    client_cert_pem = client_cert.public_bytes(serialization.Encoding.PEM)
+    client_key_pem = client_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    )
+
+    cert_file = tempfile.NamedTemporaryFile(
+        delete=False, suffix=".pem", prefix="guidebook_ccert_"
+    )
+    cert_file.write(client_cert_pem)
+    cert_file.close()
+    key_file = tempfile.NamedTemporaryFile(
+        delete=False, suffix=".pem", prefix="guidebook_ckey_"
+    )
+    key_file.write(client_key_pem)
+    key_file.close()
+    ca_file = tempfile.NamedTemporaryFile(
+        delete=False, suffix=".pem", prefix="guidebook_cacert_"
+    )
+    ca_file.write(ca_cert_pem.encode())
+    ca_file.close()
+    p12_file = tempfile.NamedTemporaryFile(
+        delete=False, suffix=".p12", prefix="guidebook_p12_"
+    )
+    p12_file.close()
+
+    try:
+        result = subprocess.run(
+            [
+                "openssl",
+                "pkcs12",
+                "-export",
+                "-inkey",
+                key_file.name,
+                "-in",
+                cert_file.name,
+                "-certfile",
+                ca_file.name,
+                "-out",
+                p12_file.name,
+                "-passout",
+                f"pass:{password}",
+                "-keypbe",
+                "pbeWithSHA1And3-KeyTripleDES-CBC",
+                "-certpbe",
+                "pbeWithSHA1And3-KeyTripleDES-CBC",
+                "-macalg",
+                "sha1",
+                "-name",
+                f"guidebook-{label}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"openssl pkcs12 failed: {result.stderr}")
+
+        with open(p12_file.name, "rb") as f:
+            p12_bytes = f.read()
+    finally:
+        for path in (cert_file.name, key_file.name, ca_file.name, p12_file.name):
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
 
     return p12_bytes, password, serial_hex, fingerprint
 

--- a/src/guidebook/tls.py
+++ b/src/guidebook/tls.py
@@ -9,6 +9,7 @@ import tempfile
 logger = logging.getLogger("guidebook")
 
 CERT_VALIDITY_DAYS = 3650  # ~10 years
+CA_VALIDITY_DAYS = 7300  # ~20 years
 
 
 def _generate_server_cert(
@@ -96,7 +97,7 @@ def generate_ca_cert() -> tuple[str, str]:
         .public_key(key.public_key())
         .serial_number(x509.random_serial_number())
         .not_valid_before(now)
-        .not_valid_after(now + datetime.timedelta(days=CERT_VALIDITY_DAYS))
+        .not_valid_after(now + datetime.timedelta(days=CA_VALIDITY_DAYS))
         .add_extension(
             x509.BasicConstraints(ca=True, path_length=0),
             critical=True,
@@ -149,7 +150,7 @@ def ensure_ca_cert(meta_db_path: str) -> tuple[str, str]:
         logger.info("Loaded CA certificate from database")
         return row_cert[0], row_key[0]
 
-    logger.info("Generating new CA certificate (valid %d days)", CERT_VALIDITY_DAYS)
+    logger.info("Generating new CA certificate (valid %d days)", CA_VALIDITY_DAYS)
     cert_pem, key_pem = generate_ca_cert()
     conn.execute(
         "INSERT OR REPLACE INTO settings (key, value) VALUES ('ca_cert_pem', ?)",

--- a/src/guidebook/tls.py
+++ b/src/guidebook/tls.py
@@ -11,8 +11,13 @@ logger = logging.getLogger("guidebook")
 CERT_VALIDITY_DAYS = 3650  # ~10 years
 
 
-def generate_self_signed_cert() -> tuple[str, str]:
-    """Generate a self-signed TLS certificate. Returns (cert_pem, key_pem)."""
+def _generate_server_cert(
+    ca_cert_pem: str | None = None, ca_key_pem: str | None = None
+) -> tuple[str, str]:
+    """Generate a server TLS certificate. If CA cert/key are provided, the
+    server cert is signed by the CA. Otherwise it is self-signed.
+    Returns (cert_pem, key_pem).
+    """
     from cryptography import x509
     from cryptography.hazmat.primitives import hashes, serialization
     from cryptography.hazmat.primitives.asymmetric import rsa
@@ -21,11 +26,20 @@ def generate_self_signed_cert() -> tuple[str, str]:
 
     key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
 
-    subject = issuer = x509.Name(
+    subject = x509.Name(
         [
             x509.NameAttribute(NameOID.COMMON_NAME, "guidebook"),
         ]
     )
+
+    if ca_cert_pem and ca_key_pem:
+        ca_cert = x509.load_pem_x509_certificate(ca_cert_pem.encode())
+        ca_key = serialization.load_pem_private_key(ca_key_pem.encode(), password=None)
+        issuer = ca_cert.subject
+        signing_key = ca_key
+    else:
+        issuer = subject
+        signing_key = key
 
     now = datetime.datetime.now(datetime.timezone.utc)
     cert = (
@@ -46,7 +60,7 @@ def generate_self_signed_cert() -> tuple[str, str]:
             ),
             critical=False,
         )
-        .sign(key, hashes.SHA256())
+        .sign(signing_key, hashes.SHA256())
     )
 
     cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
@@ -246,14 +260,42 @@ def generate_crl(
     return crl.public_bytes(serialization.Encoding.PEM).decode()
 
 
+def _load_ca_from_db(conn) -> tuple[str | None, str | None]:
+    """Load CA cert/key from the database if they exist."""
+    row_ca_cert = conn.execute(
+        "SELECT value FROM settings WHERE key = 'ca_cert_pem'"
+    ).fetchone()
+    row_ca_key = conn.execute(
+        "SELECT value FROM settings WHERE key = 'ca_key_pem'"
+    ).fetchone()
+    ca_cert = row_ca_cert[0] if row_ca_cert and row_ca_cert[0] else None
+    ca_key = row_ca_key[0] if row_ca_key and row_ca_key[0] else None
+    return ca_cert, ca_key
+
+
+def _is_signed_by_ca(cert_pem: str, ca_cert_pem: str) -> bool:
+    """Check if a certificate was issued by the given CA."""
+    from cryptography import x509
+
+    cert = x509.load_pem_x509_certificate(cert_pem.encode())
+    ca_cert = x509.load_pem_x509_certificate(ca_cert_pem.encode())
+    return cert.issuer == ca_cert.subject
+
+
 def ensure_tls_cert(meta_db_path: str) -> tuple[str, str]:
-    """Load or generate TLS cert/key from the global database. Returns (cert_pem, key_pem)."""
+    """Load or generate TLS cert/key from the global database. Returns (cert_pem, key_pem).
+
+    If a CA exists, the server cert is signed by the CA. If the existing server
+    cert is self-signed but a CA now exists, it is regenerated as CA-signed.
+    """
     os.makedirs(os.path.dirname(meta_db_path), exist_ok=True)
     conn = sqlite3.connect(meta_db_path)
     conn.execute(
         "CREATE TABLE IF NOT EXISTS settings "
         "(id INTEGER NOT NULL PRIMARY KEY, key VARCHAR NOT NULL UNIQUE, value VARCHAR)"
     )
+
+    ca_cert_pem, ca_key_pem = _load_ca_from_db(conn)
 
     row_cert = conn.execute(
         "SELECT value FROM settings WHERE key = 'tls_cert_pem'"
@@ -263,14 +305,25 @@ def ensure_tls_cert(meta_db_path: str) -> tuple[str, str]:
     ).fetchone()
 
     if row_cert and row_key and row_cert[0] and row_key[0]:
-        conn.close()
-        logger.info("Loaded TLS certificate from database")
-        return row_cert[0], row_key[0]
+        # Check if we need to regenerate: CA exists but cert is not CA-signed
+        if ca_cert_pem and not _is_signed_by_ca(row_cert[0], ca_cert_pem):
+            logger.info("Regenerating server certificate (signing with CA)")
+        else:
+            conn.close()
+            logger.info("Loaded TLS certificate from database")
+            return row_cert[0], row_key[0]
 
-    logger.info(
-        "Generating new self-signed TLS certificate (valid %d days)", CERT_VALIDITY_DAYS
-    )
-    cert_pem, key_pem = generate_self_signed_cert()
+    if ca_cert_pem and ca_key_pem:
+        logger.info(
+            "Generating CA-signed server certificate (valid %d days)", CERT_VALIDITY_DAYS
+        )
+        cert_pem, key_pem = _generate_server_cert(ca_cert_pem, ca_key_pem)
+    else:
+        logger.info(
+            "Generating self-signed server certificate (valid %d days)", CERT_VALIDITY_DAYS
+        )
+        cert_pem, key_pem = _generate_server_cert()
+
     conn.execute(
         "INSERT OR REPLACE INTO settings (key, value) VALUES ('tls_cert_pem', ?)",
         (cert_pem,),


### PR DESCRIPTION
## Summary

- mTLS client certificate authentication with three modes: disabled, optional, enforced
- Auto-create CA on first TLS startup, sign server and client certs with CA
- Unified Active Clients list with cookie/mTLS badges, split into connected/inactive
- Certificate lifecycle: custom labels, .p12 download, revocation with collapsible accordion
- Session upgrade state machine: defer cookie revocation until first mTLS cert use
- CA info box with fingerprint and PEM download
- `--disable-auth` fully bypasses all auth: middleware, mTLS verification, cert management, and UI
- `--reset-auth` shows confirmation prompt listing all destructive actions before proceeding
- Auth status description adapts to current mTLS mode
- Fix SSE reconnect loop, rate limiting, and auth middleware issues
- Legacy 3DES+SHA1 PKCS#12 encryption for browser compatibility