### PR TITLE
Record row click-to-select and edit button improvements

### DIFF
--- a/frontend/src/Records.svelte
+++ b/frontend/src/Records.svelte
@@ -333,6 +333,12 @@
     }
   }
 
+  function selectRow(i) {
+    selectedIndex = i;
+    scrollToSelected();
+    dispatch("selectionchange", sortedRecords[selectedIndex]?.id ?? null);
+  }
+
   export function deselect() {
     if (selectedIndex >= 0) {
       selectedIndex = -1;
@@ -807,10 +813,15 @@
         <tbody>
           {#each sortedRecords as r, i (r.id)}
             <!-- svelte-ignore a11y-click-events-have-key-events -->
-            <tr class="clickable" class:editing={formId === r.id} class:selected={selectedIndex === i} title={relativeTime(r.timestamp)} on:click={() => editRecord(r)}>
+            <tr class="clickable" class:editing={formId === r.id} class:selected={selectedIndex === i} title={relativeTime(r.timestamp)} on:click={() => selectRow(i)}>
               {#each columns as col (col.key)}
                 {#if col.key === "title"}
-                  <td class="title-cell">{r.title}</td>
+                  <td class="title-cell">
+                    {r.title}
+                    {#if selectedIndex === i}
+                      <button class="edit-row-btn" on:click|stopPropagation={() => editRecord(r)} title="Edit record">&#9998;</button>
+                    {/if}
+                  </td>
                 {:else if col.key === "tags"}
                   <td class="tags-cell">{r.tags || ""}</td>
                 {:else if col.key === "content"}
@@ -1124,6 +1135,25 @@
 
   tr.editing {
     background: var(--row-editing);
+  }
+
+  .edit-row-btn {
+    display: inline-block;
+    margin-left: 0.4rem;
+    padding: 0.1rem 0.35rem;
+    border: 1px solid var(--accent, #00ff88);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--accent, #00ff88);
+    font-size: 0.8rem;
+    cursor: pointer;
+    vertical-align: middle;
+    line-height: 1;
+  }
+
+  .edit-row-btn:hover {
+    background: var(--accent, #00ff88);
+    color: var(--bg, #1a1b1e);
   }
 
   /* --- Attachments --- */

--- a/frontend/src/Records.svelte
+++ b/frontend/src/Records.svelte
@@ -814,7 +814,7 @@
         <tbody>
           {#each sortedRecords as r, i (r.id)}
             <!-- svelte-ignore a11y-click-events-have-key-events -->
-            <tr class="clickable" class:editing={formId === r.id} class:selected={selectedIndex === i} title={relativeTime(r.timestamp)} on:click={() => selectRow(i)}>
+            <tr class="clickable" class:editing={formId === r.id} class:selected={selectedIndex === i} title={relativeTime(r.timestamp)} on:click={() => selectRow(i)} on:dblclick={() => editRecord(r)}>
               <td class="action-cell">
                 {#if selectedIndex === i}
                   <button class="edit-row-btn" on:click|stopPropagation={() => editRecord(r)} title="Edit record">&#9998;</button>

--- a/frontend/src/Records.svelte
+++ b/frontend/src/Records.svelte
@@ -791,6 +791,7 @@
       <table>
         <thead>
           <tr>
+            <th class="action-col"></th>
             {#each columns as col (col.key)}
               <th class:drag-over={dragOverCol === col.key && dragCol !== col.key}
                   on:dragover={e => onColDragOver(e, col.key)}
@@ -814,14 +815,14 @@
           {#each sortedRecords as r, i (r.id)}
             <!-- svelte-ignore a11y-click-events-have-key-events -->
             <tr class="clickable" class:editing={formId === r.id} class:selected={selectedIndex === i} title={relativeTime(r.timestamp)} on:click={() => selectRow(i)}>
+              <td class="action-cell">
+                {#if selectedIndex === i}
+                  <button class="edit-row-btn" on:click|stopPropagation={() => editRecord(r)} title="Edit record">&#9998;</button>
+                {/if}
+              </td>
               {#each columns as col (col.key)}
                 {#if col.key === "title"}
-                  <td class="title-cell">
-                    {r.title}
-                    {#if selectedIndex === i}
-                      <button class="edit-row-btn" on:click|stopPropagation={() => editRecord(r)} title="Edit record">&#9998;</button>
-                    {/if}
-                  </td>
+                  <td class="title-cell">{r.title}</td>
                 {:else if col.key === "tags"}
                   <td class="tags-cell">{r.tags || ""}</td>
                 {:else if col.key === "content"}
@@ -1137,17 +1138,30 @@
     background: var(--row-editing);
   }
 
+  .action-col {
+    width: 1.8rem;
+    min-width: 1.8rem;
+    max-width: 1.8rem;
+    padding: 0 !important;
+  }
+
+  .action-cell {
+    width: 1.8rem;
+    min-width: 1.8rem;
+    max-width: 1.8rem;
+    padding: 0 !important;
+    text-align: center;
+    overflow: visible;
+  }
+
   .edit-row-btn {
-    display: inline-block;
-    margin-left: 0.4rem;
-    padding: 0.1rem 0.35rem;
+    padding: 0.1rem 0.3rem;
     border: 1px solid var(--accent, #00ff88);
     border-radius: 4px;
     background: transparent;
     color: var(--accent, #00ff88);
     font-size: 0.8rem;
     cursor: pointer;
-    vertical-align: middle;
     line-height: 1;
   }
 

--- a/frontend/src/Records.svelte
+++ b/frontend/src/Records.svelte
@@ -817,7 +817,7 @@
             <tr class="clickable" class:editing={formId === r.id} class:selected={selectedIndex === i} title={relativeTime(r.timestamp)} on:click={() => selectRow(i)} on:dblclick={() => editRecord(r)}>
               <td class="action-cell">
                 {#if selectedIndex === i}
-                  <button class="edit-row-btn" on:click|stopPropagation={() => editRecord(r)} title="Edit record">&#9998;</button>
+                  <button class="edit-row-btn" on:click|stopPropagation={() => editRecord(r)} title="Edit record"><svg viewBox="0 0 16 16" width="12" height="12" fill="currentColor"><path d="M12.1 1.3a1.1 1.1 0 0 1 1.6 0l1 1a1.1 1.1 0 0 1 0 1.6L5.7 12.9l-3.5.9.9-3.5Z"/></svg></button>
                 {/if}
               </td>
               {#each columns as col (col.key)}

--- a/frontend/src/Records.svelte
+++ b/frontend/src/Records.svelte
@@ -816,9 +816,9 @@
         <tbody>
           {#each sortedRecords as r, i (r.id)}
             <!-- svelte-ignore a11y-click-events-have-key-events -->
-            <tr class="clickable" class:editing={formId === r.id} class:selected={selectedIndex === i} title={relativeTime(r.timestamp)} on:click={() => selectRow(i)} on:dblclick={() => editRecord(r)}>
+            <tr class:clickable={!showForm} class:editing={formId === r.id} class:selected={selectedIndex === i} title={relativeTime(r.timestamp)} on:click={() => { if (!showForm) selectRow(i); }} on:dblclick={() => { if (!showForm) editRecord(r); }}>
               <td class="action-cell">
-                {#if selectedIndex === i}
+                {#if selectedIndex === i && !showForm}
                   <button class="edit-row-btn" on:click|stopPropagation={() => editRecord(r)} title="Edit record"><Icon icon={iconPencil} width="14" height="14" /></button>
                 {/if}
               </td>

--- a/frontend/src/Records.svelte
+++ b/frontend/src/Records.svelte
@@ -1,6 +1,8 @@
 <script>
   import { onMount, onDestroy, createEventDispatcher, tick } from "svelte";
   import { storageGet, storageSet } from "./storage.js";
+  import Icon from "@iconify/svelte";
+  import iconPencil from "@iconify-icons/twemoji/pencil";
 
   const dispatch = createEventDispatcher();
 
@@ -817,7 +819,7 @@
             <tr class="clickable" class:editing={formId === r.id} class:selected={selectedIndex === i} title={relativeTime(r.timestamp)} on:click={() => selectRow(i)} on:dblclick={() => editRecord(r)}>
               <td class="action-cell">
                 {#if selectedIndex === i}
-                  <button class="edit-row-btn" on:click|stopPropagation={() => editRecord(r)} title="Edit record"><svg viewBox="0 0 16 16" width="12" height="12" fill="currentColor"><path d="M12.1 1.3a1.1 1.1 0 0 1 1.6 0l1 1a1.1 1.1 0 0 1 0 1.6L5.7 12.9l-3.5.9.9-3.5Z"/></svg></button>
+                  <button class="edit-row-btn" on:click|stopPropagation={() => editRecord(r)} title="Edit record"><Icon icon={iconPencil} width="14" height="14" /></button>
                 {/if}
               </td>
               {#each columns as col (col.key)}

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -1772,7 +1772,7 @@
   {#if mtlsMode !== "required"}
   <section class="settings-section">
     <h3>Generate Login Link</h3>
-    <p class="hint">Generate a one-time login URL to share with another browser.</p>
+    <p class="hint">Generate a one-time login URL to share with another browser. {#if authSlots > 0}{authAvailableSlots} of {authSlots} slots available.{:else}Unlimited slots.{/if}</p>
     {#if !authShowLinkForm && !authTokenUrl}
       <div class="setting-row">
         <button on:click={openLoginLinkForm} disabled={authSlots > 0 && authAvailableSlots <= 0}>


### PR DESCRIPTION
## Summary
- Row click now selects/highlights the row instead of opening the edit form
- Added dedicated action column with edit button (twemoji pencil icon) at start of each row
- Double-click row to open edit form
- Row selection and edit button disabled when record form is open
- Show available slot count in Generate Login Link section