### PR TITLE
Let's Encrypt TLS via ACME-DNS (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ tags) as a starting point — replace it with your own data model and UI.
 ## Features
 
 - **Personal by default**: TLS, single-session auth, one-time login links, and optional mTLS client certificates
+- **Let's Encrypt**: Optional trusted TLS certificates via [ACME-DNS](https://github.com/joohoi/acme-dns) DNS-01 challenges, with automatic renewal
 - **Records**: Generic CRUD records (title, content, tags) — replace with your own data model
 - **Scratchpad**: Ephemeral shared notepad synced in real time across all connected clients via SSE
 - **Multi-database**: Multiple projects with separate SQLite databases and a database picker

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -1836,6 +1836,7 @@
 
       {#if mtlsMode !== "disabled" || mtlsCerts.length > 0}
         <h4 style="margin-top: 1rem; margin-bottom: 0.5rem;">Generate Client Certificate</h4>
+        <p class="hint">Generate a client certificate for mTLS authentication. {#if authSlots > 0}{authAvailableSlots} of {authSlots} slot{authSlots === 1 ? '' : 's'} available.{:else}Unlimited slots.{/if}</p>
         <div class="setting-row">
           <button on:click={openCertModal} disabled={authSlots > 0 && authAvailableSlots <= 0 && !authSessions.some(s => s.is_current)}>
             {authSlots > 0 && authAvailableSlots <= 0 && !authSessions.some(s => s.is_current) ? `No slots available (${authSlots} used)` : "Generate Client Certificate"}

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -2041,22 +2041,15 @@
     {#if !tlsEnabled}
       <p class="hint" style="color: var(--error-color, #e74c3c); font-weight: bold;">TLS is disabled via <code style="font-size: 0.75rem; white-space: nowrap">--no-tls</code>. Remove this flag to configure TLS certificates.</p>
     {:else}
-      <p class="hint">Configure how the server's TLS certificate is provisioned. The self-signed CA is always used for mTLS client certificates regardless of this setting.</p>
+      {#if tlsMode === "acme"}
+        <p class="hint">Server certificate is provisioned via <strong>Let's Encrypt</strong> (ACME-DNS). The self-signed CA is still used for mTLS client certificates.</p>
+      {:else}
+        <p class="hint">Server certificate is signed by the <strong>built-in self-signed CA</strong>. You can optionally switch to a trusted Let's Encrypt certificate below.</p>
+      {/if}
 
       {#if tlsRestartRequired}
         <p class="hint" style="color: var(--warning-color, #e6a700); font-weight: bold; margin-top: 0.5rem;">A new certificate has been provisioned. Restart the server to activate it.</p>
       {/if}
-
-      <div class="mtls-radio-group" style="margin-top: 0.75rem;">
-        <label class="mtls-radio" class:active={tlsMode === "self-signed"}>
-          <input type="radio" name="tls-mode" value="self-signed" checked={tlsMode === "self-signed"} disabled />
-          <span><strong>Self-signed CA</strong> — server cert signed by the built-in CA</span>
-        </label>
-        <label class="mtls-radio" class:active={tlsMode === "acme"}>
-          <input type="radio" name="tls-mode" value="acme" checked={tlsMode === "acme"} disabled />
-          <span><strong>Let's Encrypt</strong> — trusted cert via ACME-DNS</span>
-        </label>
-      </div>
     {/if}
   </section>
 

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -56,7 +56,7 @@
   // Store global default values for use as placeholders
   let globalPlaceholders = {};
 
-  const validTabs = ["features", "appearance", "updates", "data", "auth", "global"];
+  const validTabs = ["features", "appearance", "updates", "data", "auth", "tls", "global"];
   let activeTab = (initialTab && validTabs.includes(initialTab)) ? initialTab : "features";
   let settingsLoaded = false;
 
@@ -396,6 +396,191 @@
       mtlsError = e.message;
     }
     mtlsActivating = false;
+  }
+
+  // TLS settings
+  let tlsEnabled = true;
+  let tlsMode = "self-signed";
+  let tlsCaFingerprint = null;
+  let tlsServerFingerprint = null;
+  let tlsCertIssuer = null;
+  let tlsCertNotBefore = null;
+  let tlsCertNotAfter = null;
+  let tlsCertSan = [];
+  let tlsNextRenewal = null;
+  let tlsAcmeDomain = "";
+  let tlsAcmeEndpoint = "le-production";
+  let tlsAcmeDnsServer = "https://auth.acme-dns.io";
+  let tlsAcmeFulldomain = null;
+  let tlsAcmeRegistered = false;
+  let tlsAcmeConfigured = false;
+  let tlsAcmeStep = "configure"; // configure, register, cname, provision, active
+  let tlsAcmeProvisioning = false;
+  let tlsAcmeError = "";
+  let tlsAcmeProgress = "";
+  let tlsAcmeCnameRecord = "";
+  let tlsAcmeCnameTarget = "";
+  let tlsAcmeCnameStatus = null;
+  let tlsAcmeVerifying = false;
+  let tlsAcmeConfiguring = false;
+  let tlsAcmeRegistering = false;
+  let tlsAcmeReverting = false;
+  let tlsRestartRequired = false;
+
+  async function loadTlsStatus() {
+    try {
+      const res = await fetch("/api/tls/status");
+      if (res.ok) {
+        const data = await res.json();
+        tlsEnabled = data.tls_enabled;
+        tlsMode = data.tls_mode;
+        tlsCaFingerprint = data.ca_fingerprint;
+        tlsServerFingerprint = data.server_cert_fingerprint;
+        tlsCertIssuer = data.cert_issuer;
+        tlsCertNotBefore = data.cert_not_before;
+        tlsCertNotAfter = data.cert_not_after;
+        tlsCertSan = data.cert_san || [];
+        tlsNextRenewal = data.next_renewal;
+        if (data.acme_domain) tlsAcmeDomain = data.acme_domain;
+        if (data.acme_endpoint) tlsAcmeEndpoint = data.acme_endpoint;
+        if (data.acme_dns_server) tlsAcmeDnsServer = data.acme_dns_server;
+        tlsAcmeFulldomain = data.acme_dns_fulldomain;
+        tlsAcmeRegistered = data.acme_registered;
+        tlsAcmeConfigured = data.acme_configured;
+        // Determine step
+        if (tlsMode === "acme") {
+          tlsAcmeStep = "active";
+        } else if (data.acme_registered) {
+          tlsAcmeStep = "cname";
+        } else if (data.acme_configured) {
+          tlsAcmeStep = "register";
+        } else {
+          tlsAcmeStep = "configure";
+        }
+        if (data.acme_domain) {
+          tlsAcmeCnameRecord = `_acme-challenge.${data.acme_domain}`;
+          if (data.acme_dns_fulldomain) {
+            tlsAcmeCnameTarget = `${data.acme_dns_fulldomain}.`;
+          }
+        }
+      }
+    } catch {}
+  }
+
+  async function tlsAcmeConfigure() {
+    tlsAcmeError = "";
+    tlsAcmeConfiguring = true;
+    try {
+      const res = await fetch("/api/tls/acme/configure", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          domain: tlsAcmeDomain,
+          endpoint: tlsAcmeEndpoint,
+          acme_dns_server: tlsAcmeDnsServer,
+        }),
+      });
+      if (res.ok) {
+        await loadTlsStatus();
+        tlsAcmeStep = "register";
+      } else {
+        const data = await res.json().catch(() => null);
+        tlsAcmeError = data?.detail || "Failed to save configuration";
+      }
+    } catch (e) {
+      tlsAcmeError = e.message;
+    }
+    tlsAcmeConfiguring = false;
+  }
+
+  async function tlsAcmeRegister() {
+    tlsAcmeError = "";
+    tlsAcmeRegistering = true;
+    try {
+      const res = await fetch("/api/tls/acme/register", { method: "POST" });
+      if (res.ok) {
+        const data = await res.json();
+        tlsAcmeFulldomain = data.fulldomain;
+        tlsAcmeCnameRecord = data.cname_record;
+        tlsAcmeCnameTarget = data.cname_target;
+        tlsAcmeRegistered = true;
+        tlsAcmeStep = "cname";
+      } else {
+        const data = await res.json().catch(() => null);
+        tlsAcmeError = data?.detail || "Failed to register with acme-dns";
+      }
+    } catch (e) {
+      tlsAcmeError = e.message;
+    }
+    tlsAcmeRegistering = false;
+  }
+
+  async function tlsAcmeVerifyCname() {
+    tlsAcmeError = "";
+    tlsAcmeVerifying = true;
+    tlsAcmeCnameStatus = null;
+    try {
+      const res = await fetch("/api/tls/acme/verify-cname", { method: "POST" });
+      if (res.ok) {
+        const data = await res.json();
+        tlsAcmeCnameStatus = data;
+      } else {
+        const data = await res.json().catch(() => null);
+        tlsAcmeError = data?.detail || "DNS verification failed";
+      }
+    } catch (e) {
+      tlsAcmeError = e.message;
+    }
+    tlsAcmeVerifying = false;
+  }
+
+  async function tlsAcmeProvision() {
+    tlsAcmeError = "";
+    tlsAcmeProvisioning = true;
+    tlsAcmeProgress = "Starting certificate provisioning...";
+    try {
+      const res = await fetch("/api/tls/acme/provision", { method: "POST" });
+      if (res.ok) {
+        tlsAcmeStep = "active";
+        tlsRestartRequired = true;
+        await loadTlsStatus();
+      } else {
+        const data = await res.json().catch(() => null);
+        tlsAcmeError = data?.detail || "Provisioning failed";
+      }
+    } catch (e) {
+      tlsAcmeError = e.message;
+    }
+    tlsAcmeProvisioning = false;
+    tlsAcmeProgress = "";
+  }
+
+  async function tlsAcmeRevert() {
+    tlsAcmeError = "";
+    tlsAcmeReverting = true;
+    try {
+      const res = await fetch("/api/tls/acme/revert", { method: "POST" });
+      if (res.ok) {
+        tlsMode = "self-signed";
+        tlsAcmeStep = "configure";
+        tlsRestartRequired = true;
+        await loadTlsStatus();
+      } else {
+        const data = await res.json().catch(() => null);
+        tlsAcmeError = data?.detail || "Failed to revert";
+      }
+    } catch (e) {
+      tlsAcmeError = e.message;
+    }
+    tlsAcmeReverting = false;
+  }
+
+  function formatIsoDate(iso) {
+    if (!iso) return "—";
+    try {
+      const d = new Date(iso);
+      return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+    } catch { return iso; }
   }
 
   async function loadDbInfo() {
@@ -1222,6 +1407,7 @@
     loadAuthStatus();
     loadAuthSessions();
     loadMtlsStatus();
+    loadTlsStatus();
   });
 
   onDestroy(() => {
@@ -1238,6 +1424,7 @@
     <button class="tab" class:active={activeTab === "updates"} on:click={() => switchTab("updates")}>Updates</button>
     <button class="tab" class:active={activeTab === "data"} on:click={() => switchTab("data")}>Data</button>
     <button class="tab" class:active={activeTab === "auth"} on:click={() => switchTab("auth")}>Auth</button>
+    <button class="tab" class:active={activeTab === "tls"} on:click={() => switchTab("tls")}>TLS</button>
   </div>
 
   {#if activeTab === "features"}
@@ -1844,6 +2031,209 @@
       <p class="danger-error">{authError}</p>
     </section>
   {/if}
+  </div></div>
+  {/if}
+
+  {#if activeTab === "tls"}
+  <div class="tab-scroll"><div class="tab-content" use:masonry>
+  <section class="settings-section">
+    <h3>TLS Certificates</h3>
+    {#if !tlsEnabled}
+      <p class="hint" style="color: var(--error-color, #e74c3c); font-weight: bold;">TLS is disabled via <code style="font-size: 0.75rem; white-space: nowrap">--no-tls</code>. Remove this flag to configure TLS certificates.</p>
+    {:else}
+      <p class="hint">Configure how the server's TLS certificate is provisioned. The self-signed CA is always used for mTLS client certificates regardless of this setting.</p>
+
+      {#if tlsRestartRequired}
+        <p class="hint" style="color: var(--warning-color, #e6a700); font-weight: bold; margin-top: 0.5rem;">A new certificate has been provisioned. Restart the server to activate it.</p>
+      {/if}
+
+      <div class="mtls-radio-group" style="margin-top: 0.75rem;">
+        <label class="mtls-radio" class:active={tlsMode === "self-signed"}>
+          <input type="radio" name="tls-mode" value="self-signed" checked={tlsMode === "self-signed"} disabled />
+          <span><strong>Self-signed CA</strong> — server cert signed by the built-in CA</span>
+        </label>
+        <label class="mtls-radio" class:active={tlsMode === "acme"}>
+          <input type="radio" name="tls-mode" value="acme" checked={tlsMode === "acme"} disabled />
+          <span><strong>Let's Encrypt</strong> — trusted cert via ACME-DNS</span>
+        </label>
+      </div>
+    {/if}
+  </section>
+
+  {#if tlsEnabled && tlsMode === "self-signed"}
+  <section class="settings-section">
+    <h3>Self-signed Certificate Info</h3>
+    {#if tlsCaFingerprint}
+      <div style="margin-bottom: 0.75rem;">
+        <span style="font-size: 0.8rem; opacity: 0.7; display: block;">CA Fingerprint (SHA-256)</span>
+        <div style="font-family: monospace; font-size: 0.75rem; word-break: break-all;">{tlsCaFingerprint}</div>
+      </div>
+    {/if}
+    {#if tlsServerFingerprint}
+      <div style="margin-bottom: 0.75rem;">
+        <span style="font-size: 0.8rem; opacity: 0.7; display: block;">Server Cert Fingerprint (SHA-256)</span>
+        <div style="font-family: monospace; font-size: 0.75rem; word-break: break-all;">{tlsServerFingerprint}</div>
+      </div>
+    {/if}
+    {#if tlsCertIssuer}
+      <div style="margin-bottom: 0.75rem;">
+        <span style="font-size: 0.8rem; opacity: 0.7; display: block;">Issuer</span>
+        <div style="font-family: monospace; font-size: 0.85rem;">{tlsCertIssuer}</div>
+      </div>
+    {/if}
+    {#if tlsCertNotBefore && tlsCertNotAfter}
+      <div style="margin-bottom: 0.75rem;">
+        <span style="font-size: 0.8rem; opacity: 0.7; display: block;">Validity</span>
+        <div style="font-size: 0.85rem;">{formatIsoDate(tlsCertNotBefore)} — {formatIsoDate(tlsCertNotAfter)}</div>
+      </div>
+    {/if}
+    <div class="setting-row">
+      <a href="/api/tls/ca.pem" download="guidebook-ca.pem" style="display: inline-block;">
+        <button type="button">Download CA Certificate</button>
+      </a>
+    </div>
+  </section>
+  {/if}
+
+  {#if tlsEnabled && (tlsMode === "acme" || tlsAcmeStep !== "configure" || tlsMode !== "acme")}
+  <section class="settings-section">
+    <h3>Let's Encrypt via ACME-DNS</h3>
+
+    {#if tlsMode === "acme" && tlsAcmeStep === "active"}
+      <!-- Active ACME cert -->
+      <div style="margin-bottom: 0.75rem;">
+        <span style="font-size: 0.8rem; opacity: 0.7; display: block;">Domain</span>
+        <div style="font-family: monospace; font-size: 0.85rem;">{tlsAcmeDomain}</div>
+      </div>
+      <div style="margin-bottom: 0.75rem;">
+        <span style="font-size: 0.8rem; opacity: 0.7; display: block;">Issuer</span>
+        <div style="font-family: monospace; font-size: 0.85rem;">{tlsCertIssuer}</div>
+      </div>
+      {#if tlsServerFingerprint}
+        <div style="margin-bottom: 0.75rem;">
+          <span style="font-size: 0.8rem; opacity: 0.7; display: block;">Server Cert Fingerprint (SHA-256)</span>
+          <div style="font-family: monospace; font-size: 0.75rem; word-break: break-all;">{tlsServerFingerprint}</div>
+        </div>
+      {/if}
+      {#if tlsCertNotBefore && tlsCertNotAfter}
+        <div style="margin-bottom: 0.75rem;">
+          <span style="font-size: 0.8rem; opacity: 0.7; display: block;">Validity</span>
+          <div style="font-size: 0.85rem;">{formatIsoDate(tlsCertNotBefore)} — {formatIsoDate(tlsCertNotAfter)}</div>
+        </div>
+      {/if}
+      {#if tlsNextRenewal}
+        <div style="margin-bottom: 0.75rem;">
+          <span style="font-size: 0.8rem; opacity: 0.7; display: block;">Auto-renewal at</span>
+          <div style="font-size: 0.85rem;">{formatIsoDate(tlsNextRenewal)}</div>
+        </div>
+      {/if}
+      {#if tlsAcmeFulldomain}
+        <div style="margin-bottom: 0.75rem;">
+          <span style="font-size: 0.8rem; opacity: 0.7; display: block;">ACME-DNS Fulldomain</span>
+          <div style="font-family: monospace; font-size: 0.85rem;">{tlsAcmeFulldomain}</div>
+        </div>
+      {/if}
+      <div class="setting-row" style="margin-top: 1rem;">
+        <button class="danger-btn" on:click={tlsAcmeRevert} disabled={tlsAcmeReverting}>
+          {tlsAcmeReverting ? "Reverting..." : "Revert to Self-signed"}
+        </button>
+      </div>
+
+    {:else}
+      <!-- ACME setup wizard -->
+      <h4 style="margin-bottom: 0.5rem;">Step 1: Configure</h4>
+      <div style="margin-bottom: 0.75rem;">
+        <span style="font-size: 0.8rem; opacity: 0.7; display: block; margin-bottom: 0.3rem;">Domain name</span>
+        <input type="text" bind:value={tlsAcmeDomain} placeholder="notes.example.com" style="width: 100%; box-sizing: border-box;" disabled={tlsAcmeStep !== "configure"} />
+      </div>
+      <div style="margin-bottom: 0.75rem;">
+        <span style="font-size: 0.8rem; opacity: 0.7; display: block; margin-bottom: 0.3rem;">ACME endpoint</span>
+        <select bind:value={tlsAcmeEndpoint} style="width: 100%; box-sizing: border-box;" disabled={tlsAcmeStep !== "configure"}>
+          <option value="le-production">Let's Encrypt (Production)</option>
+          <option value="le-staging">Let's Encrypt (Staging)</option>
+          <option value="custom">Custom URL</option>
+        </select>
+        {#if tlsAcmeEndpoint === "custom"}
+          <input type="text" bind:value={tlsAcmeEndpoint} placeholder="https://acme.example.com/directory" style="width: 100%; box-sizing: border-box; margin-top: 0.3rem;" />
+        {/if}
+      </div>
+      <div style="margin-bottom: 0.75rem;">
+        <span style="font-size: 0.8rem; opacity: 0.7; display: block; margin-bottom: 0.3rem;">ACME-DNS server</span>
+        <input type="text" bind:value={tlsAcmeDnsServer} placeholder="https://auth.acme-dns.io" style="width: 100%; box-sizing: border-box;" disabled={tlsAcmeStep !== "configure"} />
+        <p class="hint" style="margin-top: 0.25rem;">The default is a free public instance. You can host your own <a href="https://github.com/joohoi/acme-dns" target="_blank" rel="noopener">acme-dns</a> server.</p>
+      </div>
+      {#if tlsAcmeStep === "configure"}
+        <div class="setting-row">
+          <button on:click={tlsAcmeConfigure} disabled={tlsAcmeConfiguring || !tlsAcmeDomain.trim()}>
+            {tlsAcmeConfiguring ? "Saving..." : "Save & Continue"}
+          </button>
+        </div>
+      {/if}
+
+      {#if tlsAcmeStep === "register" || tlsAcmeStep === "cname" || tlsAcmeStep === "provision"}
+        <h4 style="margin-top: 1.25rem; margin-bottom: 0.5rem;">Step 2: Register with ACME-DNS</h4>
+        {#if !tlsAcmeRegistered}
+          <p class="hint">Register with the ACME-DNS server to get a subdomain for DNS validation.</p>
+          <div class="setting-row">
+            <button on:click={tlsAcmeRegister} disabled={tlsAcmeRegistering}>
+              {tlsAcmeRegistering ? "Registering..." : "Register"}
+            </button>
+          </div>
+        {:else}
+          <p class="hint" style="color: var(--success-color, #27ae60);">Registered. ACME-DNS fulldomain: <code style="font-size: 0.75rem;">{tlsAcmeFulldomain}</code></p>
+        {/if}
+      {/if}
+
+      {#if (tlsAcmeStep === "cname" || tlsAcmeStep === "provision") && tlsAcmeRegistered}
+        <h4 style="margin-top: 1.25rem; margin-bottom: 0.5rem;">Step 3: Create DNS CNAME Record</h4>
+        <p class="hint">Add this CNAME record to your DNS provider:</p>
+        <div style="background: var(--input-bg, #1a1b20); padding: 0.75rem; border-radius: 4px; margin: 0.5rem 0; font-family: monospace; font-size: 0.8rem; word-break: break-all;">
+          <div><strong>{tlsAcmeCnameRecord}</strong></div>
+          <div style="opacity: 0.6;">CNAME →</div>
+          <div><strong>{tlsAcmeCnameTarget}</strong></div>
+        </div>
+        <div class="setting-row" style="gap: 0.5rem; display: flex; align-items: center;">
+          <button on:click={tlsAcmeVerifyCname} disabled={tlsAcmeVerifying}>
+            {tlsAcmeVerifying ? "Checking..." : "Verify DNS"}
+          </button>
+          {#if tlsAcmeCnameStatus}
+            {#if tlsAcmeCnameStatus.status === "ok"}
+              <span style="color: var(--success-color, #27ae60); font-size: 0.85rem;">CNAME verified</span>
+            {:else if tlsAcmeCnameStatus.status === "resolved"}
+              <span style="color: var(--warning-color, #e6a700); font-size: 0.85rem;">DNS resolved (CNAME not directly confirmed)</span>
+            {:else}
+              <span style="color: var(--error-color, #e74c3c); font-size: 0.85rem;">CNAME not found</span>
+            {/if}
+          {/if}
+        </div>
+
+        <h4 style="margin-top: 1.25rem; margin-bottom: 0.5rem;">Step 4: Request Certificate</h4>
+        <p class="hint">Once the CNAME is in place, request a certificate from Let's Encrypt.</p>
+        {#if tlsAcmeProvisioning}
+          <div style="margin: 0.5rem 0; font-size: 0.85rem; opacity: 0.8;">
+            {tlsAcmeProgress}
+          </div>
+        {/if}
+        <div class="setting-row">
+          <button on:click={tlsAcmeProvision} disabled={tlsAcmeProvisioning}>
+            {tlsAcmeProvisioning ? "Provisioning..." : "Request Certificate"}
+          </button>
+        </div>
+      {/if}
+
+      {#if tlsAcmeStep === "configure" && (tlsAcmeConfigured || tlsAcmeRegistered)}
+        <div class="setting-row" style="margin-top: 1rem;">
+          <button on:click={() => { if (tlsAcmeRegistered) tlsAcmeStep = "cname"; else if (tlsAcmeConfigured) tlsAcmeStep = "register"; }}>Resume Setup</button>
+        </div>
+      {/if}
+    {/if}
+
+    {#if tlsAcmeError}
+      <p class="danger-error" style="margin-top: 0.5rem;">{tlsAcmeError}</p>
+    {/if}
+  </section>
+  {/if}
+
   </div></div>
   {/if}
 

--- a/src/guidebook/acme.py
+++ b/src/guidebook/acme.py
@@ -1,0 +1,547 @@
+"""ACME protocol client for Let's Encrypt DNS-01 challenges via acme-dns.
+
+Implements RFC 8555 (ACME) with DNS-01 validation using acme-dns as the
+DNS provider.  No external ACME libraries required — uses ``cryptography``
+for JWS/CSR and ``httpx`` for HTTP.
+"""
+
+import base64
+import datetime
+import hashlib
+import json
+import logging
+
+import httpx
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.x509.oid import NameOID
+
+logger = logging.getLogger("guidebook")
+
+# Well-known ACME directory URLs
+LE_PRODUCTION = "https://acme-v02.api.letsencrypt.org/directory"
+LE_STAGING = "https://acme-staging-v02.api.letsencrypt.org/directory"
+
+DEFAULT_ACME_DNS_SERVER = "https://auth.acme-dns.io"
+
+# Timeout for HTTP requests (seconds)
+_HTTP_TIMEOUT = 30
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _b64url(data: bytes) -> str:
+    """Base64url-encode without padding."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _jwk_thumbprint(pub: rsa.RSAPublicKey) -> str:
+    """Compute JWK thumbprint (RFC 7638) of an RSA public key."""
+    nums = pub.public_numbers()
+    jwk_obj = {
+        "e": _b64url(nums.e.to_bytes((nums.e.bit_length() + 7) // 8, "big")),
+        "kty": "RSA",
+        "n": _b64url(nums.n.to_bytes((nums.n.bit_length() + 7) // 8, "big")),
+    }
+    # Keys MUST be sorted for canonical JSON
+    canonical = json.dumps(jwk_obj, sort_keys=True, separators=(",", ":"))
+    return _b64url(hashlib.sha256(canonical.encode()).digest())
+
+
+def _jwk_public(pub: rsa.RSAPublicKey) -> dict:
+    """Return the JWK dict for an RSA public key."""
+    nums = pub.public_numbers()
+    return {
+        "e": _b64url(nums.e.to_bytes((nums.e.bit_length() + 7) // 8, "big")),
+        "kty": "RSA",
+        "n": _b64url(nums.n.to_bytes((nums.n.bit_length() + 7) // 8, "big")),
+    }
+
+
+def _load_account_key(pem: str) -> rsa.RSAPrivateKey:
+    return serialization.load_pem_private_key(pem.encode(), password=None)
+
+
+def generate_account_key() -> str:
+    """Generate a new RSA-2048 account key, returned as PEM string."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    ).decode()
+
+
+# ---------------------------------------------------------------------------
+# JWS signing (RFC 7515 — flattened JSON serialization for ACME)
+# ---------------------------------------------------------------------------
+
+
+def _sign_jws(
+    url: str,
+    payload: dict | str | None,
+    account_key: rsa.RSAPrivateKey,
+    nonce: str,
+    *,
+    kid: str | None = None,
+) -> dict:
+    """Build a JWS body for an ACME request.
+
+    If *kid* is provided the protected header uses ``kid``; otherwise it
+    embeds the full JWK (used only for newAccount).
+
+    *payload* may be a dict (JSON-serialised), the empty string ``""`` for
+    POST-as-GET, or ``None`` which is treated the same as ``""``.
+    """
+    protected: dict = {"alg": "RS256", "nonce": nonce, "url": url}
+    if kid:
+        protected["kid"] = kid
+    else:
+        protected["jwk"] = _jwk_public(account_key.public_key())
+
+    protected_b64 = _b64url(json.dumps(protected).encode())
+
+    if payload is None or payload == "":
+        payload_b64 = ""
+    else:
+        payload_b64 = _b64url(json.dumps(payload).encode())
+
+    sig_input = f"{protected_b64}.{payload_b64}".encode()
+    signature = account_key.sign(sig_input, padding.PKCS1v15(), hashes.SHA256())
+
+    return {
+        "protected": protected_b64,
+        "payload": payload_b64,
+        "signature": _b64url(signature),
+    }
+
+
+# ---------------------------------------------------------------------------
+# ACME directory & nonce management
+# ---------------------------------------------------------------------------
+
+_directory_cache: dict | None = None
+_nonce: str | None = None
+
+
+async def acme_directory(endpoint: str) -> dict:
+    """Fetch (and cache) the ACME directory."""
+    global _directory_cache
+    if _directory_cache and _directory_cache.get("_endpoint") == endpoint:
+        return _directory_cache
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as c:
+        r = await c.get(endpoint)
+        r.raise_for_status()
+        d = r.json()
+        d["_endpoint"] = endpoint
+        _directory_cache = d
+        return d
+
+
+async def _get_nonce(directory: dict) -> str:
+    """Get a fresh anti-replay nonce."""
+    global _nonce
+    if _nonce:
+        n = _nonce
+        _nonce = None
+        return n
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as c:
+        r = await c.head(directory["newNonce"])
+        return r.headers["Replay-Nonce"]
+
+
+def _save_nonce(response: httpx.Response) -> None:
+    """Stash the Replay-Nonce from a response for the next request."""
+    global _nonce
+    n = response.headers.get("Replay-Nonce")
+    if n:
+        _nonce = n
+
+
+# ---------------------------------------------------------------------------
+# Signed ACME requests
+# ---------------------------------------------------------------------------
+
+
+async def _acme_post(
+    url: str,
+    payload: dict | str | None,
+    account_key: rsa.RSAPrivateKey,
+    directory: dict,
+    *,
+    kid: str | None = None,
+) -> httpx.Response:
+    """Send a signed POST to an ACME endpoint and return the response."""
+    nonce = await _get_nonce(directory)
+    body = _sign_jws(url, payload, account_key, nonce, kid=kid)
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as c:
+        r = await c.post(
+            url,
+            json=body,
+            headers={"Content-Type": "application/jose+json"},
+        )
+    _save_nonce(r)
+    return r
+
+
+# ---------------------------------------------------------------------------
+# Account management
+# ---------------------------------------------------------------------------
+
+
+async def acme_register_account(endpoint: str, account_key_pem: str) -> tuple[str, str]:
+    """Register (or find existing) ACME account.
+
+    Returns ``(account_url, account_key_pem)``.  The key PEM is returned
+    unchanged so callers can store both together.
+    """
+    directory = await acme_directory(endpoint)
+    key = _load_account_key(account_key_pem)
+    payload = {"termsOfServiceAgreed": True}
+    r = await _acme_post(directory["newAccount"], payload, key, directory)
+    if r.status_code not in (200, 201):
+        raise RuntimeError(f"ACME newAccount failed ({r.status_code}): {r.text}")
+    account_url = r.headers["Location"]
+    logger.info("ACME account registered: %s", account_url)
+    return account_url, account_key_pem
+
+
+# ---------------------------------------------------------------------------
+# Order + DNS-01 challenge
+# ---------------------------------------------------------------------------
+
+
+async def acme_new_order(
+    endpoint: str,
+    account_key_pem: str,
+    account_url: str,
+    domain: str,
+) -> dict:
+    """Create a new ACME order for *domain*.
+
+    Returns the order dict including ``authorizations``, ``finalize``, and
+    the order URL (injected as ``_url``).
+    """
+    directory = await acme_directory(endpoint)
+    key = _load_account_key(account_key_pem)
+    payload = {"identifiers": [{"type": "dns", "value": domain}]}
+    r = await _acme_post(
+        directory["newOrder"], payload, key, directory, kid=account_url
+    )
+    if r.status_code not in (200, 201):
+        raise RuntimeError(f"ACME newOrder failed ({r.status_code}): {r.text}")
+    order = r.json()
+    order["_url"] = r.headers.get("Location", "")
+    return order
+
+
+async def acme_get_dns01_challenge(
+    endpoint: str,
+    account_key_pem: str,
+    account_url: str,
+    auth_url: str,
+) -> tuple[str, str, str]:
+    """Fetch the DNS-01 challenge for an authorization.
+
+    Returns ``(challenge_url, token, key_authorization_hash)`` where
+    *key_authorization_hash* is the value to place in the TXT record.
+    """
+    directory = await acme_directory(endpoint)
+    key = _load_account_key(account_key_pem)
+
+    # POST-as-GET to fetch the authorization
+    r = await _acme_post(auth_url, "", key, directory, kid=account_url)
+    r.raise_for_status()
+    auth = r.json()
+
+    dns01 = None
+    for ch in auth.get("challenges", []):
+        if ch["type"] == "dns-01":
+            dns01 = ch
+            break
+    if dns01 is None:
+        raise RuntimeError("No dns-01 challenge found in authorization")
+
+    token = dns01["token"]
+    thumbprint = _jwk_thumbprint(key.public_key())
+    key_auth = f"{token}.{thumbprint}"
+    txt_value = _b64url(hashlib.sha256(key_auth.encode()).digest())
+
+    return dns01["url"], token, txt_value
+
+
+async def acme_respond_challenge(
+    endpoint: str,
+    account_key_pem: str,
+    account_url: str,
+    challenge_url: str,
+) -> None:
+    """Tell the ACME server to verify the DNS-01 challenge."""
+    directory = await acme_directory(endpoint)
+    key = _load_account_key(account_key_pem)
+    r = await _acme_post(challenge_url, {}, key, directory, kid=account_url)
+    if r.status_code not in (200, 202):
+        raise RuntimeError(
+            f"ACME challenge response failed ({r.status_code}): {r.text}"
+        )
+
+
+async def acme_poll_order(
+    endpoint: str,
+    account_key_pem: str,
+    account_url: str,
+    order_url: str,
+    *,
+    max_attempts: int = 30,
+    interval: float = 5,
+) -> dict:
+    """Poll an order until it becomes ``ready`` or ``valid``, or fails."""
+    import asyncio
+
+    directory = await acme_directory(endpoint)
+    key = _load_account_key(account_key_pem)
+    for attempt in range(max_attempts):
+        r = await _acme_post(order_url, "", key, directory, kid=account_url)
+        r.raise_for_status()
+        order = r.json()
+        status = order.get("status")
+        if status in ("ready", "valid"):
+            order["_url"] = order_url
+            return order
+        if status == "invalid":
+            raise RuntimeError(f"ACME order became invalid: {json.dumps(order)}")
+        await asyncio.sleep(interval)
+    raise RuntimeError("Timed out waiting for ACME order to become ready")
+
+
+# ---------------------------------------------------------------------------
+# CSR generation & finalization
+# ---------------------------------------------------------------------------
+
+
+def generate_csr(domain: str) -> tuple[str, str]:
+    """Generate an RSA-2048 key and CSR for *domain*.
+
+    Returns ``(csr_der_b64url, key_pem)``.
+    """
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    csr = (
+        x509.CertificateSigningRequestBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, domain)]))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(domain)]),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    csr_der = csr.public_bytes(serialization.Encoding.DER)
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    ).decode()
+    return _b64url(csr_der), key_pem
+
+
+async def acme_finalize_order(
+    endpoint: str,
+    account_key_pem: str,
+    account_url: str,
+    finalize_url: str,
+    csr_b64url: str,
+) -> str:
+    """Finalize an ACME order by submitting the CSR.
+
+    Returns the certificate URL.
+    """
+    directory = await acme_directory(endpoint)
+    key = _load_account_key(account_key_pem)
+    payload = {"csr": csr_b64url}
+    r = await _acme_post(finalize_url, payload, key, directory, kid=account_url)
+    if r.status_code not in (200, 201):
+        raise RuntimeError(f"ACME finalize failed ({r.status_code}): {r.text}")
+    order = r.json()
+    cert_url = order.get("certificate")
+    if not cert_url:
+        raise RuntimeError("No certificate URL in finalized order")
+    return cert_url
+
+
+async def acme_download_cert(
+    endpoint: str,
+    account_key_pem: str,
+    account_url: str,
+    cert_url: str,
+) -> str:
+    """Download the issued certificate chain as PEM."""
+    directory = await acme_directory(endpoint)
+    key = _load_account_key(account_key_pem)
+    r = await _acme_post(cert_url, "", key, directory, kid=account_url)
+    r.raise_for_status()
+    return r.text
+
+
+# ---------------------------------------------------------------------------
+# acme-dns helpers
+# ---------------------------------------------------------------------------
+
+
+async def acmedns_register(server_url: str) -> dict:
+    """Register a new acme-dns account.
+
+    Returns the registration dict with keys: ``username``, ``password``,
+    ``fulldomain``, ``subdomain``, ``allowfrom``.
+    """
+    url = server_url.rstrip("/") + "/register"
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as c:
+        r = await c.post(url, json={})
+        r.raise_for_status()
+        return r.json()
+
+
+async def acmedns_update_txt(
+    server_url: str,
+    subdomain: str,
+    username: str,
+    password: str,
+    txt: str,
+) -> None:
+    """Update the TXT record on acme-dns."""
+    url = server_url.rstrip("/") + "/update"
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as c:
+        r = await c.post(
+            url,
+            json={"subdomain": subdomain, "txt": txt},
+            headers={
+                "X-Api-User": username,
+                "X-Api-Key": password,
+            },
+        )
+        if r.status_code not in (200, 201):
+            raise RuntimeError(f"acme-dns update failed ({r.status_code}): {r.text}")
+
+
+# ---------------------------------------------------------------------------
+# Full provisioning orchestration
+# ---------------------------------------------------------------------------
+
+
+async def acme_provision_cert(
+    domain: str,
+    endpoint: str,
+    account_key_pem: str,
+    account_url: str,
+    acmedns_server: str,
+    acmedns_subdomain: str,
+    acmedns_username: str,
+    acmedns_password: str,
+    *,
+    progress_callback=None,
+) -> tuple[str, str]:
+    """Run the complete ACME DNS-01 flow and return ``(cert_chain_pem, key_pem)``.
+
+    *progress_callback*, if provided, is called with ``(stage: str, detail: str)``
+    at each major step.  Stages: ``ordering``, ``challenge``, ``updating-dns``,
+    ``validating``, ``finalizing``, ``downloading``, ``complete``.
+    """
+    import asyncio
+
+    def _progress(stage: str, detail: str = "") -> None:
+        if progress_callback:
+            progress_callback(stage, detail)
+
+    _progress("ordering", f"Creating order for {domain}")
+    order = await acme_new_order(endpoint, account_key_pem, account_url, domain)
+
+    auth_url = order["authorizations"][0]
+    _progress("challenge", "Fetching DNS-01 challenge")
+    challenge_url, _token, txt_value = await acme_get_dns01_challenge(
+        endpoint, account_key_pem, account_url, auth_url
+    )
+
+    _progress("updating-dns", "Setting TXT record via acme-dns")
+    await acmedns_update_txt(
+        acmedns_server, acmedns_subdomain, acmedns_username, acmedns_password, txt_value
+    )
+
+    # Brief pause for DNS propagation
+    await asyncio.sleep(3)
+
+    _progress("validating", "Responding to challenge and waiting for validation")
+    await acme_respond_challenge(endpoint, account_key_pem, account_url, challenge_url)
+
+    order_url = order.get("_url") or order["authorizations"][0].rsplit("/", 2)[0]
+    order = await acme_poll_order(endpoint, account_key_pem, account_url, order_url)
+
+    _progress("finalizing", "Submitting CSR")
+    csr_b64, key_pem = generate_csr(domain)
+    cert_url = await acme_finalize_order(
+        endpoint, account_key_pem, account_url, order["finalize"], csr_b64
+    )
+
+    # Poll again until status is "valid" and certificate is available
+    if order.get("status") != "valid":
+        order = await acme_poll_order(
+            endpoint, account_key_pem, account_url, order["_url"]
+        )
+        cert_url = order.get("certificate", cert_url)
+
+    _progress("downloading", "Downloading certificate")
+    cert_pem = await acme_download_cert(
+        endpoint, account_key_pem, account_url, cert_url
+    )
+
+    _progress("complete", "Certificate provisioned successfully")
+    return cert_pem, key_pem
+
+
+# ---------------------------------------------------------------------------
+# Certificate inspection helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_cert_info(cert_pem: str) -> dict:
+    """Extract useful fields from a PEM certificate.
+
+    Returns dict with: ``issuer``, ``subject``, ``not_before``, ``not_after``,
+    ``fingerprint_sha256``, ``serial``, ``san``.
+    """
+    cert = x509.load_pem_x509_certificate(cert_pem.encode())
+    try:
+        san_ext = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+        san = san_ext.value.get_values_for_type(x509.DNSName)
+    except x509.ExtensionNotFound:
+        san = []
+
+    return {
+        "issuer": cert.issuer.rfc4514_string(),
+        "subject": cert.subject.rfc4514_string(),
+        "not_before": cert.not_valid_before_utc.isoformat(),
+        "not_after": cert.not_valid_after_utc.isoformat(),
+        "fingerprint_sha256": cert.fingerprint(hashes.SHA256()).hex(),
+        "serial": format(cert.serial_number, "x"),
+        "san": san,
+    }
+
+
+def check_needs_renewal(cert_pem: str) -> bool:
+    """Return True if ≥ 2/3 of the certificate's validity period has elapsed."""
+    cert = x509.load_pem_x509_certificate(cert_pem.encode())
+    now = datetime.datetime.now(datetime.timezone.utc)
+    total = (cert.not_valid_after_utc - cert.not_valid_before_utc).total_seconds()
+    elapsed = (now - cert.not_valid_before_utc).total_seconds()
+    if total <= 0:
+        return True
+    return elapsed >= (total * 2 / 3)
+
+
+def next_renewal_time(cert_pem: str) -> str | None:
+    """Return ISO timestamp when renewal should happen (2/3 of validity)."""
+    cert = x509.load_pem_x509_certificate(cert_pem.encode())
+    total = cert.not_valid_after_utc - cert.not_valid_before_utc
+    renewal_at = cert.not_valid_before_utc + (total * 2 / 3)
+    return renewal_at.isoformat()

--- a/src/guidebook/acme.py
+++ b/src/guidebook/acme.py
@@ -352,11 +352,14 @@ async def acme_finalize_order(
     account_key_pem: str,
     account_url: str,
     finalize_url: str,
+    order_url: str,
     csr_b64url: str,
 ) -> str:
     """Finalize an ACME order by submitting the CSR.
 
-    Returns the certificate URL.
+    After submitting the CSR the order typically enters ``processing`` state.
+    This function polls the order until it becomes ``valid`` and a certificate
+    URL is available, then returns that URL.
     """
     directory = await acme_directory(endpoint)
     key = _load_account_key(account_key_pem)
@@ -365,6 +368,12 @@ async def acme_finalize_order(
     if r.status_code not in (200, 201):
         raise RuntimeError(f"ACME finalize failed ({r.status_code}): {r.text}")
     order = r.json()
+    cert_url = order.get("certificate")
+    if cert_url:
+        return cert_url
+
+    # Order is still processing — poll until valid
+    order = await acme_poll_order(endpoint, account_key_pem, account_url, order_url)
     cert_url = order.get("certificate")
     if not cert_url:
         raise RuntimeError("No certificate URL in finalized order")
@@ -477,18 +486,16 @@ async def acme_provision_cert(
     order_url = order.get("_url") or order["authorizations"][0].rsplit("/", 2)[0]
     order = await acme_poll_order(endpoint, account_key_pem, account_url, order_url)
 
-    _progress("finalizing", "Submitting CSR")
+    _progress("finalizing", "Submitting CSR and waiting for certificate")
     csr_b64, key_pem = generate_csr(domain)
     cert_url = await acme_finalize_order(
-        endpoint, account_key_pem, account_url, order["finalize"], csr_b64
+        endpoint,
+        account_key_pem,
+        account_url,
+        order["finalize"],
+        order_url,
+        csr_b64,
     )
-
-    # Poll again until status is "valid" and certificate is available
-    if order.get("status") != "valid":
-        order = await acme_poll_order(
-            endpoint, account_key_pem, account_url, order["_url"]
-        )
-        cert_url = order.get("certificate", cert_url)
 
     _progress("downloading", "Downloading certificate")
     cert_pem = await acme_download_cert(

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -49,6 +49,11 @@ from guidebook.routes.update import router as update_router
 from guidebook.routes.scratchpad import router as scratchpad_router
 from guidebook.routes.media import router as media_router
 from guidebook.routes.mtls import router as mtls_router
+from guidebook.routes.tls import (
+    router as tls_router,
+    start_acme_renewal,
+    stop_acme_renewal,
+)
 from guidebook._build_info import BUILD_GITHUB_ACTIONS, BUILD_ORIGIN_REPO, GIT_SHA
 
 logger = logging.getLogger("guidebook")
@@ -117,7 +122,9 @@ async def lifespan(app: FastAPI):
         await gdb.commit()
     if db_manager.is_open:
         await start_auto_backup()
+    await start_acme_renewal()
     yield
+    await stop_acme_renewal()
     await stop_sse_auto_shutdown()
     await stop_auto_backup()
     await db_manager.close()
@@ -338,7 +345,10 @@ async def http_middleware(request: Request, call_next):
     response: Response = await call_next(request)
 
     # Record auth failures for rate limiting (only login attempts, not general 401s)
-    if path in ("/api/auth/login", "/api/auth/check-token") and response.status_code == 401:
+    if (
+        path in ("/api/auth/login", "/api/auth/check-token")
+        and response.status_code == 401
+    ):
         auth_limiter.record(client_ip)
 
     if path.startswith("/api/"):
@@ -580,6 +590,7 @@ app.include_router(update_router)
 app.include_router(scratchpad_router)
 app.include_router(media_router)
 app.include_router(mtls_router)
+app.include_router(tls_router)
 app.include_router(sse_router)
 
 static_dir = _resource_path("static")
@@ -946,7 +957,12 @@ environment variables (overridden by command line options):
             "created_at REAL NOT NULL, last_seen_at REAL, expires_at REAL, last_ip TEXT, "
             "is_transfer INTEGER NOT NULL DEFAULT 0)"
         )
-        for col in ("expires_at REAL", "last_ip TEXT", "jwt_nonce TEXT", "user_agent TEXT"):
+        for col in (
+            "expires_at REAL",
+            "last_ip TEXT",
+            "jwt_nonce TEXT",
+            "user_agent TEXT",
+        ):
             try:
                 conn.execute(f"ALTER TABLE auth_tokens ADD COLUMN {col}")
             except sqlite3.OperationalError:
@@ -958,13 +974,19 @@ environment variables (overridden by command line options):
 
         if args.reset_auth:
             # Count what will be destroyed
-            session_count = conn.execute("SELECT COUNT(*) FROM auth_tokens").fetchone()[0]
+            session_count = conn.execute("SELECT COUNT(*) FROM auth_tokens").fetchone()[
+                0
+            ]
             try:
-                cert_count = conn.execute("SELECT COUNT(*) FROM client_certs").fetchone()[0]
+                cert_count = conn.execute(
+                    "SELECT COUNT(*) FROM client_certs"
+                ).fetchone()[0]
             except sqlite3.OperationalError:
                 cert_count = 0
             ca_exists = bool(
-                conn.execute("SELECT 1 FROM settings WHERE key = 'ca_cert_pem'").fetchone()
+                conn.execute(
+                    "SELECT 1 FROM settings WHERE key = 'ca_cert_pem'"
+                ).fetchone()
             )
 
             print("--reset-auth will perform the following actions:")
@@ -1003,7 +1025,13 @@ environment variables (overridden by command line options):
                 conn.execute("DELETE FROM client_certs")
             except sqlite3.OperationalError:
                 pass  # table may not exist yet
-            for k in ("mtls_mode", "ca_cert_pem", "ca_key_pem", "tls_cert_pem", "tls_key_pem"):
+            for k in (
+                "mtls_mode",
+                "ca_cert_pem",
+                "ca_key_pem",
+                "tls_cert_pem",
+                "tls_key_pem",
+            ):
                 conn.execute("DELETE FROM settings WHERE key = ?", (k,))
             conn.commit()
             os.environ["_GUIDEBOOK_RESET_AUTH_TOKEN"] = token_str

--- a/src/guidebook/routes/tls.py
+++ b/src/guidebook/routes/tls.py
@@ -1,0 +1,551 @@
+"""TLS certificate management endpoints and ACME auto-renewal."""
+
+import asyncio
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Response
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from guidebook.db import GlobalSetting, get_global_session
+
+logger = logging.getLogger("guidebook")
+
+router = APIRouter(prefix="/api/tls", tags=["tls"])
+
+
+# ---------------------------------------------------------------------------
+# DB helpers (same pattern as mtls.py)
+# ---------------------------------------------------------------------------
+
+
+async def _get_setting(gdb: AsyncSession, key: str) -> str | None:
+    row = (
+        await gdb.execute(select(GlobalSetting).where(GlobalSetting.key == key))
+    ).scalar_one_or_none()
+    return row.value if row else None
+
+
+async def _set_setting(gdb: AsyncSession, key: str, value: str) -> None:
+    from sqlalchemy.dialects.sqlite import insert
+
+    stmt = insert(GlobalSetting).values(key=key, value=value)
+    stmt = stmt.on_conflict_do_update(index_elements=["key"], set_={"value": value})
+    await gdb.execute(stmt)
+
+
+async def _delete_setting(gdb: AsyncSession, key: str) -> None:
+    row = (
+        await gdb.execute(select(GlobalSetting).where(GlobalSetting.key == key))
+    ).scalar_one_or_none()
+    if row:
+        await gdb.delete(row)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/tls/status
+# ---------------------------------------------------------------------------
+
+
+class TlsStatusResponse(BaseModel):
+    tls_enabled: bool
+    tls_mode: str  # "self-signed" or "acme"
+    # Self-signed info
+    ca_fingerprint: str | None = None
+    server_cert_fingerprint: str | None = None
+    # Common cert info
+    cert_issuer: str | None = None
+    cert_subject: str | None = None
+    cert_not_before: str | None = None
+    cert_not_after: str | None = None
+    cert_san: list[str] | None = None
+    next_renewal: str | None = None
+    # ACME-DNS state
+    acme_domain: str | None = None
+    acme_endpoint: str | None = None
+    acme_dns_server: str | None = None
+    acme_dns_fulldomain: str | None = None
+    acme_registered: bool = False
+    acme_configured: bool = False
+
+
+@router.get("/status")
+async def tls_status(
+    gdb: AsyncSession = Depends(get_global_session),
+) -> TlsStatusResponse:
+    from guidebook.routes.auth import TLS_ENABLED
+
+    tls_mode = await _get_setting(gdb, "tls_mode") or "self-signed"
+    resp = TlsStatusResponse(tls_enabled=TLS_ENABLED, tls_mode=tls_mode)
+
+    if not TLS_ENABLED:
+        return resp
+
+    # Parse current server cert info
+    cert_pem = await _get_setting(gdb, "tls_cert_pem")
+    if cert_pem:
+        from guidebook.acme import parse_cert_info
+
+        info = parse_cert_info(cert_pem)
+        resp.cert_issuer = info["issuer"]
+        resp.cert_subject = info["subject"]
+        resp.cert_not_before = info["not_before"]
+        resp.cert_not_after = info["not_after"]
+        resp.server_cert_fingerprint = info["fingerprint_sha256"]
+        resp.cert_san = info["san"]
+
+    # CA fingerprint (for self-signed mode display)
+    ca_pem = await _get_setting(gdb, "ca_cert_pem")
+    if ca_pem:
+        from guidebook.acme import parse_cert_info
+
+        ca_info = parse_cert_info(ca_pem)
+        resp.ca_fingerprint = ca_info["fingerprint_sha256"]
+
+    # ACME config state
+    acme_domain = await _get_setting(gdb, "acme_domain")
+    acme_endpoint = await _get_setting(gdb, "acme_endpoint")
+    acme_dns_server = await _get_setting(gdb, "acme_dns_server")
+    acme_dns_fulldomain = await _get_setting(gdb, "acme_dns_fulldomain")
+
+    resp.acme_domain = acme_domain
+    resp.acme_endpoint = acme_endpoint
+    resp.acme_dns_server = acme_dns_server
+    resp.acme_dns_fulldomain = acme_dns_fulldomain
+    resp.acme_configured = bool(acme_domain and acme_endpoint and acme_dns_server)
+    resp.acme_registered = bool(acme_dns_fulldomain)
+
+    # Renewal info for ACME certs
+    if tls_mode == "acme" and cert_pem:
+        from guidebook.acme import next_renewal_time
+
+        resp.next_renewal = next_renewal_time(cert_pem)
+
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# GET /api/tls/ca.pem — download CA certificate
+# ---------------------------------------------------------------------------
+
+
+@router.get("/ca.pem")
+async def download_ca_pem(
+    gdb: AsyncSession = Depends(get_global_session),
+):
+    from guidebook.routes.auth import TLS_ENABLED
+
+    if not TLS_ENABLED:
+        raise HTTPException(404, "TLS is disabled")
+    ca_pem = await _get_setting(gdb, "ca_cert_pem")
+    if not ca_pem:
+        raise HTTPException(404, "No CA certificate available")
+    return Response(
+        content=ca_pem,
+        media_type="application/x-pem-file",
+        headers={"Content-Disposition": "attachment; filename=guidebook-ca.pem"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /api/tls/acme/configure
+# ---------------------------------------------------------------------------
+
+
+class AcmeConfigureRequest(BaseModel):
+    domain: str
+    endpoint: str  # "le-production", "le-staging", or custom URL
+    acme_dns_server: str = "https://auth.acme-dns.io"
+
+
+@router.post("/acme/configure")
+async def acme_configure(
+    body: AcmeConfigureRequest,
+    gdb: AsyncSession = Depends(get_global_session),
+):
+    from guidebook.routes.auth import TLS_ENABLED
+
+    if not TLS_ENABLED:
+        raise HTTPException(400, "TLS is disabled")
+
+    from guidebook.acme import LE_PRODUCTION, LE_STAGING
+
+    endpoint_url = body.endpoint
+    if endpoint_url == "le-production":
+        endpoint_url = LE_PRODUCTION
+    elif endpoint_url == "le-staging":
+        endpoint_url = LE_STAGING
+
+    domain = body.domain.strip().lower()
+    if not domain:
+        raise HTTPException(400, "Domain is required")
+
+    await _set_setting(gdb, "acme_domain", domain)
+    await _set_setting(gdb, "acme_endpoint", endpoint_url)
+    await _set_setting(gdb, "acme_dns_server", body.acme_dns_server.rstrip("/"))
+    await gdb.commit()
+
+    logger.info("ACME configured: domain=%s endpoint=%s", domain, endpoint_url)
+    return {"status": "configured", "domain": domain, "endpoint": endpoint_url}
+
+
+# ---------------------------------------------------------------------------
+# POST /api/tls/acme/register — register with acme-dns
+# ---------------------------------------------------------------------------
+
+
+@router.post("/acme/register")
+async def acme_register(
+    gdb: AsyncSession = Depends(get_global_session),
+):
+    from guidebook.routes.auth import TLS_ENABLED
+
+    if not TLS_ENABLED:
+        raise HTTPException(400, "TLS is disabled")
+
+    acme_dns_server = await _get_setting(gdb, "acme_dns_server")
+    if not acme_dns_server:
+        raise HTTPException(
+            400, "ACME not configured. Call /api/tls/acme/configure first."
+        )
+
+    domain = await _get_setting(gdb, "acme_domain")
+    if not domain:
+        raise HTTPException(400, "No domain configured")
+
+    from guidebook.acme import acmedns_register
+
+    reg = await acmedns_register(acme_dns_server)
+
+    await _set_setting(gdb, "acme_dns_subdomain", reg["subdomain"])
+    await _set_setting(gdb, "acme_dns_username", reg["username"])
+    await _set_setting(gdb, "acme_dns_password", reg["password"])
+    await _set_setting(gdb, "acme_dns_fulldomain", reg["fulldomain"])
+    await gdb.commit()
+
+    logger.info("acme-dns registered: fulldomain=%s", reg["fulldomain"])
+    return {
+        "status": "registered",
+        "fulldomain": reg["fulldomain"],
+        "cname_record": f"_acme-challenge.{domain}",
+        "cname_target": f"{reg['fulldomain']}.",
+    }
+
+
+# ---------------------------------------------------------------------------
+# POST /api/tls/acme/verify-cname — check DNS CNAME
+# ---------------------------------------------------------------------------
+
+
+@router.post("/acme/verify-cname")
+async def acme_verify_cname(
+    gdb: AsyncSession = Depends(get_global_session),
+):
+    from guidebook.routes.auth import TLS_ENABLED
+
+    if not TLS_ENABLED:
+        raise HTTPException(400, "TLS is disabled")
+
+    domain = await _get_setting(gdb, "acme_domain")
+    fulldomain = await _get_setting(gdb, "acme_dns_fulldomain")
+    if not domain or not fulldomain:
+        raise HTTPException(400, "ACME not fully configured or registered")
+
+    # Use asyncio subprocess to do a DNS lookup
+    import asyncio
+
+    cname_host = f"_acme-challenge.{domain}"
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "dig",
+            "+short",
+            "CNAME",
+            cname_host,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
+        result = stdout.decode().strip()
+        # dig returns the CNAME target with trailing dot
+        expected = f"{fulldomain}."
+        found = any(
+            line.strip().rstrip(".") == fulldomain
+            for line in result.splitlines()
+            if line.strip()
+        )
+        return {
+            "status": "ok" if found else "not_found",
+            "cname_host": cname_host,
+            "expected": expected,
+            "found": result or None,
+        }
+    except FileNotFoundError:
+        # dig not available, try Python socket
+        import socket
+
+        try:
+            socket.getaddrinfo(
+                f"_acme-challenge.{domain}", None, type=socket.SOCK_STREAM
+            )
+            # Can't reliably check CNAME via getaddrinfo, just report it resolved
+            return {
+                "status": "resolved",
+                "cname_host": cname_host,
+                "expected": f"{fulldomain}.",
+                "found": "DNS resolved (dig unavailable for CNAME check)",
+            }
+        except socket.gaierror:
+            return {
+                "status": "not_found",
+                "cname_host": cname_host,
+                "expected": f"{fulldomain}.",
+                "found": None,
+            }
+    except Exception as e:
+        return {
+            "status": "error",
+            "cname_host": cname_host,
+            "error": str(e),
+        }
+
+
+# ---------------------------------------------------------------------------
+# POST /api/tls/acme/provision — full ACME flow
+# ---------------------------------------------------------------------------
+
+_provision_lock = asyncio.Lock()
+
+
+@router.post("/acme/provision")
+async def acme_provision(
+    gdb: AsyncSession = Depends(get_global_session),
+):
+    from guidebook.routes.auth import TLS_ENABLED
+
+    if not TLS_ENABLED:
+        raise HTTPException(400, "TLS is disabled")
+
+    if _provision_lock.locked():
+        raise HTTPException(409, "Certificate provisioning already in progress")
+
+    domain = await _get_setting(gdb, "acme_domain")
+    endpoint = await _get_setting(gdb, "acme_endpoint")
+    acme_dns_server = await _get_setting(gdb, "acme_dns_server")
+    acme_dns_subdomain = await _get_setting(gdb, "acme_dns_subdomain")
+    acme_dns_username = await _get_setting(gdb, "acme_dns_username")
+    acme_dns_password = await _get_setting(gdb, "acme_dns_password")
+
+    if not all([domain, endpoint, acme_dns_server, acme_dns_subdomain]):
+        raise HTTPException(400, "ACME not fully configured and registered")
+
+    # Ensure ACME account exists
+    account_key_pem = await _get_setting(gdb, "acme_account_key_pem")
+    account_url = await _get_setting(gdb, "acme_account_url")
+    if not account_key_pem:
+        from guidebook.acme import generate_account_key
+
+        account_key_pem = generate_account_key()
+        await _set_setting(gdb, "acme_account_key_pem", account_key_pem)
+        await gdb.commit()
+
+    if not account_url:
+        from guidebook.acme import acme_register_account
+
+        account_url, _ = await acme_register_account(endpoint, account_key_pem)
+        await _set_setting(gdb, "acme_account_url", account_url)
+        await gdb.commit()
+
+    from guidebook.acme import acme_provision_cert
+    from guidebook.sse import broadcast
+
+    async with _provision_lock:
+
+        def on_progress(stage, detail):
+            broadcast("tls-acme-progress", {"stage": stage, "detail": detail})
+
+        try:
+            cert_pem, key_pem = await acme_provision_cert(
+                domain=domain,
+                endpoint=endpoint,
+                account_key_pem=account_key_pem,
+                account_url=account_url,
+                acmedns_server=acme_dns_server,
+                acmedns_subdomain=acme_dns_subdomain,
+                acmedns_username=acme_dns_username,
+                acmedns_password=acme_dns_password,
+                progress_callback=on_progress,
+            )
+        except Exception as e:
+            logger.exception("ACME provisioning failed")
+            broadcast(
+                "tls-acme-progress",
+                {"stage": "error", "detail": str(e)},
+            )
+            raise HTTPException(500, f"ACME provisioning failed: {e}")
+
+    # Store the cert as the active TLS cert
+    await _set_setting(gdb, "tls_cert_pem", cert_pem)
+    await _set_setting(gdb, "tls_key_pem", key_pem)
+    await _set_setting(gdb, "tls_mode", "acme")
+    await gdb.commit()
+
+    broadcast("tls-cert-updated", {"restart_required": True})
+
+    from guidebook.acme import parse_cert_info
+
+    info = parse_cert_info(cert_pem)
+    logger.info(
+        "ACME cert provisioned for %s (issuer: %s, expires: %s)",
+        domain,
+        info["issuer"],
+        info["not_after"],
+    )
+    return {
+        "status": "provisioned",
+        "restart_required": True,
+        "cert": info,
+    }
+
+
+# ---------------------------------------------------------------------------
+# POST /api/tls/acme/revert — switch back to self-signed
+# ---------------------------------------------------------------------------
+
+
+@router.post("/acme/revert")
+async def acme_revert(
+    gdb: AsyncSession = Depends(get_global_session),
+):
+    from guidebook.routes.auth import TLS_ENABLED
+
+    if not TLS_ENABLED:
+        raise HTTPException(400, "TLS is disabled")
+
+    from guidebook.db import META_DB_PATH
+    from guidebook.tls import ensure_tls_cert
+
+    # Delete the ACME cert and regenerate self-signed
+    await _delete_setting(gdb, "tls_cert_pem")
+    await _delete_setting(gdb, "tls_key_pem")
+    await _set_setting(gdb, "tls_mode", "self-signed")
+    await gdb.commit()
+
+    # Regenerate self-signed cert (synchronous, uses sqlite3 directly)
+    cert_pem, _key_pem = ensure_tls_cert(str(META_DB_PATH))
+
+    from guidebook.sse import broadcast
+
+    broadcast("tls-cert-updated", {"restart_required": True})
+
+    logger.info("Reverted to self-signed TLS certificate")
+    return {"status": "reverted", "restart_required": True}
+
+
+# ---------------------------------------------------------------------------
+# Background ACME renewal task
+# ---------------------------------------------------------------------------
+
+_acme_renewal_task: asyncio.Task | None = None
+
+
+async def _acme_renewal_loop(initial_delay: float = 300):
+    """Periodically check if the ACME cert needs renewal.
+
+    Waits *initial_delay* seconds (default 5 minutes) before the first check,
+    then checks every hour.
+    """
+    await asyncio.sleep(initial_delay)
+    while True:
+        try:
+            await _check_and_renew()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("ACME renewal check failed")
+        await asyncio.sleep(3600)
+
+
+async def _check_and_renew():
+    """Check if renewal is needed and run the ACME flow if so."""
+    from guidebook.db import global_async_session
+
+    async with global_async_session() as gdb:
+        tls_mode = await _get_setting(gdb, "tls_mode")
+        if tls_mode != "acme":
+            return
+
+        cert_pem = await _get_setting(gdb, "tls_cert_pem")
+        if not cert_pem:
+            return
+
+        from guidebook.acme import check_needs_renewal
+
+        if not check_needs_renewal(cert_pem):
+            return
+
+        logger.info("ACME certificate needs renewal, starting provisioning")
+
+        domain = await _get_setting(gdb, "acme_domain")
+        endpoint = await _get_setting(gdb, "acme_endpoint")
+        acme_dns_server = await _get_setting(gdb, "acme_dns_server")
+        acme_dns_subdomain = await _get_setting(gdb, "acme_dns_subdomain")
+        acme_dns_username = await _get_setting(gdb, "acme_dns_username")
+        acme_dns_password = await _get_setting(gdb, "acme_dns_password")
+        account_key_pem = await _get_setting(gdb, "acme_account_key_pem")
+        account_url = await _get_setting(gdb, "acme_account_url")
+
+        if not all(
+            [
+                domain,
+                endpoint,
+                acme_dns_server,
+                acme_dns_subdomain,
+                account_key_pem,
+                account_url,
+            ]
+        ):
+            logger.warning("ACME renewal skipped: incomplete configuration")
+            return
+
+        from guidebook.acme import acme_provision_cert
+        from guidebook.sse import broadcast
+
+        async with _provision_lock:
+            cert_pem, key_pem = await acme_provision_cert(
+                domain=domain,
+                endpoint=endpoint,
+                account_key_pem=account_key_pem,
+                account_url=account_url,
+                acmedns_server=acme_dns_server,
+                acmedns_subdomain=acme_dns_subdomain,
+                acmedns_username=acme_dns_username,
+                acmedns_password=acme_dns_password,
+            )
+
+        await _set_setting(gdb, "tls_cert_pem", cert_pem)
+        await _set_setting(gdb, "tls_key_pem", key_pem)
+        await gdb.commit()
+
+        broadcast("tls-cert-updated", {"restart_required": True})
+        logger.info("ACME certificate renewed successfully")
+
+
+async def start_acme_renewal(initial_delay: float = 300):
+    """Start the background ACME renewal task."""
+    global _acme_renewal_task
+    if _acme_renewal_task is not None:
+        return
+    _acme_renewal_task = asyncio.create_task(_acme_renewal_loop(initial_delay))
+
+
+async def stop_acme_renewal():
+    """Cancel the background ACME renewal task."""
+    global _acme_renewal_task
+    if _acme_renewal_task is not None:
+        _acme_renewal_task.cancel()
+        try:
+            await _acme_renewal_task
+        except asyncio.CancelledError:
+            pass
+        _acme_renewal_task = None

--- a/src/guidebook/tls.py
+++ b/src/guidebook/tls.py
@@ -348,8 +348,10 @@ def _is_signed_by_ca(cert_pem: str, ca_cert_pem: str) -> bool:
 def ensure_tls_cert(meta_db_path: str) -> tuple[str, str]:
     """Load or generate TLS cert/key from the global database. Returns (cert_pem, key_pem).
 
-    If a CA exists, the server cert is signed by the CA. If the existing server
-    cert is self-signed but a CA now exists, it is regenerated as CA-signed.
+    If ``tls_mode`` is ``"acme"`` and an ACME cert exists, it is returned as-is.
+    Otherwise, if a CA exists, the server cert is signed by the CA.  If the
+    existing server cert is self-signed but a CA now exists, it is regenerated
+    as CA-signed.
     """
     os.makedirs(os.path.dirname(meta_db_path), exist_ok=True)
     conn = sqlite3.connect(meta_db_path)
@@ -357,6 +359,12 @@ def ensure_tls_cert(meta_db_path: str) -> tuple[str, str]:
         "CREATE TABLE IF NOT EXISTS settings "
         "(id INTEGER NOT NULL PRIMARY KEY, key VARCHAR NOT NULL UNIQUE, value VARCHAR)"
     )
+
+    # If in ACME mode, use the stored cert directly (don't regenerate)
+    tls_mode_row = conn.execute(
+        "SELECT value FROM settings WHERE key = 'tls_mode'"
+    ).fetchone()
+    tls_mode = tls_mode_row[0] if tls_mode_row and tls_mode_row[0] else "self-signed"
 
     ca_cert_pem, ca_key_pem = _load_ca_from_db(conn)
 
@@ -368,6 +376,10 @@ def ensure_tls_cert(meta_db_path: str) -> tuple[str, str]:
     ).fetchone()
 
     if row_cert and row_key and row_cert[0] and row_key[0]:
+        if tls_mode == "acme":
+            conn.close()
+            logger.info("Loaded ACME TLS certificate from database")
+            return row_cert[0], row_key[0]
         # Check if we need to regenerate: CA exists but cert is not CA-signed
         if ca_cert_pem and not _is_signed_by_ca(row_cert[0], ca_cert_pem):
             logger.info("Regenerating server certificate (signing with CA)")
@@ -378,12 +390,14 @@ def ensure_tls_cert(meta_db_path: str) -> tuple[str, str]:
 
     if ca_cert_pem and ca_key_pem:
         logger.info(
-            "Generating CA-signed server certificate (valid %d days)", CERT_VALIDITY_DAYS
+            "Generating CA-signed server certificate (valid %d days)",
+            CERT_VALIDITY_DAYS,
         )
         cert_pem, key_pem = _generate_server_cert(ca_cert_pem, ca_key_pem)
     else:
         logger.info(
-            "Generating self-signed server certificate (valid %d days)", CERT_VALIDITY_DAYS
+            "Generating self-signed server certificate (valid %d days)",
+            CERT_VALIDITY_DAYS,
         )
         cert_pem, key_pem = _generate_server_cert()
 


### PR DESCRIPTION
- Add ACME protocol client (`acme.py`) for Let's Encrypt DNS-01 challenges via acme-dns
- Add TLS settings tab with self-signed CA info and ACME-DNS setup wizard
- Add API endpoints for ACME configure, register, verify CNAME, provision, and revert
- Add background auto-renewal task (checks hourly after 5min startup delay, renews at 2/3 cert lifetime)
- Update `ensure_tls_cert()` to load ACME certs without regenerating
- Fix ACME finalize to poll order until certificate URL is available
- Replace confusing disabled radio buttons with clear status text
- Show available slots on Generate Client Certificate (matching login link style)
- Add Let's Encrypt feature to README

Closes #18