### PR TITLE
NATS chat with lobby, challenge-response verification, and private rooms

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -597,6 +597,10 @@
       natsConnected = data.state === "connected";
       window.dispatchEvent(new CustomEvent("nats-status", { detail: data }));
     });
+    eventSource.addEventListener("chat-enabled", (e) => {
+      const data = JSON.parse(e.data);
+      natsChatEnabled = data.enabled;
+    });
     for (const evt of ["chat-message", "chat-peers", "chat-verify-request", "chat-verify-complete", "chat-rooms"]) {
       eventSource.addEventListener(evt, (e) => {
         window.dispatchEvent(new CustomEvent(evt, { detail: JSON.parse(e.data) }));

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -607,7 +607,7 @@
       const data = JSON.parse(e.data);
       natsChatEnabled = data.enabled;
     });
-    for (const evt of ["chat-message", "chat-peers", "chat-verify-request", "chat-verify-complete", "chat-rooms"]) {
+    for (const evt of ["chat-message", "chat-peers", "chat-verify-request", "chat-verify-complete", "chat-rooms", "chat-defriended"]) {
       eventSource.addEventListener(evt, (e) => {
         window.dispatchEvent(new CustomEvent(evt, { detail: JSON.parse(e.data) }));
       });

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -9,6 +9,7 @@
   import Query from "./Query.svelte";
   import Scratchpad from "./Scratchpad.svelte";
   import Media from "./Media.svelte";
+  import Chat from "./Chat.svelte";
   import Icon from "@iconify/svelte";
   import iconBook from "@iconify-icons/twemoji/open-book";
   import iconBell from "@iconify-icons/twemoji/bell";
@@ -33,6 +34,7 @@
       return { page: "query", editId: null, dualRight: null, querySql: sp?.get("sql") || "" };
     }
     if (hash === "/scratchpad") return { page: "scratchpad", editId: null, dualRight: null };
+    if (hash === "/chat") return { page: "chat", editId: null, dualRight: null };
     if (hash === "/media") return { page: isWide() ? "dual" : "media", editId: null, dualRight: "media" };
     if (hash === "/notifications") return { page: isWide() ? "dual" : "notifications", editId: null, dualRight: "notifications" };
     if (hash === "/database" || hash === "/records") return { page: isWide() ? "dual" : "records", editId: null, dualRight: null };
@@ -160,6 +162,8 @@
   let updateSupported = false;
   let appFrozen = true;
   let sqlQueryEnabled = false;
+  let natsChatEnabled = false;
+  let natsConnected = false;
   let noShutdown = false;
   let unreadCount = 0;
   let prevUnreadCount = -1;
@@ -284,6 +288,7 @@
     fetchPopupNotifEnabled();
     await fetchDatabaseRight();
     await fetchSqlQueryEnabled();
+    fetchNatsChatEnabled();
     fetchUnreadCount();
     connectSSE();
   }
@@ -588,8 +593,15 @@
       applyThemeFromState(_themeState);
     });
     eventSource.addEventListener("nats-status", (e) => {
-      window.dispatchEvent(new CustomEvent("nats-status", { detail: JSON.parse(e.data) }));
+      const data = JSON.parse(e.data);
+      natsConnected = data.state === "connected";
+      window.dispatchEvent(new CustomEvent("nats-status", { detail: data }));
     });
+    for (const evt of ["chat-message", "chat-peers", "chat-verify-request", "chat-verify-complete", "chat-rooms"]) {
+      eventSource.addEventListener(evt, (e) => {
+        window.dispatchEvent(new CustomEvent(evt, { detail: JSON.parse(e.data) }));
+      });
+    }
     eventSource.addEventListener("database-changed", () => {
       if (switchingDatabase || !welcomeAcknowledged) return;
       // Navigate home before reloading — the new database may not support the current page
@@ -748,6 +760,23 @@
     } catch {}
   }
 
+  async function fetchNatsChatEnabled() {
+    try {
+      const [chatRes, statusRes] = await Promise.all([
+        fetch("/api/global-settings/nats_chat_enabled"),
+        fetch("/api/nats/status"),
+      ]);
+      if (chatRes.ok) {
+        const data = await chatRes.json();
+        natsChatEnabled = data.value === "true";
+      }
+      if (statusRes.ok) {
+        const data = await statusRes.json();
+        natsConnected = data.state === "connected";
+      }
+    } catch {}
+  }
+
 
   function isWide() {
     return typeof window !== "undefined" && window.innerWidth >= wideBreakpoint;
@@ -799,6 +828,7 @@
     }
     // Redirect disabled pages to home
     if (p === "query" && !sqlQueryEnabled) p = "records";
