### PR TITLE
Optional NATS pub/sub connection with mTLS support

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -587,6 +587,9 @@
       _themeState[key] = value;
       applyThemeFromState(_themeState);
     });
+    eventSource.addEventListener("nats-status", (e) => {
+      window.dispatchEvent(new CustomEvent("nats-status", { detail: JSON.parse(e.data) }));
+    });
     eventSource.addEventListener("database-changed", () => {
       if (switchingDatabase || !welcomeAcknowledged) return;
       // Navigate home before reloading — the new database may not support the current page

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -2310,6 +2310,125 @@
   </div></div>
   {/if}
 
+  {#if activeTab === "nats"}
+  <div class="tab-scroll"><div class="tab-content" use:masonry>
+    <section class="settings-section">
+      <h3>NATS Connection</h3>
+      <div class="setting-row">
+        <label class="toggle-label">
+          <input type="checkbox" bind:checked={natsEnabled} on:change={toggleNats} />
+          Enable NATS
+        </label>
+      </div>
+      <p class="hint">Connect to a NATS server for real-time pub/sub messaging.</p>
+    </section>
+
+    {#if natsEnabled}
+    <section class="settings-section">
+      <h3>Connection Status</h3>
+      <div class="setting-row">
+        <span class="nats-status-dot"
+          class:connected={natsStatus.state === "connected"}
+          class:connecting={natsStatus.state === "connecting"}
+          class:error={natsStatus.state === "error"}
+          class:disconnected={natsStatus.state === "disconnected" || natsStatus.state === "disabled"}
+        ></span>
+        <span class="nats-status-text">
+          {#if natsStatus.state === "connected"}
+            Connected
+          {:else if natsStatus.state === "connecting"}
+            Connecting...
+          {:else if natsStatus.state === "error"}
+            Error: {natsStatus.detail || "unknown"}
+          {:else if natsStatus.state === "disconnected"}
+            Disconnected
+          {:else}
+            Disabled
+          {/if}
+        </span>
+      </div>
+      {#if natsStatus.cn}
+        <p class="hint">Client CN: {natsStatus.cn}</p>
+      {/if}
+      <div class="setting-row" style="margin-top: 0.5em;">
+        <button class="btn" on:click={async () => { await fetch("/api/nats/restart", { method: "POST" }); }}>Reconnect</button>
+      </div>
+    </section>
+
+    <section class="settings-section">
+      <h3>Server</h3>
+      <div class="setting-row">
+        <label for="nats-endpoint">NATS Endpoint</label>
+        <input id="nats-endpoint" type="text" bind:value={natsEndpoint} placeholder="nats://host:4222" />
+      </div>
+    </section>
+
+    <section class="settings-section">
+      <h3>TLS Certificates</h3>
+
+      <div class="setting-row">
+        <label>Root CA Certificate</label>
+        {#if natsCertInfo.ca_fingerprint && !natsReplacing.ca}
+          <p class="cert-fingerprint">SHA-256: {natsCertInfo.ca_fingerprint}</p>
+          <button class="btn btn-small" on:click={() => { natsReplacing = { ...natsReplacing, ca: true }; }}>Replace</button>
+        {:else}
+          <textarea bind:value={natsCaCert} placeholder="Paste PEM-encoded CA certificate..." rows="4"></textarea>
+          <div class="file-upload-row">
+            <input type="file" accept=".pem,.crt,.cer" on:change={(e) => handleNatsFileUpload("ca", e)} />
+          </div>
+          {#if natsCertInfo.ca_fingerprint}
+            <button class="btn btn-small" on:click={() => { natsReplacing = { ...natsReplacing, ca: false }; natsCaCert = ""; }}>Cancel</button>
+          {/if}
+        {/if}
+      </div>
+
+      <div class="setting-row">
+        <label>Client Certificate</label>
+        {#if natsCertInfo.client_fingerprint && !natsReplacing.cert}
+          <p class="cert-fingerprint">SHA-256: {natsCertInfo.client_fingerprint}</p>
+          {#if natsCertInfo.cn}
+            <p class="hint">CN: {natsCertInfo.cn}</p>
+          {/if}
+          <button class="btn btn-small" on:click={() => { natsReplacing = { ...natsReplacing, cert: true }; }}>Replace</button>
+        {:else}
+          <textarea bind:value={natsClientCert} placeholder="Paste PEM-encoded client certificate..." rows="4"></textarea>
+          <div class="file-upload-row">
+            <input type="file" accept=".pem,.crt,.cer" on:change={(e) => handleNatsFileUpload("cert", e)} />
+          </div>
+          {#if natsCertInfo.client_fingerprint}
+            <button class="btn btn-small" on:click={() => { natsReplacing = { ...natsReplacing, cert: false }; natsClientCert = ""; }}>Cancel</button>
+          {/if}
+        {/if}
+      </div>
+
+      <div class="setting-row">
+        <label>Client Key</label>
+        {#if natsCertInfo.has_key && !natsReplacing.key}
+          <p class="hint">Key saved (hidden)</p>
+          <button class="btn btn-small" on:click={() => { natsReplacing = { ...natsReplacing, key: true }; }}>Replace</button>
+        {:else}
+          <textarea bind:value={natsClientKey} placeholder="Paste PEM-encoded client key..." rows="4"></textarea>
+          <div class="file-upload-row">
+            <input type="file" accept=".pem,.key" on:change={(e) => handleNatsFileUpload("key", e)} />
+          </div>
+          {#if natsCertInfo.has_key}
+            <button class="btn btn-small" on:click={() => { natsReplacing = { ...natsReplacing, key: false }; natsClientKey = ""; }}>Cancel</button>
+          {/if}
+        {/if}
+      </div>
+    </section>
+
+    <section class="settings-section">
+      <div class="setting-row">
+        <button class="btn" on:click={saveNatsSettings} disabled={natsSaving}>
+          {natsSaving ? "Saving..." : "Save & Connect"}
+        </button>
+      </div>
+    </section>
+    {/if}
+  </div></div>
+  {/if}
+
 </div>
 
 {#if mtlsShowCertModal}
@@ -2376,125 +2495,6 @@
     {/if}
   </div>
 </div>
-{/if}
-
-{#if activeTab === "nats"}
-<div class="tab-scroll"><div class="tab-content" use:masonry>
-  <section class="settings-section">
-    <h3>NATS Connection</h3>
-    <div class="setting-row">
-      <label class="toggle-label">
-        <input type="checkbox" bind:checked={natsEnabled} on:change={toggleNats} />
-        Enable NATS
-      </label>
-    </div>
-    <p class="hint">Connect to a NATS server for real-time pub/sub messaging.</p>
-  </section>
-
-  {#if natsEnabled}
-  <section class="settings-section">
-    <h3>Connection Status</h3>
-    <div class="setting-row">
-      <span class="nats-status-dot"
-        class:connected={natsStatus.state === "connected"}
-        class:connecting={natsStatus.state === "connecting"}
-        class:error={natsStatus.state === "error"}
-        class:disconnected={natsStatus.state === "disconnected" || natsStatus.state === "disabled"}
-      ></span>
-      <span class="nats-status-text">
-        {#if natsStatus.state === "connected"}
-          Connected
-        {:else if natsStatus.state === "connecting"}
-          Connecting...
-        {:else if natsStatus.state === "error"}
-          Error: {natsStatus.detail || "unknown"}
-        {:else if natsStatus.state === "disconnected"}
-          Disconnected
-        {:else}
-          Disabled
-        {/if}
-      </span>
-    </div>
-    {#if natsStatus.cn}
-      <p class="hint">Client CN: {natsStatus.cn}</p>
-    {/if}
-    <div class="setting-row" style="margin-top: 0.5em;">
-      <button class="btn" on:click={async () => { await fetch("/api/nats/restart", { method: "POST" }); }}>Reconnect</button>
-    </div>
-  </section>
-
-  <section class="settings-section">
-    <h3>Server</h3>
-    <div class="setting-row">
-      <label for="nats-endpoint">NATS Endpoint</label>
-      <input id="nats-endpoint" type="text" bind:value={natsEndpoint} placeholder="nats://host:4222" />
-    </div>
-  </section>
-
-  <section class="settings-section">
-    <h3>TLS Certificates</h3>
-
-    <div class="setting-row">
-      <label>Root CA Certificate</label>
-      {#if natsCertInfo.ca_fingerprint && !natsReplacing.ca}
-        <p class="cert-fingerprint">SHA-256: {natsCertInfo.ca_fingerprint}</p>
-        <button class="btn btn-small" on:click={() => { natsReplacing = { ...natsReplacing, ca: true }; }}>Replace</button>
-      {:else}
-        <textarea bind:value={natsCaCert} placeholder="Paste PEM-encoded CA certificate..." rows="4"></textarea>
-        <div class="file-upload-row">
-          <input type="file" accept=".pem,.crt,.cer" on:change={(e) => handleNatsFileUpload("ca", e)} />
-        </div>
-        {#if natsCertInfo.ca_fingerprint}
-          <button class="btn btn-small" on:click={() => { natsReplacing = { ...natsReplacing, ca: false }; natsCaCert = ""; }}>Cancel</button>
-        {/if}
-      {/if}
-    </div>
-
-    <div class="setting-row">
-      <label>Client Certificate</label>
-      {#if natsCertInfo.client_fingerprint && !natsReplacing.cert}
-        <p class="cert-fingerprint">SHA-256: {natsCertInfo.client_fingerprint}</p>
-        {#if natsCertInfo.cn}
-          <p class="hint">CN: {natsCertInfo.cn}</p>
-        {/if}
-        <button class="btn btn-small" on:click={() => { natsReplacing = { ...natsReplacing, cert: true }; }}>Replace</button>
-      {:else}
-        <textarea bind:value={natsClientCert} placeholder="Paste PEM-encoded client certificate..." rows="4"></textarea>
-        <div class="file-upload-row">
-          <input type="file" accept=".pem,.crt,.cer" on:change={(e) => handleNatsFileUpload("cert", e)} />
-        </div>
-        {#if natsCertInfo.client_fingerprint}
-          <button class="btn btn-small" on:click={() => { natsReplacing = { ...natsReplacing, cert: false }; natsClientCert = ""; }}>Cancel</button>
-        {/if}
-      {/if}
-    </div>
-
-    <div class="setting-row">
-      <label>Client Key</label>
-      {#if natsCertInfo.has_key && !natsReplacing.key}
-        <p class="hint">Key saved (hidden)</p>
-        <button class="btn btn-small" on:click={() => { natsReplacing = { ...natsReplacing, key: true }; }}>Replace</button>
-      {:else}
-        <textarea bind:value={natsClientKey} placeholder="Paste PEM-encoded client key..." rows="4"></textarea>
-        <div class="file-upload-row">
-          <input type="file" accept=".pem,.key" on:change={(e) => handleNatsFileUpload("key", e)} />
-        </div>
-        {#if natsCertInfo.has_key}
-          <button class="btn btn-small" on:click={() => { natsReplacing = { ...natsReplacing, key: false }; natsClientKey = ""; }}>Cancel</button>
-        {/if}
-      {/if}
-    </div>
-  </section>
-
-  <section class="settings-section">
-    <div class="setting-row">
-      <button class="btn" on:click={saveNatsSettings} disabled={natsSaving}>
-        {natsSaving ? "Saving..." : "Save & Connect"}
-      </button>
-    </div>
-  </section>
-  {/if}
-</div></div>
 {/if}
 
 <style>

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -56,7 +56,7 @@
   // Store global default values for use as placeholders
   let globalPlaceholders = {};
 
-  const validTabs = ["features", "appearance", "updates", "data", "auth", "tls", "global"];
+  const validTabs = ["features", "appearance", "updates", "data", "auth", "tls", "nats", "global"];
   let activeTab = (initialTab && validTabs.includes(initialTab)) ? initialTab : "features";
   let settingsLoaded = false;
 
@@ -426,6 +426,75 @@
   let tlsAcmeRegistering = false;
   let tlsAcmeReverting = false;
   let tlsRestartRequired = false;
+
+  // NATS settings
+  let natsEnabled = false;
+  let natsEndpoint = "";
+  let natsCaCert = "";
+  let natsClientCert = "";
+  let natsClientKey = "";
+  let natsStatus = { state: "disabled", detail: null, cn: null };
+  let natsCertInfo = { ca_fingerprint: null, client_fingerprint: null, cn: null, has_key: false };
+  let natsSaving = false;
+  let natsReplacing = { ca: false, cert: false, key: false };
+
+  async function loadNatsStatus() {
+    try {
+      const res = await fetch("/api/nats/status");
+      if (res.ok) natsStatus = await res.json();
+    } catch {}
+  }
+
+  async function loadNatsCerts() {
+    try {
+      const res = await fetch("/api/nats/certs");
+      if (res.ok) natsCertInfo = await res.json();
+    } catch {}
+  }
+
+  async function saveNatsSettings() {
+    natsSaving = true;
+    const settings = {};
+    settings.nats_endpoint = natsEndpoint;
+    if (natsCaCert) settings.nats_ca_cert = natsCaCert;
+    if (natsClientCert) settings.nats_client_cert = natsClientCert;
+    if (natsClientKey) settings.nats_client_key = natsClientKey;
+    for (const [key, value] of Object.entries(settings)) {
+      await fetch(`/api/global-settings/${key}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value }),
+      });
+    }
+    await fetch("/api/nats/restart", { method: "POST" });
+    natsCaCert = "";
+    natsClientCert = "";
+    natsClientKey = "";
+    natsReplacing = { ca: false, cert: false, key: false };
+    await loadNatsCerts();
+    natsSaving = false;
+  }
+
+  async function toggleNats() {
+    await fetch("/api/global-settings/nats_enabled", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ value: natsEnabled ? "true" : "false" }),
+    });
+    await fetch("/api/nats/restart", { method: "POST" });
+  }
+
+  function handleNatsFileUpload(field, event) {
+    const file = event.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      if (field === "ca") natsCaCert = e.target.result;
+      else if (field === "cert") natsClientCert = e.target.result;
+      else if (field === "key") natsClientKey = e.target.result;
+    };
+    reader.readAsText(file);
+  }
 
   async function loadTlsStatus() {
     try {
@@ -1261,6 +1330,8 @@
         const data = await res.json();
         for (const s of data) {
           if (s.key === "update_check_enabled") update_check_enabled = s.value !== "false";
+          if (s.key === "nats_enabled") natsEnabled = s.value === "true";
+          if (s.key === "nats_endpoint") natsEndpoint = s.value || "";
         }
         globalSettingsLoaded = true;
       }
@@ -1408,10 +1479,17 @@
     loadAuthSessions();
     loadMtlsStatus();
     loadTlsStatus();
+    loadNatsStatus();
+    loadNatsCerts();
+    function onNatsStatus(e) { natsStatus = e.detail; }
+    window.addEventListener("nats-status", onNatsStatus);
+    natsCleanup = () => window.removeEventListener("nats-status", onNatsStatus);
   });
 
+  let natsCleanup = null;
   onDestroy(() => {
     flushPending();
+    if (natsCleanup) natsCleanup();
   });
 </script>
 
@@ -1425,6 +1503,7 @@
     <button class="tab" class:active={activeTab === "data"} on:click={() => switchTab("data")}>Data</button>
     <button class="tab" class:active={activeTab === "auth"} on:click={() => switchTab("auth")}>Auth</button>
     <button class="tab" class:active={activeTab === "tls"} on:click={() => switchTab("tls")}>TLS</button>
+    <button class="tab" class:active={activeTab === "nats"} on:click={() => switchTab("nats")}>NATS</button>
   </div>
 
   {#if activeTab === "features"}
@@ -2299,6 +2378,125 @@
 </div>
 {/if}
 
+{#if activeTab === "nats"}
+<div class="tab-scroll"><div class="tab-content" use:masonry>
+  <section class="settings-section">
+    <h3>NATS Connection</h3>
+    <div class="setting-row">
+      <label class="toggle-label">
+        <input type="checkbox" bind:checked={natsEnabled} on:change={toggleNats} />
+        Enable NATS
+      </label>
+    </div>
+    <p class="hint">Connect to a NATS server for real-time pub/sub messaging.</p>
+  </section>
+
+  {#if natsEnabled}
+  <section class="settings-section">
+    <h3>Connection Status</h3>
+    <div class="setting-row">
+      <span class="nats-status-dot"
+        class:connected={natsStatus.state === "connected"}
+        class:connecting={natsStatus.state === "connecting"}
+        class:error={natsStatus.state === "error"}
+        class:disconnected={natsStatus.state === "disconnected" || natsStatus.state === "disabled"}
+      ></span>
+      <span class="nats-status-text">
+        {#if natsStatus.state === "connected"}
+          Connected
+        {:else if natsStatus.state === "connecting"}
+          Connecting...
+        {:else if natsStatus.state === "error"}
+          Error: {natsStatus.detail || "unknown"}
+        {:else if natsStatus.state === "disconnected"}
+          Disconnected
+        {:else}
+          Disabled
+        {/if}
+      </span>
+    </div>
+    {#if natsStatus.cn}
+      <p class="hint">Client CN: {natsStatus.cn}</p>
+    {/if}
+    <div class="setting-row" style="margin-top: 0.5em;">
+      <button class="btn" on:click={async () => { await fetch("/api/nats/restart", { method: "POST" }); }}>Reconnect</button>
+    </div>
+  </section>
+
+  <section class="settings-section">
+    <h3>Server</h3>
+    <div class="setting-row">
+      <label for="nats-endpoint">NATS Endpoint</label>
+      <input id="nats-endpoint" type="text" bind:value={natsEndpoint} placeholder="nats://host:4222" />
+    </div>
+  </section>
+
+  <section class="settings-section">
+    <h3>TLS Certificates</h3>
+
+    <div class="setting-row">
+      <label>Root CA Certificate</label>
+      {#if natsCertInfo.ca_fingerprint && !natsReplacing.ca}
+        <p class="cert-fingerprint">SHA-256: {natsCertInfo.ca_fingerprint}</p>
+        <button class="btn btn-small" on:click={() => { natsReplacing = { ...natsReplacing, ca: true }; }}>Replace</button>
+      {:else}
+        <textarea bind:value={natsCaCert} placeholder="Paste PEM-encoded CA certificate..." rows="4"></textarea>
+        <div class="file-upload-row">
+          <input type="file" accept=".pem,.crt,.cer" on:change={(e) => handleNatsFileUpload("ca", e)} />
+        </div>
+        {#if natsCertInfo.ca_fingerprint}
+          <button class="btn btn-small" on:click={() => { natsReplacing = { ...natsReplacing, ca: false }; natsCaCert = ""; }}>Cancel</button>
+        {/if}
+      {/if}
+    </div>
+
+    <div class="setting-row">
+      <label>Client Certificate</label>
+      {#if natsCertInfo.client_fingerprint && !natsReplacing.cert}
+        <p class="cert-fingerprint">SHA-256: {natsCertInfo.client_fingerprint}</p>
+        {#if natsCertInfo.cn}
+          <p class="hint">CN: {natsCertInfo.cn}</p>
+        {/if}
+        <button class="btn btn-small" on:click={() => { natsReplacing = { ...natsReplacing, cert: true }; }}>Replace</button>
+      {:else}
+        <textarea bind:value={natsClientCert} placeholder="Paste PEM-encoded client certificate..." rows="4"></textarea>
+        <div class="file-upload-row">
+          <input type="file" accept=".pem,.crt,.cer" on:change={(e) => handleNatsFileUpload("cert", e)} />
+        </div>
+        {#if natsCertInfo.client_fingerprint}
+          <button class="btn btn-small" on:click={() => { natsReplacing = { ...natsReplacing, cert: false }; natsClientCert = ""; }}>Cancel</button>
+        {/if}
+      {/if}
+    </div>
+
+    <div class="setting-row">
+      <label>Client Key</label>
+      {#if natsCertInfo.has_key && !natsReplacing.key}
+        <p class="hint">Key saved (hidden)</p>
+        <button class="btn btn-small" on:click={() => { natsReplacing = { ...natsReplacing, key: true }; }}>Replace</button>
+      {:else}
+        <textarea bind:value={natsClientKey} placeholder="Paste PEM-encoded client key..." rows="4"></textarea>
+        <div class="file-upload-row">
+          <input type="file" accept=".pem,.key" on:change={(e) => handleNatsFileUpload("key", e)} />
+        </div>
+        {#if natsCertInfo.has_key}
+          <button class="btn btn-small" on:click={() => { natsReplacing = { ...natsReplacing, key: false }; natsClientKey = ""; }}>Cancel</button>
+        {/if}
+      {/if}
+    </div>
+  </section>
+
+  <section class="settings-section">
+    <div class="setting-row">
+      <button class="btn" on:click={saveNatsSettings} disabled={natsSaving}>
+        {natsSaving ? "Saving..." : "Save & Connect"}
+      </button>
+    </div>
+  </section>
+  {/if}
+</div></div>
+{/if}
+
 <style>
   .settings {
     display: flex;
@@ -3000,5 +3198,48 @@
   }
   .mtls-radio input[type="radio"]:disabled {
     cursor: wait;
+  }
+  .nats-status-dot {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    margin-right: 0.5em;
+    background: var(--muted, #666);
+  }
+  .nats-status-dot.connected {
+    background: #22c55e;
+  }
+  .nats-status-dot.connecting {
+    background: #eab308;
+    animation: pulse 1s ease-in-out infinite;
+  }
+  .nats-status-dot.error {
+    background: #ef4444;
+  }
+  .nats-status-dot.disconnected {
+    background: var(--muted, #666);
+  }
+  .nats-status-text {
+    vertical-align: middle;
+  }
+  .cert-fingerprint {
+    font-family: monospace;
+    font-size: 0.8em;
+    word-break: break-all;
+    color: var(--muted, #999);
+    margin: 0.25em 0;
+  }
+  .file-upload-row {
+    margin-top: 0.5em;
+  }
+  .btn-small {
+    font-size: 0.85em;
+    padding: 0.25em 0.75em;
+    margin-top: 0.5em;
+  }
+  @keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
   }
 </style>

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -2359,7 +2359,7 @@
       <h3>Server</h3>
       <div class="setting-row">
         <label for="nats-endpoint">NATS Endpoint</label>
-        <input id="nats-endpoint" type="text" bind:value={natsEndpoint} placeholder="nats://host:4222" />
+        <input id="nats-endpoint" type="text" bind:value={natsEndpoint} placeholder="tls://host:4222" />
       </div>
     </section>
 

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -3223,6 +3223,25 @@
   .nats-status-text {
     vertical-align: middle;
   }
+  textarea {
+    width: 100%;
+    font-family: monospace;
+    font-size: 0.85rem;
+    padding: 0.5rem;
+    border: 1px solid var(--border-input);
+    border-radius: 4px;
+    background: var(--bg-input);
+    color: var(--text);
+    resize: vertical;
+    box-sizing: border-box;
+  }
+  textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  textarea::placeholder {
+    color: var(--text-muted);
+  }
   .cert-fingerprint {
     font-family: monospace;
     font-size: 0.8em;

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -2327,6 +2327,7 @@
     <section class="settings-section">
       <h3>Connection Status</h3>
       <div class="setting-row">
+        <span class="nats-status-line">
         <span class="nats-status-dot"
           class:connected={natsStatus.state === "connected"}
           class:connecting={natsStatus.state === "connecting"}
@@ -2346,6 +2347,7 @@
             Disabled
           {/if}
         </span>
+      </span>
       </div>
       {#if natsStatus.cn}
         <p class="hint">Client CN: {natsStatus.cn}</p>
@@ -3198,6 +3200,11 @@
   }
   .mtls-radio input[type="radio"]:disabled {
     cursor: wait;
+  }
+  .nats-status-line {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
   }
   .nats-status-dot {
     display: inline-block;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "cryptography",
     "pyjwt",
     "python-multipart>=0.0.26",
+    "nats-py",
 ]
 
 [project.scripts]

--- a/src/guidebook/db.py
+++ b/src/guidebook/db.py
@@ -74,6 +74,11 @@ GLOBAL_ONLY_KEYS = {
     "auth_required",
     "auth_slots",
     "auth_configured",
+    "nats_enabled",
+    "nats_endpoint",
+    "nats_ca_cert",
+    "nats_client_cert",
+    "nats_client_key",
 }
 
 

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -49,6 +49,7 @@ from guidebook.routes.update import router as update_router
 from guidebook.routes.scratchpad import router as scratchpad_router
 from guidebook.routes.media import router as media_router
 from guidebook.routes.mtls import router as mtls_router
+from guidebook.routes.nats import router as nats_router
 from guidebook.routes.tls import (
     router as tls_router,
     start_acme_renewal,
@@ -123,7 +124,11 @@ async def lifespan(app: FastAPI):
     if db_manager.is_open:
         await start_auto_backup()
     await start_acme_renewal()
+    from guidebook.nats_client import start_nats, stop_nats
+
+    await start_nats()
     yield
+    await stop_nats()
     await stop_acme_renewal()
     await stop_sse_auto_shutdown()
     await stop_auto_backup()
@@ -591,6 +596,7 @@ app.include_router(scratchpad_router)
 app.include_router(media_router)
 app.include_router(mtls_router)
 app.include_router(tls_router)
+app.include_router(nats_router)
 app.include_router(sse_router)
 
 static_dir = _resource_path("static")

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -367,7 +367,7 @@ async def http_middleware(request: Request, call_next):
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
     response.headers["Content-Security-Policy"] = (
         "default-src 'self'; "
-        "script-src 'self' 'wasm-unsafe-eval'; "
+        "script-src 'self' 'wasm-unsafe-eval' 'sha256-yei5Fza+Eyx4G0smvN0xBqEesIKumz6RSyGsU3FJowI='; "
         "style-src 'self' 'unsafe-inline'; "
         "img-src 'self' data: blob:; "
         "connect-src 'self'"

--- a/src/guidebook/nats_client.py
+++ b/src/guidebook/nats_client.py
@@ -1,0 +1,238 @@
+"""NATS connection manager.
+
+Maintains an optional background NATS connection with TLS/mTLS support.
+Connection status is broadcast to the frontend via SSE.
+"""
+
+import asyncio
+import logging
+import os
+import ssl
+import tempfile
+
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+
+logger = logging.getLogger("guidebook.nats")
+
+_nats_task: asyncio.Task | None = None
+_nats_client = None
+_nats_status: dict = {"state": "disabled", "detail": None, "cn": None}
+
+
+def get_status() -> dict:
+    return dict(_nats_status)
+
+
+def compute_fingerprint(cert_pem: str) -> str | None:
+    """Return the SHA-256 fingerprint of a PEM certificate."""
+    try:
+        from cryptography.hazmat.primitives import hashes
+
+        cert = x509.load_pem_x509_certificate(cert_pem.encode())
+        digest = cert.fingerprint(hashes.SHA256())
+        return ":".join(f"{b:02X}" for b in digest)
+    except Exception:
+        return None
+
+
+def extract_cn(cert_pem: str) -> str | None:
+    """Extract the Common Name from a PEM certificate."""
+    try:
+        cert = x509.load_pem_x509_certificate(cert_pem.encode())
+        cn_attrs = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+        return cn_attrs[0].value if cn_attrs else None
+    except Exception:
+        return None
+
+
+async def _read_nats_settings() -> dict:
+    from sqlalchemy import select
+
+    from guidebook.db import GlobalSetting, global_async_session
+
+    keys = [
+        "nats_enabled",
+        "nats_endpoint",
+        "nats_ca_cert",
+        "nats_client_cert",
+        "nats_client_key",
+    ]
+    result = {}
+    async with global_async_session() as gdb:
+        for key in keys:
+            row = (
+                await gdb.execute(select(GlobalSetting).where(GlobalSetting.key == key))
+            ).scalar_one_or_none()
+            result[key] = row.value if row else None
+    return result
+
+
+def _build_ssl_context(
+    ca_cert: str, client_cert: str | None, client_key: str | None
+) -> tuple[ssl.SSLContext, list[str]]:
+    temp_files: list[str] = []
+    ctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
+
+    ca_file = tempfile.NamedTemporaryFile(
+        delete=False, suffix=".pem", prefix="guidebook_nats_ca_"
+    )
+    ca_file.write(ca_cert.encode())
+    ca_file.close()
+    temp_files.append(ca_file.name)
+    ctx.load_verify_locations(cafile=ca_file.name)
+
+    if client_cert and client_key:
+        cert_file = tempfile.NamedTemporaryFile(
+            delete=False, suffix=".pem", prefix="guidebook_nats_cert_"
+        )
+        cert_file.write(client_cert.encode())
+        cert_file.close()
+        temp_files.append(cert_file.name)
+        os.chmod(cert_file.name, 0o600)
+
+        key_file = tempfile.NamedTemporaryFile(
+            delete=False, suffix=".pem", prefix="guidebook_nats_key_"
+        )
+        key_file.write(client_key.encode())
+        key_file.close()
+        temp_files.append(key_file.name)
+        os.chmod(key_file.name, 0o600)
+
+        ctx.load_cert_chain(certfile=cert_file.name, keyfile=key_file.name)
+
+    return ctx, temp_files
+
+
+def _cleanup_temp_files(paths: list[str]):
+    for p in paths:
+        try:
+            os.unlink(p)
+        except OSError:
+            pass
+
+
+def _set_status(state: str, detail: str | None = None, cn: str | None = None):
+    global _nats_status
+    _nats_status = {"state": state, "detail": detail, "cn": cn}
+    from guidebook.sse import broadcast
+
+    broadcast("nats-status", _nats_status)
+
+
+async def _nats_connection_loop():
+    import nats as nats_lib
+
+    global _nats_client
+    temp_files: list[str] = []
+    try:
+        while True:
+            settings = await _read_nats_settings()
+            if settings.get("nats_enabled") != "true":
+                _set_status("disabled")
+                await asyncio.sleep(10)
+                continue
+
+            endpoint = (settings.get("nats_endpoint") or "").strip()
+            ca_cert = settings.get("nats_ca_cert") or ""
+            client_cert = settings.get("nats_client_cert") or ""
+            client_key = settings.get("nats_client_key") or ""
+
+            if not endpoint:
+                _set_status("error", detail="No endpoint configured")
+                await asyncio.sleep(10)
+                continue
+
+            cn = extract_cn(client_cert) if client_cert else None
+
+            tls_ctx = None
+            if ca_cert:
+                try:
+                    _cleanup_temp_files(temp_files)
+                    tls_ctx, temp_files = _build_ssl_context(
+                        ca_cert, client_cert, client_key
+                    )
+                except Exception as e:
+                    _set_status("error", detail=f"TLS config error: {e}", cn=cn)
+                    await asyncio.sleep(30)
+                    continue
+
+            _set_status("connecting", cn=cn)
+
+            try:
+                nc = await nats_lib.connect(
+                    endpoint,
+                    tls=tls_ctx,
+                    reconnect_time_wait=5,
+                    max_reconnect_attempts=-1,
+                    disconnected_cb=_make_cb("disconnected", cn),
+                    reconnected_cb=_make_cb("connected", cn),
+                    error_cb=_make_error_cb(cn),
+                )
+                _nats_client = nc
+                _set_status("connected", cn=cn)
+
+                while nc.is_connected or nc.is_reconnecting:
+                    await asyncio.sleep(5)
+                    fresh = await _read_nats_settings()
+                    if fresh.get("nats_enabled") != "true":
+                        await nc.close()
+                        _nats_client = None
+                        _set_status("disabled")
+                        break
+
+                if nc.is_connected:
+                    await nc.close()
+                _nats_client = None
+
+            except Exception as e:
+                _set_status("error", detail=str(e), cn=cn)
+                _nats_client = None
+                await asyncio.sleep(10)
+
+    except asyncio.CancelledError:
+        if _nats_client and _nats_client.is_connected:
+            await _nats_client.close()
+        _nats_client = None
+        _cleanup_temp_files(temp_files)
+        raise
+
+
+def _make_cb(state: str, cn: str | None):
+    async def cb():
+        _set_status(state, cn=cn)
+
+    return cb
+
+
+def _make_error_cb(cn: str | None):
+    async def cb(e):
+        _set_status("error", detail=str(e), cn=cn)
+
+    return cb
+
+
+async def start_nats():
+    global _nats_task
+    if _nats_task is not None:
+        return
+    _nats_task = asyncio.create_task(_nats_connection_loop())
+    logger.info("NATS connection manager started")
+
+
+async def stop_nats():
+    global _nats_task, _nats_client
+    if _nats_task is not None:
+        _nats_task.cancel()
+        try:
+            await _nats_task
+        except asyncio.CancelledError:
+            pass
+        _nats_task = None
+        _nats_client = None
+        _set_status("disabled")
+
+
+async def restart_nats():
+    await stop_nats()
+    await start_nats()

--- a/src/guidebook/nats_client.py
+++ b/src/guidebook/nats_client.py
@@ -139,6 +139,7 @@ async def _nats_connection_loop():
             client_key = settings.get("nats_client_key") or ""
 
             if not endpoint:
+                logger.warning("NATS enabled but no endpoint configured")
                 _set_status("error", detail="No endpoint configured")
                 await asyncio.sleep(10)
                 continue
@@ -158,6 +159,7 @@ async def _nats_connection_loop():
                     continue
 
             _set_status("connecting", cn=cn)
+            logger.info("Connecting to NATS %s (CN=%s)", endpoint, cn or "none")
 
             try:
                 nc = await nats_lib.connect(
@@ -171,6 +173,7 @@ async def _nats_connection_loop():
                 )
                 _nats_client = nc
                 _set_status("connected", cn=cn)
+                logger.info("Connected to NATS %s", endpoint)
 
                 while nc.is_connected or nc.is_reconnecting:
                     await asyncio.sleep(5)
@@ -186,6 +189,7 @@ async def _nats_connection_loop():
                 _nats_client = None
 
             except Exception as e:
+                logger.warning("NATS connection failed (%s): %s", endpoint, e)
                 _set_status("error", detail=str(e), cn=cn)
                 _nats_client = None
                 await asyncio.sleep(10)

--- a/src/guidebook/routes/global_settings.py
+++ b/src/guidebook/routes/global_settings.py
@@ -17,7 +17,7 @@ logger = logging.getLogger("guidebook")
 router = APIRouter(prefix="/api/global-settings", tags=["global-settings"])
 
 ALLOWED_KEYS = GLOBAL_DEFAULTABLE_KEYS | GLOBAL_ONLY_KEYS
-HIDDEN_KEYS: set[str] = set()
+HIDDEN_KEYS: set[str] = {"nats_ca_cert", "nats_client_cert", "nats_client_key"}
 
 
 class SettingValue(BaseModel):

--- a/src/guidebook/routes/nats.py
+++ b/src/guidebook/routes/nats.py
@@ -1,0 +1,63 @@
+"""NATS connection management API routes."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from guidebook.db import GlobalSetting, get_global_session
+from guidebook.nats_client import (
+    compute_fingerprint,
+    extract_cn,
+    get_status,
+    restart_nats,
+)
+
+router = APIRouter(prefix="/api/nats", tags=["nats"])
+
+
+@router.get("/status")
+async def nats_status():
+    return get_status()
+
+
+@router.get("/certs")
+async def nats_certs(gdb: AsyncSession = Depends(get_global_session)):
+    ca_pem = (
+        await gdb.execute(
+            select(GlobalSetting).where(GlobalSetting.key == "nats_ca_cert")
+        )
+    ).scalar_one_or_none()
+    client_pem = (
+        await gdb.execute(
+            select(GlobalSetting).where(GlobalSetting.key == "nats_client_cert")
+        )
+    ).scalar_one_or_none()
+
+    ca_fingerprint = None
+    client_fingerprint = None
+    cn = None
+
+    if ca_pem and ca_pem.value:
+        ca_fingerprint = compute_fingerprint(ca_pem.value)
+    if client_pem and client_pem.value:
+        client_fingerprint = compute_fingerprint(client_pem.value)
+        cn = extract_cn(client_pem.value)
+
+    has_key = (
+        await gdb.execute(
+            select(GlobalSetting).where(GlobalSetting.key == "nats_client_key")
+        )
+    ).scalar_one_or_none()
+
+    return {
+        "ca_fingerprint": ca_fingerprint,
+        "client_fingerprint": client_fingerprint,
+        "cn": cn,
+        "has_key": bool(has_key and has_key.value),
+    }
+
+
+@router.post("/restart")
+async def nats_restart():
+    await restart_nats()
+    return {"ok": True}

--- a/uv.lock
+++ b/uv.lock
@@ -259,6 +259,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "nats-py" },
     { name = "packaging" },
     { name = "pyjwt" },
     { name = "python-multipart" },
@@ -282,6 +283,7 @@ requires-dist = [
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "nats-py" },
     { name = "packaging" },
     { name = "pyjwt" },
     { name = "python-multipart", specifier = ">=0.0.26" },
@@ -391,6 +393,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
+]
+
+[[package]]
+name = "nats-py"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/f8/b956c4621ba88748ed707c52e69f95b7a50c8914e750edca59a5bef84a76/nats_py-2.14.0.tar.gz", hash = "sha256:4ed02cb8e3b55c68074a063aa2687087115d805d1513297da90cb2068fb07bed", size = 120751, upload-time = "2026-02-23T22:44:58.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/39/0e87753df1072254bac190b33ed34b264f28f6aa9bea0f01b7e818071756/nats_py-2.14.0-py3-none-any.whl", hash = "sha256:4116f5d2233ce16e63c3d5538fa40a5e207f75fcf42a741773929ddf1e29d19d", size = 82259, upload-time = "2026-02-23T22:45:00.152Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add optional NATS connection with TLS/mTLS support (#23)
- New NATS settings tab with enable/disable, endpoint, and certificate management
- Background connection manager with auto-reconnect and SSE status updates
- Certificate fingerprints displayed for saved CA and client certs; client key hidden
- Allow inline script hash in CSP for vanilla-colorful
- Style and layout fixes for NATS tab UI