+    if (p === "chat" && !(natsChatEnabled && natsConnected)) p = "records";
 
     if (isWide() && (p === "add" || p === "records" || DUAL_RIGHT_PAGES.has(p))) {
       if (DUAL_RIGHT_PAGES.has(p)) dualRightPage = p;
@@ -817,7 +847,7 @@
     if (p === "dual") {
       window.location.hash = `/dual/${dualRightPage}`;
     } else {
-      const paths = { records: "/records", add: "/add", query: "/query", notifications: "/notifications", media: "/media", scratchpad: "/scratchpad", settings: settingsTab ? `/settings/${settingsTab}` : "/settings", about: "/about", picker: "/picker" };
+      const paths = { records: "/records", add: "/add", query: "/query", notifications: "/notifications", media: "/media", scratchpad: "/scratchpad", chat: "/chat", settings: settingsTab ? `/settings/${settingsTab}` : "/settings", about: "/about", picker: "/picker" };
       window.location.hash = paths[p] || "/";
     }
     setTimeout(() => { navigating = false; }, 0);
@@ -1100,10 +1130,12 @@
         <button class="add-btn dual-btn" class:active-nav={dualRightPage === "media"} on:click={() => { dualRightPage = "media"; navigate("media"); }} title="Records & Media">{#if dualRightPage === "media" && !databaseRight}<Icon icon={iconBook} width={14} />{/if}<Icon icon={iconCamera} width={18} />{#if dualRightPage === "media" && databaseRight}<Icon icon={iconBook} width={14} />{/if}</button>
         <button class="add-btn dual-btn" class:active-nav={dualRightPage === "notifications"} on:click={handleNotificationClick} title="Records & Notifications">{#if dualRightPage === "notifications" && !databaseRight}<Icon icon={iconBook} width={14} />{/if}{#if unreadCount > 0}<span class="notif-badge">{unreadCount > 99 ? "99+" : unreadCount}</span>{:else}<Icon icon={iconBell} width={18} />{/if}{#if dualRightPage === "notifications" && databaseRight}<Icon icon={iconBook} width={14} />{/if}</button>
         <button class="add-btn" class:active-nav={page === "scratchpad"} on:click={() => navigate("scratchpad")} title="Scratchpad">💭</button>
+        {#if natsChatEnabled && natsConnected}<button class="add-btn" class:active-nav={page === "chat"} on:click={() => navigate("chat")} title="Chat">💬</button>{/if}
       {:else}
         <button class="add-btn" on:click={() => navigate("records")} title="Records"><Icon icon={iconBook} width={18} /></button>
         <button class="add-btn" class:active-nav={page === "media"} on:click={() => navigate("media")} title="Media"><Icon icon={iconCamera} width={18} /></button>
         <button class="add-btn" class:active-nav={page === "scratchpad"} on:click={() => navigate("scratchpad")} title="Scratchpad">💭</button>
+        {#if natsChatEnabled && natsConnected}<button class="add-btn" class:active-nav={page === "chat"} on:click={() => navigate("chat")} title="Chat">💬</button>{/if}
         <button class="add-btn notification-btn" class:has-unread={unreadCount > 0} on:click={handleNotificationClick} title="Notifications">
           {#if unreadCount > 0}
             <span class="notif-badge">{unreadCount > 99 ? "99+" : unreadCount}</span>
@@ -1129,6 +1161,7 @@
           <button class="menu-item" class:active={page === "notifications" || (page === "dual" && dualRightPage === "notifications")} on:click={() => navigate("notifications")}>Notifications{#if unreadCount > 0} ({unreadCount}){/if}</button>
           {#if sqlQueryEnabled}<button class="menu-item" class:active={page === "query"} on:click={() => navigate("query")}>SQL Query</button>{/if}
           <button class="menu-item" class:active={page === "scratchpad"} on:click={() => navigate("scratchpad")}>Scratchpad</button>
+          {#if natsChatEnabled && natsConnected}<button class="menu-item" class:active={page === "chat"} on:click={() => navigate("chat")}>Chat</button>{/if}
           <button class="menu-item" class:active={page === "settings"} on:click={() => navigate("settings")}>Settings</button>
           <button class="menu-item" class:active={page === "about"} on:click={() => navigate("about")}>About</button>
           {#if pickerMode}
@@ -1168,9 +1201,11 @@
     {:else if page === "notifications"}
       <Notifications refreshTrigger={notifRefreshTrigger} on:countchange={() => fetchUnreadCount()} />
     {:else if page === "settings"}
-      <Settings databaseName={currentDatabase} pickerMode={pickerMode} initialTab={settingsTab} bind:highlightSection={settingsHighlight} {clientCount} {authRefreshTrigger} on:disconnect-others={async () => { const nonce = Math.random().toString(36).slice(2); disconnectNonce = nonce; try { await fetch("/api/events/disconnect-others", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ nonce }) }); } catch {} }} on:deleted={e => { if (e.detail.shutdown) { setShutdownState(); } else { stopAppServices(); databaseOpen = false; currentDatabase = ""; page = "picker"; applySystemTheme(); } }} on:setupcomplete={async () => { await fetchDatabaseRight(); await fetchSqlQueryEnabled(); navigate(isWide() ? "dual" : "records"); }} on:saved={async () => { fetchCustomHeader(); fetchDefaultPage(); applyTheme(); fetchPopupNotifEnabled(); await fetchDatabaseRight(); await fetchSqlQueryEnabled(); fetchUpdateCheck(); }} on:shutdown-pending={() => { shutdownPendingSince = Date.now(); }} on:shutdown={() => { setShutdownState(); }} />
+      <Settings databaseName={currentDatabase} pickerMode={pickerMode} initialTab={settingsTab} bind:highlightSection={settingsHighlight} {clientCount} {authRefreshTrigger} on:disconnect-others={async () => { const nonce = Math.random().toString(36).slice(2); disconnectNonce = nonce; try { await fetch("/api/events/disconnect-others", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ nonce }) }); } catch {} }} on:deleted={e => { if (e.detail.shutdown) { setShutdownState(); } else { stopAppServices(); databaseOpen = false; currentDatabase = ""; page = "picker"; applySystemTheme(); } }} on:setupcomplete={async () => { await fetchDatabaseRight(); await fetchSqlQueryEnabled(); navigate(isWide() ? "dual" : "records"); }} on:saved={async () => { fetchCustomHeader(); fetchDefaultPage(); applyTheme(); fetchPopupNotifEnabled(); await fetchDatabaseRight(); await fetchSqlQueryEnabled(); fetchNatsChatEnabled(); fetchUpdateCheck(); }} on:shutdown-pending={() => { shutdownPendingSince = Date.now(); }} on:shutdown={() => { setShutdownState(); }} />
     {:else if page === "scratchpad"}
       <Scratchpad />
+    {:else if page === "chat"}
+      <Chat />
     {:else if page === "about"}
       <About />
     {/if}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1062,7 +1062,7 @@
   on:drop={onGlobalDrop}
 />
 
-<main class:picker-mode={pickerMode && !databaseOpen} class:dual-mode={page === "dual"} class:records-mode={page === "records" || page === "add"} class:query-mode={page === "query"} class:scratchpad-mode={page === "scratchpad"} class:settings-mode={page === "settings"}>
+<main class:picker-mode={pickerMode && !databaseOpen} class:dual-mode={page === "dual"} class:records-mode={page === "records" || page === "add"} class:query-mode={page === "query"} class:scratchpad-mode={page === "scratchpad"} class:chat-mode={page === "chat"} class:settings-mode={page === "settings"}>
   {#if globalDragOver && databaseOpen}
     <div class="global-drop-overlay">
       <div class="global-drop-message">Drop files to attach</div>
@@ -1400,6 +1400,23 @@
   }
 
   :global(main.scratchpad-mode) .page-content {
+    max-width: 100%;
+    margin: 0;
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  :global(main.chat-mode) {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    overflow: hidden;
+    box-sizing: border-box;
+  }
+
+  :global(main.chat-mode) .page-content {
     max-width: 100%;
     margin: 0;
     flex: 1;

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -787,7 +787,7 @@
   async function fetchNatsChatEnabled() {
     try {
       const [chatRes, statusRes] = await Promise.all([
-        fetch("/api/global-settings/nats_chat_enabled"),
+        fetch("/api/instance-settings/nats_chat_enabled"),
         fetch("/api/nats/status"),
       ]);
       if (chatRes.ok) {

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -5,11 +5,10 @@
   let peers = [];
   let trusted = [];
   let pendingVerifications = [];
-  let activeRoom = "lobby";
+  let activeRoom = null;
   let messages = [];
   let messageInput = "";
   let sending = false;
-  let showPeers = false;
   let chatStatus = { active: false, cn: null, fingerprint: null, lobby_joined: false };
   let messagesEnd;
 
@@ -23,7 +22,13 @@
   async function loadRooms() {
     try {
       const res = await fetch("/api/chat/rooms");
-      if (res.ok) rooms = await res.json();
+      if (res.ok) {
+        rooms = await res.json();
+        if (!activeRoom && rooms.length > 0) {
+          activeRoom = rooms[0].id;
+          loadMessages();
+        }
+      }
     } catch {}
   }
 
@@ -149,6 +154,10 @@
 
   function onChatRooms(e) {
     rooms = e.detail.rooms || [];
+    if (!activeRoom && rooms.length > 0) {
+      activeRoom = rooms[0].id;
+      loadMessages();
+    }
   }
 
   onMount(() => {
@@ -184,23 +193,16 @@
         class:active={activeRoom === room.id}
         on:click={() => selectRoom(room.id)}
       >
-        <span class="room-icon">{room.type === "lobby" ? "🌐" : "🔒"}</span>
+        <span class="room-icon">🔒</span>
         <span class="room-name">{room.name}</span>
       </button>
     {/each}
     {#if rooms.length === 0}
-      <p class="sidebar-hint">No rooms available. Enable lobby or verify a peer.</p>
+      <p class="sidebar-hint">No rooms yet. Verify a peer to start chatting.</p>
     {/if}
 
-    <div class="sidebar-header" style="margin-top: 1em;">
-      Peers
-      {#if chatStatus.lobby_joined}
-        <button class="btn-icon" on:click={() => { showPeers = !showPeers; if (showPeers) loadPeers(); }} title="Toggle peer list">
-          {showPeers ? "▲" : "▼"}
-        </button>
-      {/if}
-    </div>
-    {#if showPeers && chatStatus.lobby_joined}
+    {#if chatStatus.lobby_joined}
+      <div class="sidebar-header" style="margin-top: 1em;">Peers</div>
       {#each peers as peer}
         <div class="peer-item">
           <div class="peer-cn">{peer.cn}</div>
@@ -237,6 +239,10 @@
       <div class="chat-empty">
         <p>Chat is not active. Enable NATS Chat in Settings.</p>
       </div>
+    {:else if !activeRoom}
+      <div class="chat-empty">
+        <p>Verify a peer to start a private conversation.</p>
+      </div>
     {:else}
       <div class="chat-messages">
         {#each messages as msg}
@@ -256,7 +262,7 @@
           type="text"
           bind:value={messageInput}
           on:keydown={handleKeydown}
-          placeholder={activeRoom === "lobby" ? "Message the lobby..." : "Send a message..."}
+          placeholder="Send a message..."
           disabled={sending}
         />
         <button class="btn-send" on:click={sendMessage} disabled={sending || !messageInput.trim()}>Send</button>
@@ -390,15 +396,6 @@
   .btn-reject {
     border-color: #a44;
     color: #f88;
-  }
-
-  .btn-icon {
-    background: none;
-    border: none;
-    color: var(--text-muted, #888);
-    cursor: pointer;
-    font-size: 0.7rem;
-    padding: 0 4px;
   }
 
   .chat-main {

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -174,6 +174,15 @@
       activeRoom = rooms[0].id;
       loadMessages();
     }
+    if (activeRoom && !rooms.find(r => r.id === activeRoom)) {
+      activeRoom = rooms.length > 0 ? rooms[0].id : null;
+      if (activeRoom) loadMessages();
+    }
+  }
+
+  function onChatDefriended(e) {
+    loadTrusted();
+    loadRooms();
   }
 
   onMount(() => {
@@ -189,6 +198,7 @@
     window.addEventListener("chat-verify-request", onChatVerifyRequest);
     window.addEventListener("chat-verify-complete", onChatVerifyComplete);
     window.addEventListener("chat-rooms", onChatRooms);
+    window.addEventListener("chat-defriended", onChatDefriended);
   });
 
   onDestroy(() => {
@@ -197,6 +207,7 @@
     window.removeEventListener("chat-verify-request", onChatVerifyRequest);
     window.removeEventListener("chat-verify-complete", onChatVerifyComplete);
     window.removeEventListener("chat-rooms", onChatRooms);
+    window.removeEventListener("chat-defriended", onChatDefriended);
   });
 </script>
 

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -1,0 +1,523 @@
+<script>
+  import { onMount, onDestroy, tick } from "svelte";
+
+  let rooms = [];
+  let peers = [];
+  let trusted = [];
+  let pendingVerifications = [];
+  let activeRoom = "lobby";
+  let messages = [];
+  let messageInput = "";
+  let sending = false;
+  let showPeers = false;
+  let chatStatus = { active: false, cn: null, fingerprint: null, lobby_joined: false };
+  let messagesEnd;
+
+  async function loadStatus() {
+    try {
+      const res = await fetch("/api/chat/status");
+      if (res.ok) chatStatus = await res.json();
+    } catch {}
+  }
+
+  async function loadRooms() {
+    try {
+      const res = await fetch("/api/chat/rooms");
+      if (res.ok) rooms = await res.json();
+    } catch {}
+  }
+
+  async function loadPeers() {
+    try {
+      const res = await fetch("/api/chat/peers");
+      if (res.ok) peers = await res.json();
+    } catch {}
+  }
+
+  async function loadTrusted() {
+    try {
+      const res = await fetch("/api/chat/trusted");
+      if (res.ok) trusted = await res.json();
+    } catch {}
+  }
+
+  async function loadPending() {
+    try {
+      const res = await fetch("/api/chat/verify/pending");
+      if (res.ok) pendingVerifications = await res.json();
+    } catch {}
+  }
+
+  async function loadMessages() {
+    try {
+      const res = await fetch(`/api/chat/rooms/${activeRoom}/messages?limit=200`);
+      if (res.ok) messages = await res.json();
+      await tick();
+      scrollToBottom();
+    } catch {}
+  }
+
+  async function sendMessage() {
+    if (!messageInput.trim() || sending) return;
+    sending = true;
+    try {
+      await fetch(`/api/chat/rooms/${activeRoom}/send`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: messageInput }),
+      });
+      messageInput = "";
+    } catch {}
+    sending = false;
+  }
+
+  async function verifyPeer(fingerprint) {
+    await fetch(`/api/chat/verify/${encodeURIComponent(fingerprint)}`, { method: "POST" });
+  }
+
+  async function acceptVerification(fingerprint) {
+    await fetch(`/api/chat/verify/${encodeURIComponent(fingerprint)}/accept`, { method: "POST" });
+    pendingVerifications = pendingVerifications.filter(p => p.fingerprint !== fingerprint);
+    await loadTrusted();
+    await loadRooms();
+  }
+
+  async function rejectVerification(fingerprint) {
+    await fetch(`/api/chat/verify/${encodeURIComponent(fingerprint)}/reject`, { method: "POST" });
+    pendingVerifications = pendingVerifications.filter(p => p.fingerprint !== fingerprint);
+  }
+
+  function selectRoom(roomId) {
+    activeRoom = roomId;
+    loadMessages();
+  }
+
+  function scrollToBottom() {
+    if (messagesEnd) {
+      messagesEnd.scrollIntoView({ behavior: "smooth" });
+    }
+  }
+
+  function formatTime(ts) {
+    const d = new Date(ts * 1000);
+    return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  }
+
+  function shortFingerprint(fp) {
+    if (!fp) return "";
+    return fp.split(":").slice(0, 4).join(":");
+  }
+
+  function isOwnMessage(msg) {
+    return msg.fingerprint === chatStatus.fingerprint;
+  }
+
+  function isTrusted(fingerprint) {
+    return trusted.some(t => t.fingerprint === fingerprint);
+  }
+
+  function isPendingOutgoing(fingerprint) {
+    // We don't track this client-side yet, just return false
+    return false;
+  }
+
+  function handleKeydown(e) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  }
+
+  function onChatMessage(e) {
+    const msg = e.detail;
+    if (msg.room === activeRoom) {
+      messages = [...messages, msg];
+      tick().then(scrollToBottom);
+    }
+  }
+
+  function onChatPeers(e) {
+    peers = e.detail.peers || [];
+  }
+
+  function onChatVerifyRequest(e) {
+    loadPending();
+  }
+
+  function onChatVerifyComplete(e) {
+    loadTrusted();
+    loadRooms();
+  }
+
+  function onChatRooms(e) {
+    rooms = e.detail.rooms || [];
+  }
+
+  onMount(() => {
+    loadStatus();
+    loadRooms();
+    loadPeers();
+    loadTrusted();
+    loadPending();
+    loadMessages();
+
+    window.addEventListener("chat-message", onChatMessage);
+    window.addEventListener("chat-peers", onChatPeers);
+    window.addEventListener("chat-verify-request", onChatVerifyRequest);
+    window.addEventListener("chat-verify-complete", onChatVerifyComplete);
+    window.addEventListener("chat-rooms", onChatRooms);
+  });
+
+  onDestroy(() => {
+    window.removeEventListener("chat-message", onChatMessage);
+    window.removeEventListener("chat-peers", onChatPeers);
+    window.removeEventListener("chat-verify-request", onChatVerifyRequest);
+    window.removeEventListener("chat-verify-complete", onChatVerifyComplete);
+    window.removeEventListener("chat-rooms", onChatRooms);
+  });
+</script>
+
+<div class="chat-container">
+  <div class="chat-sidebar">
+    <div class="sidebar-header">Rooms</div>
+    {#each rooms as room}
+      <button
+        class="room-item"
+        class:active={activeRoom === room.id}
+        on:click={() => selectRoom(room.id)}
+      >
+        <span class="room-icon">{room.type === "lobby" ? "🌐" : "🔒"}</span>
+        <span class="room-name">{room.name}</span>
+      </button>
+    {/each}
+    {#if rooms.length === 0}
+      <p class="sidebar-hint">No rooms available. Enable lobby or verify a peer.</p>
+    {/if}
+
+    <div class="sidebar-header" style="margin-top: 1em;">
+      Peers
+      {#if chatStatus.lobby_joined}
+        <button class="btn-icon" on:click={() => { showPeers = !showPeers; if (showPeers) loadPeers(); }} title="Toggle peer list">
+          {showPeers ? "▲" : "▼"}
+        </button>
+      {/if}
+    </div>
+    {#if showPeers && chatStatus.lobby_joined}
+      {#each peers as peer}
+        <div class="peer-item">
+          <div class="peer-cn">{peer.cn}</div>
+          <div class="peer-fp">{shortFingerprint(peer.fingerprint)}</div>
+          {#if isTrusted(peer.fingerprint)}
+            <span class="peer-badge trusted">Trusted</span>
+          {:else}
+            <button class="btn-small" on:click={() => verifyPeer(peer.fingerprint)}>Verify</button>
+          {/if}
+        </div>
+      {/each}
+      {#if peers.length === 0}
+        <p class="sidebar-hint">No peers online.</p>
+      {/if}
+    {/if}
+
+    {#if pendingVerifications.length > 0}
+      <div class="sidebar-header" style="margin-top: 1em;">Verification Requests</div>
+      {#each pendingVerifications as req}
+        <div class="verify-request">
+          <div class="peer-cn">{req.cn}</div>
+          <div class="peer-fp">{shortFingerprint(req.fingerprint)}</div>
+          <div class="verify-actions">
+            <button class="btn-small btn-accept" on:click={() => acceptVerification(req.fingerprint)}>Accept</button>
+            <button class="btn-small btn-reject" on:click={() => rejectVerification(req.fingerprint)}>Reject</button>
+          </div>
+        </div>
+      {/each}
+    {/if}
+  </div>
+
+  <div class="chat-main">
+    {#if !chatStatus.active}
+      <div class="chat-empty">
+        <p>Chat is not active. Enable NATS Chat in Settings.</p>
+      </div>
+    {:else}
+      <div class="chat-messages">
+        {#each messages as msg}
+          <div class="message" class:own={isOwnMessage(msg)}>
+            <div class="message-header">
+              <span class="message-cn" class:own-cn={isOwnMessage(msg)}>{msg.cn}</span>
+              <span class="message-time">{formatTime(msg.ts)}</span>
+            </div>
+            <div class="message-text">{msg.text}</div>
+          </div>
+        {/each}
+        <div bind:this={messagesEnd}></div>
+      </div>
+
+      <div class="chat-input">
+        <input
+          type="text"
+          bind:value={messageInput}
+          on:keydown={handleKeydown}
+          placeholder={activeRoom === "lobby" ? "Message the lobby..." : "Send a message..."}
+          disabled={sending}
+        />
+        <button class="btn-send" on:click={sendMessage} disabled={sending || !messageInput.trim()}>Send</button>
+      </div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .chat-container {
+    display: flex;
+    height: calc(100vh - 60px);
+    overflow: hidden;
+  }
+
+  .chat-sidebar {
+    width: 240px;
+    min-width: 200px;
+    border-right: 1px solid var(--border, #333);
+    overflow-y: auto;
+    padding: 0.5em;
+    background: var(--bg-sidebar, var(--bg, #1a1a1a));
+  }
+
+  .sidebar-header {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    color: var(--text-muted, #888);
+    padding: 0.5em 0.5em 0.25em;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .sidebar-hint {
+    font-size: 0.8rem;
+    color: var(--text-muted, #888);
+    padding: 0.25em 0.5em;
+    margin: 0;
+  }
+
+  .room-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    width: 100%;
+    padding: 0.5em;
+    border: none;
+    background: transparent;
+    color: var(--text, #ccc);
+    cursor: pointer;
+    border-radius: 4px;
+    font-size: 0.9rem;
+    text-align: left;
+  }
+
+  .room-item:hover {
+    background: var(--bg-hover, #2a2a2a);
+  }
+
+  .room-item.active {
+    background: var(--accent, #e6a700);
+    color: var(--bg, #111);
+  }
+
+  .room-icon {
+    font-size: 1rem;
+  }
+
+  .room-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .peer-item, .verify-request {
+    padding: 0.4em 0.5em;
+    border-bottom: 1px solid var(--border, #333);
+  }
+
+  .peer-cn {
+    font-size: 0.85rem;
+    color: var(--text, #ccc);
+  }
+
+  .peer-fp {
+    font-size: 0.7rem;
+    color: var(--text-muted, #888);
+    font-family: monospace;
+  }
+
+  .peer-badge {
+    display: inline-block;
+    font-size: 0.7rem;
+    padding: 1px 6px;
+    border-radius: 3px;
+    margin-top: 2px;
+  }
+
+  .peer-badge.trusted {
+    background: #2d5a2d;
+    color: #8f8;
+  }
+
+  .verify-actions {
+    display: flex;
+    gap: 0.3em;
+    margin-top: 0.3em;
+  }
+
+  .btn-small {
+    font-size: 0.75rem;
+    padding: 2px 8px;
+    border: 1px solid var(--border, #555);
+    background: var(--bg-input, #222);
+    color: var(--text, #ccc);
+    border-radius: 3px;
+    cursor: pointer;
+  }
+
+  .btn-small:hover {
+    background: var(--bg-hover, #333);
+  }
+
+  .btn-accept {
+    border-color: #4a4;
+    color: #8f8;
+  }
+
+  .btn-reject {
+    border-color: #a44;
+    color: #f88;
+  }
+
+  .btn-icon {
+    background: none;
+    border: none;
+    color: var(--text-muted, #888);
+    cursor: pointer;
+    font-size: 0.7rem;
+    padding: 0 4px;
+  }
+
+  .chat-main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .chat-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+    color: var(--text-muted, #888);
+  }
+
+  .chat-messages {
+    flex: 1;
+    overflow-y: auto;
+    padding: 1em;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3em;
+  }
+
+  .message {
+    max-width: 80%;
+    padding: 0.4em 0.7em;
+    border-radius: 6px;
+    background: var(--bg-input, #222);
+  }
+
+  .message.own {
+    align-self: flex-end;
+    background: var(--accent, #e6a700);
+    color: var(--bg, #111);
+  }
+
+  .message-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 1em;
+    font-size: 0.7rem;
+    margin-bottom: 2px;
+  }
+
+  .message-cn {
+    font-weight: bold;
+    color: var(--accent, #e6a700);
+  }
+
+  .message-cn.own-cn {
+    color: var(--bg, #111);
+  }
+
+  .message-time {
+    color: var(--text-muted, #888);
+    white-space: nowrap;
+  }
+
+  .message.own .message-time {
+    color: var(--bg, #333);
+  }
+
+  .message-text {
+    font-size: 0.9rem;
+    word-break: break-word;
+    white-space: pre-wrap;
+  }
+
+  .chat-input {
+    display: flex;
+    gap: 0.5em;
+    padding: 0.5em 1em;
+    border-top: 1px solid var(--border, #333);
+    background: var(--bg, #1a1a1a);
+  }
+
+  .chat-input input {
+    flex: 1;
+    padding: 0.5em 0.75em;
+    border: 1px solid var(--border-input, #444);
+    border-radius: 4px;
+    background: var(--bg-input, #222);
+    color: var(--text, #ccc);
+    font-size: 0.9rem;
+  }
+
+  .chat-input input:focus {
+    outline: none;
+    border-color: var(--accent, #e6a700);
+  }
+
+  .btn-send {
+    padding: 0.5em 1em;
+    border: none;
+    border-radius: 4px;
+    background: var(--accent, #e6a700);
+    color: var(--bg, #111);
+    font-size: 0.9rem;
+    cursor: pointer;
+    font-weight: bold;
+  }
+
+  .btn-send:hover:not(:disabled) {
+    opacity: 0.9;
+  }
+
+  .btn-send:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  @media (max-width: 600px) {
+    .chat-sidebar {
+      width: 180px;
+      min-width: 140px;
+    }
+  }
+</style>

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -11,6 +11,7 @@
   let sending = false;
   let chatStatus = { active: false, cn: null, fingerprint: null, lobby_joined: false };
   let messagesEnd;
+  let messageInputEl;
 
   async function loadStatus() {
     try {
@@ -74,6 +75,8 @@
       messageInput = "";
     } catch {}
     sending = false;
+    await tick();
+    if (messageInputEl) messageInputEl.focus();
   }
 
   async function verifyPeer(fingerprint) {
@@ -260,6 +263,7 @@
       <div class="chat-input">
         <input
           type="text"
+          bind:this={messageInputEl}
           bind:value={messageInput}
           on:keydown={handleKeydown}
           placeholder="Send a message..."

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -112,9 +112,7 @@
     return msg.fingerprint === chatStatus.fingerprint;
   }
 
-  function isTrusted(fingerprint) {
-    return trusted.some(t => t.fingerprint === fingerprint);
-  }
+  $: trustedSet = new Set(trusted.map(t => t.fingerprint));
 
   function isPendingOutgoing(fingerprint) {
     // We don't track this client-side yet, just return false
@@ -207,7 +205,7 @@
         <div class="peer-item">
           <div class="peer-cn">{peer.cn}</div>
           <div class="peer-fp">{shortFingerprint(peer.fingerprint)}</div>
-          {#if isTrusted(peer.fingerprint)}
+          {#if trustedSet.has(peer.fingerprint)}
             <span class="peer-badge trusted">Trusted</span>
           {:else}
             <button class="btn-small" on:click={() => verifyPeer(peer.fingerprint)}>Verify</button>

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -270,7 +270,8 @@
 <style>
   .chat-container {
     display: flex;
-    height: calc(100dvh - 5rem);
+    flex: 1;
+    min-height: 0;
     overflow: hidden;
   }
 

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -1,5 +1,7 @@
 <script>
   import { onMount, onDestroy, tick } from "svelte";
+  import Icon from "@iconify/svelte";
+  import iconLocked from "@iconify-icons/twemoji/locked";
 
   let rooms = [];
   let peers = [];
@@ -207,7 +209,7 @@
         class:active={activeRoom === room.id}
         on:click={() => selectRoom(room.id)}
       >
-        <span class="room-icon">🔒</span>
+        <span class="room-icon"><Icon icon={iconLocked} width={16} /></span>
         <span class="room-name">{room.name}</span>
       </button>
     {/each}

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -211,7 +211,7 @@
           <div class="peer-cn">{peer.cn}</div>
           <div class="peer-fp">{shortFingerprint(peer.fingerprint)}</div>
           {#if trustedSet.has(peer.fingerprint)}
-            <span class="peer-badge trusted">Trusted</span>
+            <span class="peer-badge trusted">Friends</span>
           {:else}
             <button class="btn-small" on:click={() => verifyPeer(peer.fingerprint)}>Verify</button>
           {/if}

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -270,7 +270,7 @@
 <style>
   .chat-container {
     display: flex;
-    height: calc(100vh - 60px);
+    height: calc(100dvh - 5rem);
     overflow: hidden;
   }
 

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -90,6 +90,17 @@
     await loadRooms();
   }
 
+  async function defriend(peer) {
+    if (!confirm(`Remove ${peer.cn} as a friend? This will close your private room.`)) return;
+    await fetch(`/api/chat/trusted/${encodeURIComponent(peer.fingerprint)}`, { method: "DELETE" });
+    await loadTrusted();
+    await loadRooms();
+    if (activeRoom && !rooms.find(r => r.id === activeRoom)) {
+      activeRoom = rooms.length > 0 ? rooms[0].id : null;
+      if (activeRoom) loadMessages();
+    }
+  }
+
   async function rejectVerification(fingerprint) {
     await fetch(`/api/chat/verify/${encodeURIComponent(fingerprint)}/reject`, { method: "POST" });
     pendingVerifications = pendingVerifications.filter(p => p.fingerprint !== fingerprint);
@@ -212,6 +223,7 @@
           <div class="peer-fp">{shortFingerprint(peer.fingerprint)}</div>
           {#if trustedSet.has(peer.fingerprint)}
             <span class="peer-badge trusted">Friends</span>
+            <button class="btn-small btn-defriend" on:click={() => defriend(peer)} title="Remove friend">✕</button>
           {:else}
             <button class="btn-small" on:click={() => verifyPeer(peer.fingerprint)}>Verify</button>
           {/if}
@@ -370,6 +382,14 @@
   .peer-badge.trusted {
     background: #2d5a2d;
     color: #8f8;
+  }
+
+  .btn-defriend {
+    border-color: #a44;
+    color: #f88;
+    margin-left: 0.3em;
+    padding: 1px 5px;
+    font-size: 0.7rem;
   }
 
   .verify-actions {

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -504,7 +504,7 @@
   }
 
   async function toggleNatsChat() {
-    await fetch("/api/global-settings/nats_chat_enabled", {
+    await fetch("/api/instance-settings/nats_chat_enabled", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ value: natsChatEnabled ? "true" : "false" }),
@@ -512,7 +512,7 @@
   }
 
   async function toggleNatsLobby() {
-    await fetch("/api/global-settings/nats_lobby_enabled", {
+    await fetch("/api/instance-settings/nats_lobby_enabled", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ value: natsLobbyEnabled ? "true" : "false" }),
@@ -522,8 +522,8 @@
   async function loadNatsChatSettings() {
     try {
       const [chatRes, lobbyRes] = await Promise.all([
-        fetch("/api/global-settings/nats_chat_enabled"),
-        fetch("/api/global-settings/nats_lobby_enabled"),
+        fetch("/api/instance-settings/nats_chat_enabled"),
+        fetch("/api/instance-settings/nats_lobby_enabled"),
       ]);
       if (chatRes.ok) {
         const d = await chatRes.json();

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -437,6 +437,8 @@
   let natsCertInfo = { ca_fingerprint: null, client_fingerprint: null, cn: null, has_key: false };
   let natsSaving = false;
   let natsReplacing = { ca: false, cert: false, key: false };
+  let natsChatEnabled = false;
+  let natsLobbyEnabled = false;
 
   async function loadNatsStatus() {
     try {
@@ -494,6 +496,39 @@
       else if (field === "key") natsClientKey = e.target.result;
     };
     reader.readAsText(file);
+  }
+
+  async function toggleNatsChat() {
+    await fetch("/api/global-settings/nats_chat_enabled", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ value: natsChatEnabled ? "true" : "false" }),
+    });
+  }
+
+  async function toggleNatsLobby() {
+    await fetch("/api/global-settings/nats_lobby_enabled", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ value: natsLobbyEnabled ? "true" : "false" }),
+    });
+  }
+
+  async function loadNatsChatSettings() {
+    try {
+      const [chatRes, lobbyRes] = await Promise.all([
+        fetch("/api/global-settings/nats_chat_enabled"),
+        fetch("/api/global-settings/nats_lobby_enabled"),
+      ]);
+      if (chatRes.ok) {
+        const d = await chatRes.json();
+        natsChatEnabled = d.value === "true";
+      }
+      if (lobbyRes.ok) {
+        const d = await lobbyRes.json();
+        natsLobbyEnabled = d.value === "true";
+      }
+    } catch {}
   }
 
   async function loadTlsStatus() {
@@ -1481,6 +1516,7 @@
     loadTlsStatus();
     loadNatsStatus();
     loadNatsCerts();
+    loadNatsChatSettings();
     function onNatsStatus(e) { natsStatus = e.detail; }
     window.addEventListener("nats-status", onNatsStatus);
     natsCleanup = () => window.removeEventListener("nats-status", onNatsStatus);
@@ -2427,6 +2463,29 @@
         </button>
       </div>
     </section>
+
+    {#if natsStatus.state === "connected"}
+    <section class="settings-section">
+      <h3>NATS Chat</h3>
+      <div class="setting-row">
+        <label class="toggle-label">
+          <input type="checkbox" bind:checked={natsChatEnabled} on:change={toggleNatsChat} />
+          Enable NATS Chat
+        </label>
+      </div>
+      <p class="hint">Enable peer-to-peer chat via NATS with identity verification.</p>
+      {#if natsChatEnabled}
+      <div class="setting-row" style="margin-left: 1.5em;">
+        <label class="toggle-label">
+          <input type="checkbox" bind:checked={natsLobbyEnabled} on:change={toggleNatsLobby} />
+          Join Public Lobby
+        </label>
+      </div>
+      <p class="hint" style="margin-left: 1.5em;">Discover peers and chat publicly. Disable to use only private rooms.</p>
+      {/if}
+    </section>
+    {/if}
+
     {/if}
   </div></div>
   {/if}

--- a/src/guidebook/chat.py
+++ b/src/guidebook/chat.py
@@ -243,6 +243,7 @@ async def _on_verify_message(msg):
                 {"cn": from_cn, "fingerprint": from_fp, "room_id": room_id},
             )
             _broadcast_chat_event("chat-rooms", {"rooms": get_rooms()})
+            await _publish_presence()
             return
 
         # Store as pending incoming request for UI
@@ -315,6 +316,7 @@ async def _on_verify_message(msg):
             {"cn": from_cn, "fingerprint": from_fp, "room_id": room_id},
         )
         _broadcast_chat_event("chat-rooms", {"rooms": get_rooms()})
+        await _publish_presence()
 
 
 def _verify_signature(cert_pem: str, nonce: str, signature_b64: str) -> bool:
@@ -559,24 +561,27 @@ async def _subscribe_dm(room_id: str):
     logger.info("Subscribed to DM room %s", room_id[:16])
 
 
-async def _presence_loop():
-    """Periodically publish presence and prune stale peers."""
+async def _publish_presence():
+    """Publish presence to the lobby."""
     from guidebook.nats_client import get_client
 
+    nc = get_client()
+    if nc and nc.is_connected and _lobby_enabled and _own_fingerprint:
+        presence = {
+            "type": "presence",
+            "cn": _own_cn,
+            "fingerprint": _own_fingerprint,
+            "cert_pem": _own_cert_pem,
+            "timestamp": time.time(),
+        }
+        await nc.publish("guidebook.chat.lobby", json.dumps(presence).encode())
+
+
+async def _presence_loop():
+    """Periodically publish presence and prune stale peers."""
     while True:
         try:
-            nc = get_client()
-            if nc and nc.is_connected and _lobby_enabled and _own_fingerprint:
-                presence = {
-                    "type": "presence",
-                    "cn": _own_cn,
-                    "fingerprint": _own_fingerprint,
-                    "cert_pem": _own_cert_pem,
-                    "timestamp": time.time(),
-                }
-                await nc.publish(
-                    "guidebook.chat.lobby", json.dumps(presence).encode()
-                )
+            await _publish_presence()
 
             # Prune stale peers
             now = time.time()

--- a/src/guidebook/chat.py
+++ b/src/guidebook/chat.py
@@ -175,6 +175,15 @@ async def _on_verify_message(msg):
         if reciprocal and from_fp in _trusted:
             # Auto-respond to reciprocal challenges from already-accepted peers
             await _sign_and_respond(from_fp, nonce)
+            # Subscribe to private room (the initiator already did on their side)
+            _trusted[from_fp]["mutual"] = True
+            room_id = _derive_room_id(_own_fingerprint, from_fp)
+            await _subscribe_dm(room_id)
+            _broadcast_chat_event(
+                "chat-verify-complete",
+                {"cn": from_cn, "fingerprint": from_fp, "room_id": room_id},
+            )
+            _broadcast_chat_event("chat-rooms", {"rooms": get_rooms()})
             return
 
         # Store as pending incoming request for UI

--- a/src/guidebook/chat.py
+++ b/src/guidebook/chat.py
@@ -1,0 +1,637 @@
+"""NATS Chat manager.
+
+Provides lobby presence/chat, challenge-response peer verification,
+trusted contacts, and deterministic private room derivation.
+"""
+
+import asyncio
+import base64
+import hashlib
+import json
+import logging
+import os
+import time
+from collections import deque
+
+logger = logging.getLogger("guidebook.chat")
+
+# --- Module state ---
+_chat_task: asyncio.Task | None = None
+_lobby_sub = None
+_verify_sub = None
+_dm_subs: dict[str, object] = {}  # room_id -> NATS subscription
+
+_peers: dict[str, dict] = {}  # fingerprint -> {cn, last_seen, cert_pem}
+_trusted: dict[str, dict] = {}  # fingerprint -> {cn, cert_pem, verified_at, mutual}
+_pending_challenges: dict[str, dict] = {}  # fingerprint -> {nonce, timestamp}
+_pending_incoming: dict[str, dict] = {}  # fingerprint -> {from_cn, from_fingerprint, nonce}
+
+_chat_buffers: dict[str, deque] = {}  # room_id -> deque of messages
+_buffer_sizes: dict[str, int] = {}  # room_id -> current buffer size in bytes
+BUFFER_MAX_BYTES = 100_000  # 100KB per room
+
+_lobby_enabled = False
+_own_cn: str | None = None
+_own_fingerprint: str | None = None
+_own_cert_pem: str | None = None
+
+
+def _broadcast_chat_event(event_type: str, data: dict):
+    from guidebook.sse import broadcast
+
+    broadcast(event_type, data)
+
+
+def _append_message(room_id: str, msg: dict):
+    if room_id not in _chat_buffers:
+        _chat_buffers[room_id] = deque()
+        _buffer_sizes[room_id] = 0
+    buf = _chat_buffers[room_id]
+    msg_bytes = len(json.dumps(msg).encode())
+    buf.append(msg)
+    _buffer_sizes[room_id] += msg_bytes
+    # Evict oldest messages if over limit
+    while _buffer_sizes[room_id] > BUFFER_MAX_BYTES and buf:
+        old = buf.popleft()
+        _buffer_sizes[room_id] -= len(json.dumps(old).encode())
+
+
+def _derive_room_id(fp_a: str, fp_b: str) -> str:
+    """Derive a deterministic private room subject from two fingerprints."""
+    parts = sorted([fp_a, fp_b])
+    h = hashlib.sha256((parts[0] + parts[1]).encode()).hexdigest()
+    return h
+
+
+def get_peers() -> list[dict]:
+    now = time.time()
+    return [
+        {"cn": p["cn"], "fingerprint": fp, "last_seen": p["last_seen"]}
+        for fp, p in _peers.items()
+        if now - p["last_seen"] < 60 and fp != _own_fingerprint
+    ]
+
+
+def get_trusted() -> list[dict]:
+    return [
+        {
+            "cn": t["cn"],
+            "fingerprint": fp,
+            "verified_at": t["verified_at"],
+            "mutual": t["mutual"],
+        }
+        for fp, t in _trusted.items()
+    ]
+
+
+def get_pending_incoming() -> list[dict]:
+    return [
+        {"cn": v["from_cn"], "fingerprint": v["from_fingerprint"], "nonce": v["nonce"]}
+        for v in _pending_incoming.values()
+    ]
+
+
+def get_rooms() -> list[dict]:
+    rooms = []
+    if _lobby_enabled:
+        rooms.append(
+            {
+                "id": "lobby",
+                "type": "lobby",
+                "name": "Public Lobby",
+                "subject": "guidebook.chat.lobby",
+            }
+        )
+    for fp, t in _trusted.items():
+        if t["mutual"]:
+            room_id = _derive_room_id(_own_fingerprint, fp)
+            rooms.append(
+                {
+                    "id": room_id,
+                    "type": "dm",
+                    "name": t["cn"],
+                    "fingerprint": fp,
+                    "subject": f"guidebook.chat.dm.{room_id}",
+                }
+            )
+    return rooms
+
+
+def get_messages(room_id: str, limit: int = 100) -> list[dict]:
+    buf = _chat_buffers.get(room_id, deque())
+    msgs = list(buf)
+    if limit and len(msgs) > limit:
+        msgs = msgs[-limit:]
+    return msgs
+
+
+async def _on_lobby_message(msg):
+    try:
+        data = json.loads(msg.data.decode())
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return
+
+    msg_type = data.get("type")
+    fp = data.get("fingerprint")
+    cn = data.get("cn", "unknown")
+
+    if msg_type == "presence":
+        if fp and fp != _own_fingerprint:
+            is_new = fp not in _peers
+            _peers[fp] = {
+                "cn": cn,
+                "last_seen": time.time(),
+                "cert_pem": data.get("cert_pem"),
+            }
+            if is_new:
+                _broadcast_chat_event("chat-peers", {"peers": get_peers()})
+
+    elif msg_type == "message":
+        chat_msg = {
+            "room": "lobby",
+            "cn": cn,
+            "fingerprint": fp,
+            "text": data.get("text", ""),
+            "ts": data.get("ts", time.time()),
+        }
+        _append_message("lobby", chat_msg)
+        _broadcast_chat_event("chat-message", chat_msg)
+
+
+async def _on_verify_message(msg):
+    try:
+        data = json.loads(msg.data.decode())
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return
+
+    msg_type = data.get("type")
+    from_fp = data.get("from_fingerprint")
+    from_cn = data.get("from_cn", "unknown")
+
+    if msg_type == "challenge":
+        nonce = data.get("nonce")
+        reciprocal = data.get("reciprocal", False)
+
+        if reciprocal and from_fp in _trusted:
+            # Auto-respond to reciprocal challenges from already-accepted peers
+            await _sign_and_respond(from_fp, nonce)
+            return
+
+        # Store as pending incoming request for UI
+        _pending_incoming[from_fp] = {
+            "from_cn": from_cn,
+            "from_fingerprint": from_fp,
+            "nonce": nonce,
+        }
+        _broadcast_chat_event(
+            "chat-verify-request",
+            {"cn": from_cn, "fingerprint": from_fp},
+        )
+        logger.info("Verification request from %s (%s)", from_cn, from_fp[:16])
+
+    elif msg_type == "response":
+        nonce = data.get("nonce")
+        signature = data.get("signature")
+        cert_pem = data.get("cert_pem")
+
+        if from_fp not in _pending_challenges:
+            return
+        expected_nonce = _pending_challenges[from_fp]["nonce"]
+        if nonce != expected_nonce:
+            logger.warning("Nonce mismatch in verification response from %s", from_cn)
+            return
+
+        # Verify the signature
+        if not cert_pem or not signature:
+            logger.warning("Missing cert or signature in response from %s", from_cn)
+            return
+
+        if not _verify_signature(cert_pem, nonce, signature):
+            logger.warning("Invalid signature in verification response from %s", from_cn)
+            return
+
+        # Verify fingerprint matches the cert they provided
+        from guidebook.nats_client import compute_fingerprint
+
+        actual_fp = compute_fingerprint(cert_pem)
+        if actual_fp != from_fp:
+            logger.warning(
+                "Fingerprint mismatch: advertised %s, cert has %s",
+                from_fp[:16],
+                (actual_fp or "none")[:16],
+            )
+            return
+
+        # Trust established!
+        del _pending_challenges[from_fp]
+        already_trusted = from_fp in _trusted
+        _trusted[from_fp] = {
+            "cn": from_cn,
+            "cert_pem": cert_pem,
+            "verified_at": time.time(),
+            "mutual": True,
+        }
+        logger.info("Verified peer %s (%s)", from_cn, from_fp[:16])
+
+        if not already_trusted:
+            # Send reciprocal challenge so they can verify us too
+            await _send_challenge(from_fp, reciprocal=True)
+
+        # Subscribe to private room
+        room_id = _derive_room_id(_own_fingerprint, from_fp)
+        await _subscribe_dm(room_id)
+
+        _broadcast_chat_event(
+            "chat-verify-complete",
+            {"cn": from_cn, "fingerprint": from_fp, "room_id": room_id},
+        )
+        _broadcast_chat_event("chat-rooms", {"rooms": get_rooms()})
+
+
+def _verify_signature(cert_pem: str, nonce: str, signature_b64: str) -> bool:
+    try:
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+        from cryptography.x509 import load_pem_x509_certificate
+
+        cert = load_pem_x509_certificate(cert_pem.encode())
+        public_key = cert.public_key()
+        sig_bytes = base64.b64decode(signature_b64)
+        nonce_bytes = nonce.encode()
+
+        if isinstance(public_key, rsa.RSAPublicKey):
+            public_key.verify(sig_bytes, nonce_bytes, padding.PKCS1v15(), hashes.SHA256())
+        elif isinstance(public_key, ec.EllipticCurvePublicKey):
+            public_key.verify(sig_bytes, nonce_bytes, ec.ECDSA(hashes.SHA256()))
+        else:
+            logger.warning("Unsupported key type: %s", type(public_key))
+            return False
+        return True
+    except Exception as e:
+        logger.warning("Signature verification failed: %s", e)
+        return False
+
+
+def _sign_nonce(key_pem: str, nonce: str) -> str | None:
+    try:
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.serialization import load_pem_private_key
+        from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+
+        private_key = load_pem_private_key(key_pem.encode(), password=None)
+        nonce_bytes = nonce.encode()
+
+        if isinstance(private_key, rsa.RSAPrivateKey):
+            sig = private_key.sign(nonce_bytes, padding.PKCS1v15(), hashes.SHA256())
+        elif isinstance(private_key, ec.EllipticCurvePrivateKey):
+            sig = private_key.sign(nonce_bytes, ec.ECDSA(hashes.SHA256()))
+        else:
+            logger.warning("Unsupported key type for signing: %s", type(private_key))
+            return None
+        return base64.b64encode(sig).decode()
+    except Exception as e:
+        logger.warning("Failed to sign nonce: %s", e)
+        return None
+
+
+async def _sign_and_respond(peer_fingerprint: str, nonce: str):
+    from guidebook.nats_client import get_client, get_own_cert_pem, get_own_key_pem
+
+    nc = get_client()
+    if not nc or not nc.is_connected:
+        return
+
+    key_pem = await get_own_key_pem()
+    cert_pem = await get_own_cert_pem()
+    if not key_pem or not cert_pem:
+        return
+
+    signature = _sign_nonce(key_pem, nonce)
+    if not signature:
+        return
+
+    response = {
+        "type": "response",
+        "from_cn": _own_cn,
+        "from_fingerprint": _own_fingerprint,
+        "nonce": nonce,
+        "signature": signature,
+        "cert_pem": cert_pem,
+    }
+    # Sanitize fingerprint for NATS subject (remove colons)
+    subject_fp = peer_fingerprint.replace(":", "")
+    await nc.publish(
+        f"guidebook.chat.verify.{subject_fp}",
+        json.dumps(response).encode(),
+    )
+    logger.info("Sent verification response to %s", peer_fingerprint[:16])
+
+
+async def _send_challenge(peer_fingerprint: str, reciprocal: bool = False):
+    from guidebook.nats_client import get_client
+
+    nc = get_client()
+    if not nc or not nc.is_connected:
+        return
+
+    nonce = os.urandom(32).hex()
+    _pending_challenges[peer_fingerprint] = {"nonce": nonce, "timestamp": time.time()}
+
+    challenge = {
+        "type": "challenge",
+        "from_cn": _own_cn,
+        "from_fingerprint": _own_fingerprint,
+        "nonce": nonce,
+    }
+    if reciprocal:
+        challenge["reciprocal"] = True
+
+    subject_fp = peer_fingerprint.replace(":", "")
+    await nc.publish(
+        f"guidebook.chat.verify.{subject_fp}",
+        json.dumps(challenge).encode(),
+    )
+    logger.info(
+        "Sent %schallenge to %s",
+        "reciprocal " if reciprocal else "",
+        peer_fingerprint[:16],
+    )
+
+
+async def initiate_verification(peer_fingerprint: str):
+    await _send_challenge(peer_fingerprint)
+
+
+async def accept_verification(peer_fingerprint: str):
+    incoming = _pending_incoming.pop(peer_fingerprint, None)
+    if not incoming:
+        return
+
+    # Sign the nonce and respond
+    await _sign_and_respond(peer_fingerprint, incoming["nonce"])
+
+    # Mark as trusted (not yet mutual until they send reciprocal)
+    peer_info = _peers.get(peer_fingerprint, {})
+    _trusted[peer_fingerprint] = {
+        "cn": incoming["from_cn"],
+        "cert_pem": peer_info.get("cert_pem"),
+        "verified_at": time.time(),
+        "mutual": False,
+    }
+    logger.info(
+        "Accepted verification from %s (%s)",
+        incoming["from_cn"],
+        peer_fingerprint[:16],
+    )
+
+
+async def reject_verification(peer_fingerprint: str):
+    _pending_incoming.pop(peer_fingerprint, None)
+    logger.info("Rejected verification from %s", peer_fingerprint[:16])
+
+
+async def send_lobby_message(text: str):
+    from guidebook.nats_client import get_client
+
+    nc = get_client()
+    if not nc or not nc.is_connected or not _lobby_enabled:
+        return
+
+    msg = {
+        "type": "message",
+        "cn": _own_cn,
+        "fingerprint": _own_fingerprint,
+        "text": text,
+        "ts": time.time(),
+    }
+    await nc.publish("guidebook.chat.lobby", json.dumps(msg).encode())
+
+
+async def send_dm_message(room_id: str, text: str):
+    from guidebook.nats_client import get_client
+
+    nc = get_client()
+    if not nc or not nc.is_connected:
+        return
+
+    msg = {
+        "type": "message",
+        "cn": _own_cn,
+        "fingerprint": _own_fingerprint,
+        "text": text,
+        "ts": time.time(),
+    }
+    await nc.publish(f"guidebook.chat.dm.{room_id}", json.dumps(msg).encode())
+    # Also store locally since we won't receive our own message
+    chat_msg = {
+        "room": room_id,
+        "cn": _own_cn,
+        "fingerprint": _own_fingerprint,
+        "text": text,
+        "ts": msg["ts"],
+    }
+    _append_message(room_id, chat_msg)
+    _broadcast_chat_event("chat-message", chat_msg)
+
+
+async def _on_dm_message(room_id: str):
+    async def handler(msg):
+        try:
+            data = json.loads(msg.data.decode())
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return
+        # Skip our own messages
+        if data.get("fingerprint") == _own_fingerprint:
+            return
+        chat_msg = {
+            "room": room_id,
+            "cn": data.get("cn", "unknown"),
+            "fingerprint": data.get("fingerprint"),
+            "text": data.get("text", ""),
+            "ts": data.get("ts", time.time()),
+        }
+        _append_message(room_id, chat_msg)
+        _broadcast_chat_event("chat-message", chat_msg)
+
+    return handler
+
+
+async def _subscribe_dm(room_id: str):
+    from guidebook.nats_client import get_client
+
+    nc = get_client()
+    if not nc or not nc.is_connected:
+        return
+    if room_id in _dm_subs:
+        return
+    handler = await _on_dm_message(room_id)
+    sub = await nc.subscribe(f"guidebook.chat.dm.{room_id}", cb=handler)
+    _dm_subs[room_id] = sub
+    logger.info("Subscribed to DM room %s", room_id[:16])
+
+
+async def _presence_loop():
+    """Periodically publish presence and prune stale peers."""
+    from guidebook.nats_client import get_client
+
+    while True:
+        try:
+            nc = get_client()
+            if nc and nc.is_connected and _lobby_enabled and _own_fingerprint:
+                presence = {
+                    "type": "presence",
+                    "cn": _own_cn,
+                    "fingerprint": _own_fingerprint,
+                    "cert_pem": _own_cert_pem,
+                    "timestamp": time.time(),
+                }
+                await nc.publish(
+                    "guidebook.chat.lobby", json.dumps(presence).encode()
+                )
+
+            # Prune stale peers
+            now = time.time()
+            stale = [fp for fp, p in _peers.items() if now - p["last_seen"] > 60]
+            if stale:
+                for fp in stale:
+                    del _peers[fp]
+                _broadcast_chat_event("chat-peers", {"peers": get_peers()})
+
+        except Exception as e:
+            logger.warning("Presence loop error: %s", e)
+
+        await asyncio.sleep(30)
+
+
+async def join_lobby():
+    global _lobby_sub, _lobby_enabled
+    from guidebook.nats_client import get_client
+
+    nc = get_client()
+    if not nc or not nc.is_connected:
+        return
+    if _lobby_sub is not None:
+        return
+
+    _lobby_enabled = True
+    _lobby_sub = await nc.subscribe("guidebook.chat.lobby", cb=_on_lobby_message)
+    logger.info("Joined public lobby")
+
+    # Publish initial presence
+    if _own_fingerprint:
+        presence = {
+            "type": "presence",
+            "cn": _own_cn,
+            "fingerprint": _own_fingerprint,
+            "cert_pem": _own_cert_pem,
+            "timestamp": time.time(),
+        }
+        await nc.publish("guidebook.chat.lobby", json.dumps(presence).encode())
+
+
+async def leave_lobby():
+    global _lobby_sub, _lobby_enabled
+    _lobby_enabled = False
+    if _lobby_sub is not None:
+        try:
+            await _lobby_sub.unsubscribe()
+        except Exception:
+            pass
+        _lobby_sub = None
+    _peers.clear()
+    _chat_buffers.pop("lobby", None)
+    _buffer_sizes.pop("lobby", None)
+    _broadcast_chat_event("chat-peers", {"peers": []})
+    logger.info("Left public lobby")
+
+
+async def start_chat():
+    global _chat_task, _verify_sub, _own_cn, _own_fingerprint, _own_cert_pem
+    from guidebook.nats_client import (
+        get_client,
+        get_own_cert_pem,
+        get_own_cn,
+        get_own_fingerprint,
+    )
+
+    nc = get_client()
+    if not nc or not nc.is_connected:
+        logger.warning("Cannot start chat: NATS not connected")
+        return
+
+    _own_cn = await get_own_cn()
+    _own_fingerprint = await get_own_fingerprint()
+    _own_cert_pem = await get_own_cert_pem()
+
+    if not _own_fingerprint:
+        logger.warning("Cannot start chat: no client certificate configured")
+        return
+
+    # Subscribe to verification subject
+    subject_fp = _own_fingerprint.replace(":", "")
+    _verify_sub = await nc.subscribe(
+        f"guidebook.chat.verify.{subject_fp}", cb=_on_verify_message
+    )
+    logger.info("Chat started (CN=%s)", _own_cn)
+
+    # Check if lobby should be joined
+    from sqlalchemy import select
+
+    from guidebook.db import GlobalSetting, global_async_session
+
+    async with global_async_session() as gdb:
+        row = (
+            await gdb.execute(
+                select(GlobalSetting).where(GlobalSetting.key == "nats_lobby_enabled")
+            )
+        ).scalar_one_or_none()
+        lobby_enabled = row and row.value == "true"
+
+    if lobby_enabled:
+        await join_lobby()
+
+    # Start presence loop
+    if _chat_task is None:
+        _chat_task = asyncio.create_task(_presence_loop())
+
+
+async def stop_chat():
+    global _chat_task, _verify_sub, _lobby_sub, _lobby_enabled
+    global _own_cn, _own_fingerprint, _own_cert_pem
+
+    if _chat_task is not None:
+        _chat_task.cancel()
+        try:
+            await _chat_task
+        except asyncio.CancelledError:
+            pass
+        _chat_task = None
+
+    if _verify_sub is not None:
+        try:
+            await _verify_sub.unsubscribe()
+        except Exception:
+            pass
+        _verify_sub = None
+
+    await leave_lobby()
+
+    # Unsubscribe from all DM rooms
+    for room_id, sub in list(_dm_subs.items()):
+        try:
+            await sub.unsubscribe()
+        except Exception:
+            pass
+    _dm_subs.clear()
+
+    _peers.clear()
+    _trusted.clear()
+    _pending_challenges.clear()
+    _pending_incoming.clear()
+    _chat_buffers.clear()
+    _buffer_sizes.clear()
+    _lobby_enabled = False
+    _own_cn = None
+    _own_fingerprint = None
+    _own_cert_pem = None
+    logger.info("Chat stopped")

--- a/src/guidebook/chat.py
+++ b/src/guidebook/chat.py
@@ -577,12 +577,12 @@ async def start_chat():
     # Check if lobby should be joined
     from sqlalchemy import select
 
-    from guidebook.db import GlobalSetting, global_async_session
+    from guidebook.db import InstanceSetting, instance_async_session
 
-    async with global_async_session() as gdb:
+    async with instance_async_session() as db:
         row = (
-            await gdb.execute(
-                select(GlobalSetting).where(GlobalSetting.key == "nats_lobby_enabled")
+            await db.execute(
+                select(InstanceSetting).where(InstanceSetting.key == "nats_lobby_enabled")
             )
         ).scalar_one_or_none()
         lobby_enabled = row and row.value == "true"

--- a/src/guidebook/chat.py
+++ b/src/guidebook/chat.py
@@ -56,6 +56,73 @@ def _append_message(room_id: str, msg: dict):
         _buffer_sizes[room_id] -= len(json.dumps(old).encode())
 
 
+async def _save_trusted_peer(fingerprint: str, info: dict):
+    """Persist a trusted peer to the instance database."""
+    from sqlalchemy import select
+
+    from guidebook.db import TrustedPeer, instance_async_session
+
+    async with instance_async_session() as db:
+        row = (
+            await db.execute(
+                select(TrustedPeer).where(TrustedPeer.fingerprint == fingerprint)
+            )
+        ).scalar_one_or_none()
+        if row:
+            row.cn = info["cn"]
+            row.cert_pem = info.get("cert_pem")
+            row.verified_at = info["verified_at"]
+            row.mutual = 1 if info["mutual"] else 0
+        else:
+            db.add(
+                TrustedPeer(
+                    fingerprint=fingerprint,
+                    cn=info["cn"],
+                    cert_pem=info.get("cert_pem"),
+                    verified_at=info["verified_at"],
+                    mutual=1 if info["mutual"] else 0,
+                )
+            )
+        await db.commit()
+
+
+async def _delete_trusted_peer(fingerprint: str):
+    """Remove a trusted peer from the instance database."""
+    from sqlalchemy import delete
+
+    from guidebook.db import TrustedPeer, instance_async_session
+
+    async with instance_async_session() as db:
+        await db.execute(
+            delete(TrustedPeer).where(TrustedPeer.fingerprint == fingerprint)
+        )
+        await db.commit()
+
+
+async def _load_trusted_peers():
+    """Load trusted peers from the database into memory and subscribe to DM rooms."""
+    from sqlalchemy import select
+
+    from guidebook.db import TrustedPeer, instance_async_session
+
+    async with instance_async_session() as db:
+        rows = (await db.execute(select(TrustedPeer))).scalars().all()
+
+    for row in rows:
+        _trusted[row.fingerprint] = {
+            "cn": row.cn,
+            "cert_pem": row.cert_pem,
+            "verified_at": row.verified_at,
+            "mutual": bool(row.mutual),
+        }
+        if row.mutual:
+            room_id = _derive_room_id(_own_fingerprint, row.fingerprint)
+            await _subscribe_dm(room_id)
+
+    if rows:
+        logger.info("Loaded %d trusted peers from database", len(rows))
+
+
 def _derive_room_id(fp_a: str, fp_b: str) -> str:
     """Derive a deterministic private room subject from two fingerprints."""
     parts = sorted([fp_a, fp_b])
@@ -168,6 +235,7 @@ async def _on_verify_message(msg):
             await _sign_and_respond(from_fp, nonce)
             # Subscribe to private room (the initiator already did on their side)
             _trusted[from_fp]["mutual"] = True
+            await _save_trusted_peer(from_fp, _trusted[from_fp])
             room_id = _derive_room_id(_own_fingerprint, from_fp)
             await _subscribe_dm(room_id)
             _broadcast_chat_event(
@@ -231,6 +299,7 @@ async def _on_verify_message(msg):
             "verified_at": time.time(),
             "mutual": True,
         }
+        await _save_trusted_peer(from_fp, _trusted[from_fp])
         logger.info("Verified peer %s (%s)", from_cn, from_fp[:16])
 
         if not already_trusted:
@@ -378,6 +447,7 @@ async def accept_verification(peer_fingerprint: str):
         "verified_at": time.time(),
         "mutual": False,
     }
+    await _save_trusted_peer(peer_fingerprint, _trusted[peer_fingerprint])
     logger.info(
         "Accepted verification from %s (%s)",
         incoming["from_cn"],
@@ -439,6 +509,7 @@ async def remove_trusted(peer_fingerprint: str):
     if peer_fingerprint not in _trusted:
         return
     del _trusted[peer_fingerprint]
+    await _delete_trusted_peer(peer_fingerprint)
     room_id = _derive_room_id(_own_fingerprint, peer_fingerprint)
     sub = _dm_subs.pop(room_id, None)
     if sub:
@@ -591,6 +662,9 @@ async def start_chat():
         f"guidebook.chat.verify.{subject_fp}", cb=_on_verify_message
     )
     logger.info("Chat started (CN=%s)", _own_cn)
+
+    # Load persisted trusted peers and subscribe to their DM rooms
+    await _load_trusted_peers()
 
     # Check if lobby should be joined
     from sqlalchemy import select

--- a/src/guidebook/chat.py
+++ b/src/guidebook/chat.py
@@ -434,6 +434,24 @@ async def send_dm_message(room_id: str, text: str):
     _broadcast_chat_event("chat-message", chat_msg)
 
 
+async def remove_trusted(peer_fingerprint: str):
+    """Remove a trusted peer and unsubscribe from their DM room."""
+    if peer_fingerprint not in _trusted:
+        return
+    del _trusted[peer_fingerprint]
+    room_id = _derive_room_id(_own_fingerprint, peer_fingerprint)
+    sub = _dm_subs.pop(room_id, None)
+    if sub:
+        try:
+            await sub.unsubscribe()
+        except Exception:
+            pass
+    _chat_buffers.pop(room_id, None)
+    _buffer_sizes.pop(room_id, None)
+    _broadcast_chat_event("chat-rooms", {"rooms": get_rooms()})
+    logger.info("Removed trusted peer %s, left room %s", peer_fingerprint[:16], room_id[:16])
+
+
 async def _on_dm_message(room_id: str):
     async def handler(msg):
         try:

--- a/src/guidebook/chat.py
+++ b/src/guidebook/chat.py
@@ -318,6 +318,26 @@ async def _on_verify_message(msg):
         _broadcast_chat_event("chat-rooms", {"rooms": get_rooms()})
         await _publish_presence()
 
+    elif msg_type == "defriend":
+        if from_fp in _trusted:
+            logger.info("Received defriend from %s (%s)", from_cn, from_fp[:16])
+            del _trusted[from_fp]
+            await _delete_trusted_peer(from_fp)
+            room_id = _derive_room_id(_own_fingerprint, from_fp)
+            sub = _dm_subs.pop(room_id, None)
+            if sub:
+                try:
+                    await sub.unsubscribe()
+                except Exception:
+                    pass
+            _chat_buffers.pop(room_id, None)
+            _buffer_sizes.pop(room_id, None)
+            _broadcast_chat_event("chat-rooms", {"rooms": get_rooms()})
+            _broadcast_chat_event(
+                "chat-defriended",
+                {"cn": from_cn, "fingerprint": from_fp},
+            )
+
 
 def _verify_signature(cert_pem: str, nonce: str, signature_b64: str) -> bool:
     try:
@@ -507,9 +527,25 @@ async def send_dm_message(room_id: str, text: str):
 
 
 async def remove_trusted(peer_fingerprint: str):
-    """Remove a trusted peer and unsubscribe from their DM room."""
+    """Remove a trusted peer, notify them, and unsubscribe from their DM room."""
     if peer_fingerprint not in _trusted:
         return
+
+    # Send defriend notice to the peer
+    from guidebook.nats_client import get_client
+
+    nc = get_client()
+    if nc and nc.is_connected:
+        subject_fp = peer_fingerprint.replace(":", "")
+        msg = {
+            "type": "defriend",
+            "from_fingerprint": _own_fingerprint,
+            "from_cn": _own_cn,
+        }
+        await nc.publish(
+            f"guidebook.chat.verify.{subject_fp}", json.dumps(msg).encode()
+        )
+
     del _trusted[peer_fingerprint]
     await _delete_trusted_peer(peer_fingerprint)
     room_id = _derive_room_id(_own_fingerprint, peer_fingerprint)

--- a/src/guidebook/chat.py
+++ b/src/guidebook/chat.py
@@ -93,15 +93,6 @@ def get_pending_incoming() -> list[dict]:
 
 def get_rooms() -> list[dict]:
     rooms = []
-    if _lobby_enabled:
-        rooms.append(
-            {
-                "id": "lobby",
-                "type": "lobby",
-                "name": "Public Lobby",
-                "subject": "guidebook.chat.lobby",
-            }
-        )
     for fp, t in _trusted.items():
         if t["mutual"]:
             room_id = _derive_room_id(_own_fingerprint, fp)

--- a/src/guidebook/db.py
+++ b/src/guidebook/db.py
@@ -79,6 +79,8 @@ GLOBAL_ONLY_KEYS = {
     "nats_ca_cert",
     "nats_client_cert",
     "nats_client_key",
+    "nats_chat_enabled",
+    "nats_lobby_enabled",
 }
 
 

--- a/src/guidebook/db.py
+++ b/src/guidebook/db.py
@@ -263,6 +263,17 @@ class ClientCert(InstanceBase):
     pending_session_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
 
+class TrustedPeer(InstanceBase):
+    __tablename__ = "trusted_peers"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    fingerprint: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    cn: Mapped[str] = mapped_column(String, nullable=False)
+    cert_pem: Mapped[str | None] = mapped_column(String, nullable=True)
+    verified_at: Mapped[float] = mapped_column(Float, nullable=False)
+    mutual: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+
 class DatabaseLockError(Exception):
     """Raised when the database is already locked by another process."""
 

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -128,20 +128,8 @@ async def lifespan(app: FastAPI):
     from guidebook.nats_client import start_nats, stop_nats
 
     await start_nats()
-    # Start chat if NATS chat is enabled (checked inside start_chat)
-    from guidebook.chat import start_chat, stop_chat
-    from guidebook.db import GlobalSetting
-
-    async with global_async_session() as _gdb:
-        _chat_row = (
-            await _gdb.execute(
-                select(GlobalSetting).where(GlobalSetting.key == "nats_chat_enabled")
-            )
-        ).scalar_one_or_none()
-        if _chat_row and _chat_row.value == "true":
-            await start_chat()
     yield
-    await stop_chat()
+    # stop_nats triggers _on_nats_disconnected which stops chat
     await stop_nats()
     await stop_acme_renewal()
     await stop_sse_auto_shutdown()

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -50,6 +50,7 @@ from guidebook.routes.scratchpad import router as scratchpad_router
 from guidebook.routes.media import router as media_router
 from guidebook.routes.mtls import router as mtls_router
 from guidebook.routes.nats import router as nats_router
+from guidebook.routes.chat import router as chat_router
 from guidebook.routes.tls import (
     router as tls_router,
     start_acme_renewal,
@@ -127,7 +128,20 @@ async def lifespan(app: FastAPI):
     from guidebook.nats_client import start_nats, stop_nats
 
     await start_nats()
+    # Start chat if NATS chat is enabled (checked inside start_chat)
+    from guidebook.chat import start_chat, stop_chat
+    from guidebook.db import GlobalSetting
+
+    async with global_async_session() as _gdb:
+        _chat_row = (
+            await _gdb.execute(
+                select(GlobalSetting).where(GlobalSetting.key == "nats_chat_enabled")
+            )
+        ).scalar_one_or_none()
+        if _chat_row and _chat_row.value == "true":
+            await start_chat()
     yield
+    await stop_chat()
     await stop_nats()
     await stop_acme_renewal()
     await stop_sse_auto_shutdown()
@@ -597,6 +611,7 @@ app.include_router(media_router)
 app.include_router(mtls_router)
 app.include_router(tls_router)
 app.include_router(nats_router)
+app.include_router(chat_router)
 app.include_router(sse_router)
 
 static_dir = _resource_path("static")

--- a/src/guidebook/nats_client.py
+++ b/src/guidebook/nats_client.py
@@ -162,14 +162,14 @@ async def _on_nats_connected():
     """Called when NATS transitions to connected state."""
     from sqlalchemy import select
 
-    from guidebook.db import GlobalSetting, global_async_session
+    from guidebook.db import InstanceSetting, instance_async_session
 
     try:
-        async with global_async_session() as gdb:
+        async with instance_async_session() as db:
             row = (
-                await gdb.execute(
-                    select(GlobalSetting).where(
-                        GlobalSetting.key == "nats_chat_enabled"
+                await db.execute(
+                    select(InstanceSetting).where(
+                        InstanceSetting.key == "nats_chat_enabled"
                     )
                 )
             ).scalar_one_or_none()

--- a/src/guidebook/nats_client.py
+++ b/src/guidebook/nats_client.py
@@ -24,6 +24,35 @@ def get_status() -> dict:
     return dict(_nats_status)
 
 
+def get_client():
+    """Return the active NATS client, or None if not connected."""
+    return _nats_client
+
+
+async def get_own_cert_pem() -> str | None:
+    """Return the stored client certificate PEM."""
+    settings = await _read_nats_settings()
+    return settings.get("nats_client_cert") or None
+
+
+async def get_own_key_pem() -> str | None:
+    """Return the stored client private key PEM."""
+    settings = await _read_nats_settings()
+    return settings.get("nats_client_key") or None
+
+
+async def get_own_cn() -> str | None:
+    """Return the CN from the stored client certificate."""
+    cert_pem = await get_own_cert_pem()
+    return extract_cn(cert_pem) if cert_pem else None
+
+
+async def get_own_fingerprint() -> str | None:
+    """Return the SHA-256 fingerprint of the stored client certificate."""
+    cert_pem = await get_own_cert_pem()
+    return compute_fingerprint(cert_pem) if cert_pem else None
+
+
 def compute_fingerprint(cert_pem: str) -> str | None:
     """Return the SHA-256 fingerprint of a PEM certificate."""
     try:

--- a/src/guidebook/nats_client.py
+++ b/src/guidebook/nats_client.py
@@ -143,10 +143,50 @@ def _cleanup_temp_files(paths: list[str]):
 
 def _set_status(state: str, detail: str | None = None, cn: str | None = None):
     global _nats_status
+    prev_state = _nats_status.get("state")
     _nats_status = {"state": state, "detail": detail, "cn": cn}
     from guidebook.sse import broadcast
 
     broadcast("nats-status", _nats_status)
+
+    # Start/stop chat on NATS connection state changes
+    if state == "connected" and prev_state != "connected":
+        asyncio.ensure_future(_on_nats_connected())
+    elif state != "connected" and prev_state == "connected":
+        asyncio.ensure_future(_on_nats_disconnected())
+
+
+async def _on_nats_connected():
+    """Called when NATS transitions to connected state."""
+    from sqlalchemy import select
+
+    from guidebook.db import GlobalSetting, global_async_session
+
+    try:
+        async with global_async_session() as gdb:
+            row = (
+                await gdb.execute(
+                    select(GlobalSetting).where(
+                        GlobalSetting.key == "nats_chat_enabled"
+                    )
+                )
+            ).scalar_one_or_none()
+            if row and row.value == "true":
+                from guidebook.chat import start_chat
+
+                await start_chat()
+    except Exception as e:
+        logger.warning("Failed to start chat on NATS connect: %s", e)
+
+
+async def _on_nats_disconnected():
+    """Called when NATS transitions away from connected state."""
+    try:
+        from guidebook.chat import stop_chat
+
+        await stop_chat()
+    except Exception as e:
+        logger.warning("Failed to stop chat on NATS disconnect: %s", e)
 
 
 async def _nats_connection_loop():

--- a/src/guidebook/routes/chat.py
+++ b/src/guidebook/routes/chat.py
@@ -1,0 +1,93 @@
+import logging
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from guidebook.chat import (
+    accept_verification,
+    get_messages,
+    get_peers,
+    get_pending_incoming,
+    get_rooms,
+    get_trusted,
+    initiate_verification,
+    reject_verification,
+    send_dm_message,
+    send_lobby_message,
+)
+
+logger = logging.getLogger("guidebook.chat")
+
+router = APIRouter(prefix="/api/chat", tags=["chat"])
+
+
+class SendMessage(BaseModel):
+    text: str
+
+
+@router.get("/status")
+async def chat_status():
+    from guidebook.chat import _own_cn, _own_fingerprint, _lobby_enabled, _verify_sub
+
+    return {
+        "active": _verify_sub is not None,
+        "cn": _own_cn,
+        "fingerprint": _own_fingerprint,
+        "lobby_joined": _lobby_enabled,
+        "peer_count": len(get_peers()),
+        "room_count": len(get_rooms()),
+    }
+
+
+@router.get("/peers")
+async def list_peers():
+    return get_peers()
+
+
+@router.get("/rooms")
+async def list_rooms():
+    return get_rooms()
+
+
+@router.get("/rooms/{room_id}/messages")
+async def room_messages(room_id: str, limit: int = 100):
+    return get_messages(room_id, limit)
+
+
+@router.post("/rooms/{room_id}/send")
+async def send_message(room_id: str, data: SendMessage):
+    if not data.text.strip():
+        raise HTTPException(status_code=400, detail="Empty message")
+    if room_id == "lobby":
+        await send_lobby_message(data.text)
+    else:
+        await send_dm_message(room_id, data.text)
+    return {"ok": True}
+
+
+@router.get("/trusted")
+async def list_trusted():
+    return get_trusted()
+
+
+@router.get("/verify/pending")
+async def list_pending():
+    return get_pending_incoming()
+
+
+@router.post("/verify/{fingerprint}")
+async def start_verification(fingerprint: str):
+    await initiate_verification(fingerprint)
+    return {"ok": True}
+
+
+@router.post("/verify/{fingerprint}/accept")
+async def accept_verify(fingerprint: str):
+    await accept_verification(fingerprint)
+    return {"ok": True}
+
+
+@router.post("/verify/{fingerprint}/reject")
+async def reject_verify(fingerprint: str):
+    await reject_verification(fingerprint)
+    return {"ok": True}

--- a/src/guidebook/routes/chat.py
+++ b/src/guidebook/routes/chat.py
@@ -12,6 +12,7 @@ from guidebook.chat import (
     get_trusted,
     initiate_verification,
     reject_verification,
+    remove_trusted,
     send_dm_message,
 )
 
@@ -66,6 +67,12 @@ async def send_message(room_id: str, data: SendMessage):
 @router.get("/trusted")
 async def list_trusted():
     return get_trusted()
+
+
+@router.delete("/trusted/{fingerprint}")
+async def delete_trusted(fingerprint: str):
+    await remove_trusted(fingerprint)
+    return {"ok": True}
 
 
 @router.get("/verify/pending")

--- a/src/guidebook/routes/chat.py
+++ b/src/guidebook/routes/chat.py
@@ -13,7 +13,6 @@ from guidebook.chat import (
     initiate_verification,
     reject_verification,
     send_dm_message,
-    send_lobby_message,
 )
 
 logger = logging.getLogger("guidebook.chat")
@@ -59,9 +58,8 @@ async def send_message(room_id: str, data: SendMessage):
     if not data.text.strip():
         raise HTTPException(status_code=400, detail="Empty message")
     if room_id == "lobby":
-        await send_lobby_message(data.text)
-    else:
-        await send_dm_message(room_id, data.text)
+        raise HTTPException(status_code=403, detail="Lobby is for peer discovery only")
+    await send_dm_message(room_id, data.text)
     return {"ok": True}
 
 

--- a/src/guidebook/routes/global_settings.py
+++ b/src/guidebook/routes/global_settings.py
@@ -93,11 +93,13 @@ async def upsert_global_setting(
 
     if key == "nats_chat_enabled":
         from guidebook.chat import start_chat, stop_chat
+        from guidebook.sse import broadcast
 
         if data.value == "true":
             await start_chat()
         else:
             await stop_chat()
+        broadcast("chat-enabled", {"enabled": data.value == "true"})
 
     if key == "nats_lobby_enabled":
         from guidebook.chat import join_lobby, leave_lobby

--- a/src/guidebook/routes/global_settings.py
+++ b/src/guidebook/routes/global_settings.py
@@ -91,5 +91,21 @@ async def upsert_global_setting(
         else:
             await stop_auto_shutdown()
 
+    if key == "nats_chat_enabled":
+        from guidebook.chat import start_chat, stop_chat
+
+        if data.value == "true":
+            await start_chat()
+        else:
+            await stop_chat()
+
+    if key == "nats_lobby_enabled":
+        from guidebook.chat import join_lobby, leave_lobby
+
+        if data.value == "true":
+            await join_lobby()
+        else:
+            await leave_lobby()
+
     redacted_value = "***" if key in HIDDEN_KEYS and data.value else data.value
     return SettingResponse(key=key, value=redacted_value)


### PR DESCRIPTION
## Summary
- Adds a new Chat activity gated behind NATS connection + `nats_chat_enabled` + `nats_lobby_enabled` settings (three hierarchical checkboxes in Settings → NATS tab)
- Well-known public lobby (`guidebook.chat.lobby`) with presence heartbeats, peer discovery, and unauthenticated chat
- Challenge-response peer verification protocol: cryptographic proof-of-possession of mTLS private key, with automatic reciprocal verification for mutual trust
- Deterministic private room derivation from sorted fingerprint pairs — both sides compute the same NATS subject independently
- In-memory 100KB message buffer per room (no SQLite persistence yet)
- Chat UI with room sidebar, message area, peer list, and verification request handling
- Chat starts reactively when NATS connects (not eagerly at startup)

## New files
- `src/guidebook/chat.py` — chat manager (lobby, verification, trusted contacts, message buffers)
- `src/guidebook/routes/chat.py` — API endpoints
- `frontend/src/Chat.svelte` — chat UI component

## Modified files
- `src/guidebook/nats_client.py` — helper functions + reactive chat start/stop on connect/disconnect
- `src/guidebook/db.py` — new global settings keys
- `src/guidebook/routes/global_settings.py` — chat/lobby toggle handlers with SSE broadcast
- `src/guidebook/main.py` — router wiring
- `frontend/src/App.svelte` — chat routing, gating, SSE listeners, button bar
- `frontend/src/Settings.svelte` — chat enable checkboxes

Closes #25

## Test plan
- [ ] Enable NATS, enable NATS Chat, enable Join Public Lobby
- [ ] Verify chat button appears without page refresh
- [ ] Verify chat fills viewport without scrolling
- [ ] Verify lobby shows peers from another connected instance
- [ ] Verify challenge-response verification flow between two peers
- [ ] Verify private room appears after mutual verification
- [ ] Verify messages persist in buffer while running, lost on restart
- [ ] Disable NATS Chat → chat button disappears, subscriptions cleaned up
- [ ] Restart server → chat starts automatically when NATS reconnects