### PR TITLE
Support separate local instances with instances sub-directory (#27)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,10 +39,12 @@ guidebook/
 
 ## Data Storage
 
-Database and config stored in the OS-appropriate data directory. Created automatically on first run.
-- **Linux**: `$XDG_DATA_HOME/guidebook/` (defaults to `~/.local/share/guidebook/`)
-- **macOS**: `~/Library/Application Support/guidebook/`
-- **Windows**: `%APPDATA%\guidebook\`
+Database and config stored in the OS-appropriate data directory under an `instances/` subdirectory. Created automatically on first run. Existing installs are auto-migrated.
+- **Linux**: `$XDG_DATA_HOME/guidebook/instances/<name>/` (defaults to `~/.local/share/guidebook/instances/default/`)
+- **macOS**: `~/Library/Application Support/guidebook/instances/<name>/`
+- **Windows**: `%APPDATA%\guidebook\instances\<name>\`
+
+Each instance has its own `__instance.db` (instance-level settings), project databases, attachments, and backups. Use `--instance <name>` or `GUIDEBOOK_INSTANCE` env var to select an instance (default: `default`).
 
 ## Key Commands
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -148,6 +148,9 @@
 
   let menuOpen = false;
   let customHeader = "";
+  let instanceName = "";
+  let appName = "Guidebook";
+  let defaultAppName = "Guidebook";
   let appVersion = "";
   let updateAvailable = false;
   let updateChecked = false;
@@ -259,6 +262,8 @@
         const data = await res.json();
         pickerMode = data.picker;
         noShutdown = data.no_shutdown;
+        instanceName = data.instance_name || "";
+        defaultAppName = data.default_app_name || "Guidebook";
       }
     } catch {}
     try {
@@ -279,6 +284,7 @@
   async function startAppServices() {
     fetchVersion();
     fetchUpdateCheck();
+    fetchAppName();
     fetchCustomHeader();
     await fetchDefaultPage();
     fetchPopupNotifEnabled();
@@ -718,6 +724,20 @@
     } catch {}
   }
 
+  async function fetchAppName() {
+    try {
+      const res = await fetch("/api/instance-settings/app_name");
+      if (res.ok) {
+        const data = await res.json();
+        appName = data.value || defaultAppName;
+      } else {
+        appName = defaultAppName;
+      }
+    } catch {
+      appName = defaultAppName;
+    }
+  }
+
   async function fetchCustomHeader() {
     try {
       const res = await fetch("/api/settings/custom_header");
@@ -979,6 +999,7 @@
     await checkWelcome();
     if (!welcomeAcknowledged) return; // Welcome screen will handle the rest
     await checkDatabaseMode();
+    fetchAppName();
     setDatabase(currentDatabase);
     dualSplit = parseFloat(storageGet("dualSplit")) || 50;
     if (databaseOpen) {
@@ -1054,7 +1075,7 @@
     <header>
       <div class="header-left">
         <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-        <h1 class="app-title"><span class="title-full">Guidebook</span><span class="title-short">GB</span>{#if appVersion}<span class="app-version" title={!appFrozen ? "Local build" : updateChecked && updateExact ? "Up to date" : updateChecked && updateDev ? "Development version" : !updateChecked ? "Enable update checker in the settings" : ""} on:click={() => { navigate("about"); }} style="cursor: pointer">v{appVersion}{#if updateSupported && updateChecked && updateExact}<span class="up-to-date-check">✔</span>{/if}{#if (updateChecked && updateDev) || !appFrozen}<span class="dev-version">🚧</span>{/if}{#if updateAvailable} <button class="update-link-btn" title={"v" + updateLatest + " available"} on:click|stopPropagation={() => { settingsTab = "updates"; navigate("settings"); }}>Update Available</button><button class="update-skip-btn" title="Skip this version" on:click|stopPropagation={skipUpdate}>✕</button>{/if}</span>{/if}</h1>
+        <h1 class="app-title"><span class="title-full">{appName}</span><span class="title-short">{appName.slice(0, 2).toUpperCase()}</span>{#if appVersion}<span class="app-version" title={!appFrozen ? "Local build" : updateChecked && updateExact ? "Up to date" : updateChecked && updateDev ? "Development version" : !updateChecked ? "Enable update checker in the settings" : ""} on:click={() => { navigate("about"); }} style="cursor: pointer">v{appVersion}{#if updateSupported && updateChecked && updateExact}<span class="up-to-date-check">✔</span>{/if}{#if (updateChecked && updateDev) || !appFrozen}<span class="dev-version">🚧</span>{/if}{#if updateAvailable} <button class="update-link-btn" title={"v" + updateLatest + " available"} on:click|stopPropagation={() => { settingsTab = "updates"; navigate("settings"); }}>Update Available</button><button class="update-skip-btn" title="Skip this version" on:click|stopPropagation={skipUpdate}>✕</button>{/if}</span>{/if}</h1>
       </div>
       <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
       <span class="client-count" on:click={() => { settingsTab = "auth"; navigate("settings"); }} title="Connected clients">{clientCount} client{clientCount !== 1 ? "s" : ""}</span>
@@ -1079,7 +1100,7 @@
       <div class="title-group">
         <!-- svelte-ignore a11y-click-events-have-key-events -->
         <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
-        <h1 class="app-title" on:click={goHome} style="cursor: pointer"><span class="title-full">Guidebook</span><span class="title-short">GB</span></h1>
+        <h1 class="app-title" on:click={goHome} style="cursor: pointer"><span class="title-full">{appName}</span><span class="title-short">{appName.slice(0, 2).toUpperCase()}</span></h1>
         <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
         {#if appVersion}<span class="app-version" title={!appFrozen ? "Local build" : updateChecked && updateExact ? "Up to date" : updateChecked && updateDev ? "Development version" : !updateChecked ? "Enable update checker in the settings" : ""} on:click={() => { navigate("about"); }} style="cursor: pointer">v{appVersion}{#if updateSupported && updateChecked && updateExact}<span class="up-to-date-check">✔</span>{/if}{#if (updateChecked && updateDev) || !appFrozen}<span class="dev-version">🚧</span>{/if}{#if updateAvailable} <button class="update-link-btn" title={"v" + updateLatest + " available"} on:click|stopPropagation={() => { settingsTab = "updates"; navigate("settings"); }}>Update Available</button><button class="update-skip-btn" title="Skip this version" on:click|stopPropagation={skipUpdate}>✕</button>{/if}</span>{/if}
       </div>
@@ -1168,7 +1189,7 @@
     {:else if page === "notifications"}
       <Notifications refreshTrigger={notifRefreshTrigger} on:countchange={() => fetchUnreadCount()} />
     {:else if page === "settings"}
-      <Settings databaseName={currentDatabase} pickerMode={pickerMode} initialTab={settingsTab} bind:highlightSection={settingsHighlight} {clientCount} {authRefreshTrigger} on:disconnect-others={async () => { const nonce = Math.random().toString(36).slice(2); disconnectNonce = nonce; try { await fetch("/api/events/disconnect-others", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ nonce }) }); } catch {} }} on:deleted={e => { if (e.detail.shutdown) { setShutdownState(); } else { stopAppServices(); databaseOpen = false; currentDatabase = ""; page = "picker"; applySystemTheme(); } }} on:setupcomplete={async () => { await fetchDatabaseRight(); await fetchSqlQueryEnabled(); navigate(isWide() ? "dual" : "records"); }} on:saved={async () => { fetchCustomHeader(); fetchDefaultPage(); applyTheme(); fetchPopupNotifEnabled(); await fetchDatabaseRight(); await fetchSqlQueryEnabled(); fetchUpdateCheck(); }} on:shutdown-pending={() => { shutdownPendingSince = Date.now(); }} on:shutdown={() => { setShutdownState(); }} />
+      <Settings databaseName={currentDatabase} pickerMode={pickerMode} {instanceName} {defaultAppName} initialTab={settingsTab} bind:highlightSection={settingsHighlight} {clientCount} {authRefreshTrigger} on:disconnect-others={async () => { const nonce = Math.random().toString(36).slice(2); disconnectNonce = nonce; try { await fetch("/api/events/disconnect-others", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ nonce }) }); } catch {} }} on:deleted={e => { if (e.detail.shutdown) { setShutdownState(); } else { stopAppServices(); databaseOpen = false; currentDatabase = ""; page = "picker"; applySystemTheme(); } }} on:setupcomplete={async () => { await fetchDatabaseRight(); await fetchSqlQueryEnabled(); navigate(isWide() ? "dual" : "records"); }} on:saved={async () => { fetchCustomHeader(); fetchDefaultPage(); applyTheme(); fetchPopupNotifEnabled(); await fetchDatabaseRight(); await fetchSqlQueryEnabled(); fetchUpdateCheck(); }} on:shutdown-pending={() => { shutdownPendingSince = Date.now(); }} on:shutdown={() => { setShutdownState(); }} on:app-name-changed={fetchAppName} />
     {:else if page === "scratchpad"}
       <Scratchpad />
     {:else if page === "about"}

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -460,7 +460,7 @@
     if (natsClientCert) settings.nats_client_cert = natsClientCert;
     if (natsClientKey) settings.nats_client_key = natsClientKey;
     for (const [key, value] of Object.entries(settings)) {
-      await fetch(`/api/global-settings/${key}`, {
+      await fetch(`/api/instance-settings/${key}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ value }),
@@ -476,7 +476,7 @@
   }
 
   async function toggleNats() {
-    await fetch("/api/global-settings/nats_enabled", {
+    await fetch("/api/instance-settings/nats_enabled", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ value: natsEnabled ? "true" : "false" }),
@@ -1076,7 +1076,7 @@
       if (res.ok) {
         const data = await res.json();
         settingSources[key] = data.source || "database";
-        if (data.source === "global" && data.value) {
+        if (data.source === "instance" && data.value) {
           globalPlaceholders[key] = data.value;
         } else {
           delete globalPlaceholders[key];
@@ -1325,7 +1325,7 @@
 
   async function fetchGlobalSettings() {
     try {
-      const res = await fetch("/api/global-settings/");
+      const res = await fetch("/api/instance-settings/");
       if (res.ok) {
         const data = await res.json();
         for (const s of data) {
@@ -1339,7 +1339,7 @@
   }
 
   async function saveGlobalSetting(key, value) {
-    await fetch(`/api/global-settings/${key}`, {
+    await fetch(`/api/instance-settings/${key}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ value }),

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -1811,7 +1811,7 @@
     <h3>Instance</h3>
     <p class="hint">Instance: <strong>{instanceName || "default"}</strong></p>
     <div class="setting-row">
-      <label for="app_name">App Name</label>
+      <label for="app_name">Instance Display Name</label>
       <input id="app_name" type="text" bind:value={appNameInput} placeholder={defaultAppName} on:change={saveAppName} />
     </div>
     <p class="hint">Displayed in the header. Leave blank to use the default ({defaultAppName}).</p>

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -7,6 +7,8 @@
   export let databaseName = "";
   export const pickerMode = false;
   export const needsSetup = false;
+  export let instanceName = "";
+  export let defaultAppName = "Guidebook";
   export let initialTab = null;
   export let highlightSection = null;
   export let clientCount = 0;
@@ -47,6 +49,9 @@
 
   let sql_query_enabled = false;
   let default_page = "log";
+
+  // App name override
+  let appNameInput = "";
 
   // Global settings state
   let globalSettingsLoaded = false;
@@ -1338,6 +1343,21 @@
     } catch {}
   }
 
+  async function loadAppName() {
+    try {
+      const res = await fetch("/api/instance-settings/app_name");
+      if (res.ok) {
+        const data = await res.json();
+        appNameInput = data.value || "";
+      }
+    } catch {}
+  }
+
+  async function saveAppName() {
+    await saveGlobalSetting("app_name", appNameInput);
+    dispatch("app-name-changed");
+  }
+
   async function saveGlobalSetting(key, value) {
     await fetch(`/api/instance-settings/${key}`, {
       method: "PUT",
@@ -1471,6 +1491,7 @@
   onMount(() => {
     fetchSettings();
     fetchGlobalSettings();
+    loadAppName();
     fetchEntryCount();
     loadDbInfo();
     loadBackupStatus();
@@ -1785,6 +1806,16 @@
 
   {#if activeTab === "data"}
   <div class="tab-scroll"><div class="tab-content" use:masonry>
+
+  <section class="settings-section">
+    <h3>Instance</h3>
+    <p class="hint">Instance: <strong>{instanceName || "default"}</strong></p>
+    <div class="setting-row">
+      <label for="app_name">App Name</label>
+      <input id="app_name" type="text" bind:value={appNameInput} placeholder={defaultAppName} on:change={saveAppName} />
+    </div>
+    <p class="hint">Displayed in the header. Leave blank to use the default ({defaultAppName}).</p>
+  </section>
 
   <section class="settings-section">
     <h3>Backup</h3>

--- a/frontend/src/Welcome.svelte
+++ b/frontend/src/Welcome.svelte
@@ -23,7 +23,7 @@
 
   async function saveGlobal(key, value) {
     if (!value) return;
-    await fetch(`/api/global-settings/${key}`, {
+    await fetch(`/api/instance-settings/${key}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ value }),

--- a/src/guidebook/db.py
+++ b/src/guidebook/db.py
@@ -96,6 +96,7 @@ INSTANCE_ONLY_KEYS = {
     "nats_ca_cert",
     "nats_client_cert",
     "nats_client_key",
+    "app_name",
 }
 
 

--- a/src/guidebook/db.py
+++ b/src/guidebook/db.py
@@ -778,43 +778,8 @@ def _secure_existing_data() -> None:
             item.chmod(0o600)
 
 
-def _migrate_to_instances() -> None:
-    """One-time migration: move databases from DB_DIR root into instances/default/."""
-    default_dir = DB_DIR / "instances" / "default"
-    if default_dir.exists():
-        return  # Already migrated
-    # Check if there are any databases in the old location
-    old_dbs = list(DB_DIR.glob("*.db"))
-    old_locks = list(DB_DIR.glob("*.lock"))
-    old_addrs = list(DB_DIR.glob("*.addr"))
-    old_json = DB_DIR / "last_opened.json"
-    old_attachments = DB_DIR / "attachments"
-    old_backups = DB_DIR / "backups"
-    if not old_dbs and not old_json.exists():
-        return  # Fresh install, nothing to migrate
-    _ensure_data_dir(default_dir)
-    for f in old_dbs:
-        dest = default_dir / f.name
-        if f.stem == "__global":
-            dest = default_dir / "__instance.db"
-        f.rename(dest)
-        logger.info("Migrated %s → instances/default/%s", f.name, dest.name)
-    for f in old_locks + old_addrs:
-        f.rename(default_dir / f.name)
-    if old_json.exists():
-        old_json.rename(default_dir / old_json.name)
-    if old_attachments.exists():
-        old_attachments.rename(default_dir / "attachments")
-        logger.info("Migrated attachments/ → instances/default/attachments/")
-    if old_backups.exists():
-        old_backups.rename(default_dir / "backups")
-        logger.info("Migrated backups/ → instances/default/backups/")
-    logger.info("Migration to instances directory complete")
-
-
 async def init_db() -> None:
     _ensure_data_dir(DB_DIR)
-    _migrate_to_instances()
     _ensure_data_dir(INSTANCE_DIR)
     _secure_existing_data()
     cleanup_stale_locks()

--- a/src/guidebook/db.py
+++ b/src/guidebook/db.py
@@ -32,6 +32,23 @@ def _default_data_dir() -> Path:
 
 DB_DIR = _default_data_dir()
 
+# Instance support: databases live under DB_DIR/instances/<name>/
+_INSTANCE_NAME = os.environ.get("GUIDEBOOK_INSTANCE", "default")
+INSTANCE_DIR = DB_DIR / "instances" / _INSTANCE_NAME
+
+
+def set_instance(name: str) -> None:
+    """Set the active instance name (call before init_db)."""
+    global _INSTANCE_NAME, INSTANCE_DIR, INSTANCE_DB_PATH, _LAST_OPENED_FILE
+    _INSTANCE_NAME = name
+    INSTANCE_DIR = DB_DIR / "instances" / name
+    INSTANCE_DB_PATH = INSTANCE_DIR / "__instance.db"
+    _LAST_OPENED_FILE = INSTANCE_DIR / "last_opened.json"
+
+
+def get_instance_name() -> str:
+    return _INSTANCE_NAME
+
 
 def _ensure_data_dir(path: Path) -> None:
     """Create a directory with owner-only permissions (0o700).
@@ -49,14 +66,14 @@ def _secure_file(path: Path) -> None:
         path.chmod(0o600)
 
 
-META_DB_PATH = DB_DIR / "__global.db"
-_LAST_OPENED_FILE = DB_DIR / "last_opened.json"
+INSTANCE_DB_PATH = INSTANCE_DIR / "__instance.db"
+_LAST_OPENED_FILE = INSTANCE_DIR / "last_opened.json"
 
-# Settings that can be set globally in __global.db and overridden per-database
-GLOBAL_DEFAULTABLE_KEYS: set[str] = set()
+# Settings that can be set in __instance.db and overridden per-database
+INSTANCE_DEFAULTABLE_KEYS: set[str] = set()
 
-# Settings that live exclusively in __global.db (not per-database)
-GLOBAL_ONLY_KEYS = {
+# Settings that live exclusively in __instance.db (not per-database)
+INSTANCE_ONLY_KEYS = {
     "update_check_enabled",
     "default_pick_mode",
     "default_host",
@@ -182,14 +199,14 @@ class Notification(Base):
     )
 
 
-# --- Global database models (shared __global.db) ---
+# --- Instance database models (shared __instance.db) ---
 
 
-class GlobalBase(DeclarativeBase):
+class InstanceBase(DeclarativeBase):
     pass
 
 
-class GlobalSetting(GlobalBase):
+class InstanceSetting(InstanceBase):
     __tablename__ = "settings"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
@@ -197,7 +214,7 @@ class GlobalSetting(GlobalBase):
     value: Mapped[str | None] = mapped_column(String, nullable=True)
 
 
-class GlobalCache(GlobalBase):
+class InstanceCache(InstanceBase):
     __tablename__ = "cache"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
@@ -207,7 +224,7 @@ class GlobalCache(GlobalBase):
     expires_at: Mapped[float] = mapped_column(nullable=False)
 
 
-class GlobalLastOpened(GlobalBase):
+class InstanceLastOpened(InstanceBase):
     __tablename__ = "last_opened"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
@@ -215,7 +232,7 @@ class GlobalLastOpened(GlobalBase):
     opened_at: Mapped[float] = mapped_column(Float, nullable=False)
 
 
-class AuthToken(GlobalBase):
+class AuthToken(InstanceBase):
     __tablename__ = "auth_tokens"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
@@ -230,7 +247,7 @@ class AuthToken(GlobalBase):
     user_agent: Mapped[str | None] = mapped_column(String, nullable=True)
 
 
-class ClientCert(GlobalBase):
+class ClientCert(InstanceBase):
     __tablename__ = "client_certs"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
@@ -357,9 +374,9 @@ def _run_migrations(conn, migrations, table="settings") -> bool:
 
 DATABASE_MIGRATIONS: list = []
 
-# --- Global DB migrations ---
+# --- Instance DB migrations ---
 
-GLOBAL_MIGRATIONS: list = []
+INSTANCE_MIGRATIONS: list = []
 
 
 def _global_migration_1_client_certs(conn):
@@ -379,7 +396,7 @@ def _global_migration_1_client_certs(conn):
     )
 
 
-GLOBAL_MIGRATIONS.append(_global_migration_1_client_certs)
+INSTANCE_MIGRATIONS.append(_global_migration_1_client_certs)
 
 
 def _global_migration_2_client_certs_pending_session(conn):
@@ -390,7 +407,7 @@ def _global_migration_2_client_certs_pending_session(conn):
         pass  # column may already exist
 
 
-GLOBAL_MIGRATIONS.append(_global_migration_2_client_certs_pending_session)
+INSTANCE_MIGRATIONS.append(_global_migration_2_client_certs_pending_session)
 
 
 class DatabaseManager:
@@ -404,9 +421,9 @@ class DatabaseManager:
         self._lock_file = None
         self._host: str | None = None
         self._port: int | None = None
-        # Global database (shared __global.db)
-        self.global_engine = None
-        self._global_session_factory = None
+        # Instance database (shared __instance.db)
+        self.instance_engine = None
+        self._instance_session_factory = None
 
     def configure(self, db_name: str | None = None, picker: bool = False) -> None:
         cli_name = db_name
@@ -442,8 +459,8 @@ class DatabaseManager:
     @property
     def default_db_path(self) -> Path:
         if self._db_override:
-            return DB_DIR / f"{self._db_override}.db"
-        return DB_DIR / "guidebook.db"
+            return INSTANCE_DIR / f"{self._db_override}.db"
+        return INSTANCE_DIR / "guidebook.db"
 
     def check_lock(self, db_path: Path) -> None:
         """Raise DatabaseLockError if the database is locked by another process."""
@@ -602,16 +619,16 @@ class DatabaseManager:
         self.db_path = None
         self._release_lock()
 
-    async def open_global(self) -> None:
-        """Open the shared __global.db with WAL mode for multi-process safety."""
-        if self.global_engine is not None:
+    async def open_instance(self) -> None:
+        """Open the shared __instance.db with WAL mode for multi-process safety."""
+        if self.instance_engine is not None:
             return
-        _ensure_data_dir(META_DB_PATH.parent)
+        _ensure_data_dir(INSTANCE_DB_PATH.parent)
         # Back up before migration if needed
-        if META_DB_PATH.exists() and GLOBAL_MIGRATIONS:
+        if INSTANCE_DB_PATH.exists() and INSTANCE_MIGRATIONS:
             import sqlite3
 
-            _conn = sqlite3.connect(str(META_DB_PATH))
+            _conn = sqlite3.connect(str(INSTANCE_DB_PATH))
             try:
                 row = _conn.execute(
                     "SELECT value FROM settings WHERE key = '_schema_version'"
@@ -620,82 +637,86 @@ class DatabaseManager:
             except Exception:
                 current_v = 0
             _conn.close()
-            if current_v < len(GLOBAL_MIGRATIONS):
+            if current_v < len(INSTANCE_MIGRATIONS):
                 _backup_before_migration(
-                    META_DB_PATH, current_v, len(GLOBAL_MIGRATIONS)
+                    INSTANCE_DB_PATH, current_v, len(INSTANCE_MIGRATIONS)
                 )
-        self.global_engine = create_async_engine(f"sqlite+aiosqlite:///{META_DB_PATH}")
-        self._global_session_factory = async_sessionmaker(
-            self.global_engine, expire_on_commit=False
+        self.instance_engine = create_async_engine(
+            f"sqlite+aiosqlite:///{INSTANCE_DB_PATH}"
         )
-        async with self.global_engine.begin() as conn:
+        self._instance_session_factory = async_sessionmaker(
+            self.instance_engine, expire_on_commit=False
+        )
+        async with self.instance_engine.begin() as conn:
             await conn.execute(text("PRAGMA journal_mode=WAL"))
             await conn.execute(text("PRAGMA busy_timeout=5000"))
-            await conn.run_sync(GlobalBase.metadata.create_all)
-            await conn.run_sync(_add_missing_columns_global)
+            await conn.run_sync(InstanceBase.metadata.create_all)
+            await conn.run_sync(_add_missing_columns_instance)
             await conn.run_sync(
-                lambda c: _run_migrations(c, GLOBAL_MIGRATIONS, "settings")
+                lambda c: _run_migrations(c, INSTANCE_MIGRATIONS, "settings")
             )
-        _secure_file(META_DB_PATH)
+        _secure_file(INSTANCE_DB_PATH)
         # Migrate last_opened.json if it exists
         await self._migrate_last_opened()
-        async with self.global_engine.connect() as conn:
+        async with self.instance_engine.connect() as conn:
             gsv = await conn.run_sync(lambda c: _get_schema_version(c, "settings"))
-        logger.info("Opened global database: %s (schema v%d)", META_DB_PATH, gsv)
+        logger.info(
+            "Opened instance database: %s (schema v%d)", INSTANCE_DB_PATH, gsv
+        )
 
-    async def close_global(self) -> None:
-        """Dispose of the global database engine."""
-        if self.global_engine:
-            await self.global_engine.dispose()
-        self.global_engine = None
-        self._global_session_factory = None
+    async def close_instance(self) -> None:
+        """Dispose of the instance database engine."""
+        if self.instance_engine:
+            await self.instance_engine.dispose()
+        self.instance_engine = None
+        self._instance_session_factory = None
 
     async def _migrate_last_opened(self) -> None:
-        """One-time migration of last_opened.json into GlobalLastOpened table."""
+        """One-time migration of last_opened.json into InstanceLastOpened table."""
         if not _LAST_OPENED_FILE.exists():
             return
         data = _read_last_opened()
         if not data:
             _LAST_OPENED_FILE.unlink(missing_ok=True)
             return
-        async with self._global_session_factory() as session:
+        async with self._instance_session_factory() as session:
             for name, ts in data.items():
                 existing = (
                     await session.execute(
-                        select(GlobalLastOpened).where(GlobalLastOpened.name == name)
+                        select(InstanceLastOpened).where(InstanceLastOpened.name == name)
                     )
                 ).scalar_one_or_none()
                 if existing:
                     if ts > existing.opened_at:
                         existing.opened_at = ts
                 else:
-                    session.add(GlobalLastOpened(name=name, opened_at=ts))
+                    session.add(InstanceLastOpened(name=name, opened_at=ts))
             await session.commit()
         _LAST_OPENED_FILE.unlink(missing_ok=True)
         logger.info("Migrated last_opened.json to global database")
 
     async def record_last_opened(self, name: str) -> None:
         """Record when a database was last opened (in global DB)."""
-        if self._global_session_factory is None:
+        if self._instance_session_factory is None:
             return
-        async with self._global_session_factory() as session:
+        async with self._instance_session_factory() as session:
             existing = (
                 await session.execute(
-                    select(GlobalLastOpened).where(GlobalLastOpened.name == name)
+                    select(InstanceLastOpened).where(InstanceLastOpened.name == name)
                 )
             ).scalar_one_or_none()
             if existing:
                 existing.opened_at = time.time()
             else:
-                session.add(GlobalLastOpened(name=name, opened_at=time.time()))
+                session.add(InstanceLastOpened(name=name, opened_at=time.time()))
             await session.commit()
 
     async def read_last_opened(self) -> dict[str, float]:
         """Read last-opened timestamps from global DB."""
-        if self._global_session_factory is None:
+        if self._instance_session_factory is None:
             return {}
-        async with self._global_session_factory() as session:
-            result = await session.execute(select(GlobalLastOpened))
+        async with self._instance_session_factory() as session:
+            result = await session.execute(select(InstanceLastOpened))
             return {row.name: row.opened_at for row in result.scalars().all()}
 
 
@@ -708,22 +729,22 @@ def async_session():
     return db_manager._session_factory()
 
 
-def global_async_session():
-    if db_manager._global_session_factory is None:
-        raise RuntimeError("Global database is not open")
-    return db_manager._global_session_factory()
+def instance_async_session():
+    if db_manager._instance_session_factory is None:
+        raise RuntimeError("Instance database is not open")
+    return db_manager._instance_session_factory()
 
 
 async def resolve_setting(key: str, session: AsyncSession, default: str = "") -> str:
-    """Read a setting from the database, falling back to global DB if blank/missing."""
+    """Read a setting from the database, falling back to instance DB if blank/missing."""
     result = await session.execute(select(Setting).where(Setting.key == key))
     row = result.scalar_one_or_none()
     if row and row.value:
         return row.value
-    if key in GLOBAL_DEFAULTABLE_KEYS and db_manager._global_session_factory:
-        async with db_manager._global_session_factory() as gdb:
+    if key in INSTANCE_DEFAULTABLE_KEYS and db_manager._instance_session_factory:
+        async with db_manager._instance_session_factory() as gdb:
             gdb_result = await gdb.execute(
-                select(GlobalSetting).where(GlobalSetting.key == key)
+                select(InstanceSetting).where(InstanceSetting.key == key)
             )
             gdb_row = gdb_result.scalar_one_or_none()
             if gdb_row and gdb_row.value:
@@ -733,7 +754,7 @@ async def resolve_setting(key: str, session: AsyncSession, default: str = "") ->
 
 def cleanup_stale_locks() -> None:
     """Remove .lock and .addr files left behind by dead processes."""
-    for lock_path in DB_DIR.glob("*.lock"):
+    for lock_path in INSTANCE_DIR.glob("*.lock"):
         try:
             with open(lock_path, "r+") as f:
                 _lock_exclusive(f)
@@ -748,20 +769,56 @@ def cleanup_stale_locks() -> None:
 
 def _secure_existing_data() -> None:
     """Fix permissions on existing data directory contents (migration for existing installs)."""
-    if sys.platform == "win32" or not DB_DIR.exists():
+    if sys.platform == "win32" or not INSTANCE_DIR.exists():
         return
-    for item in DB_DIR.iterdir():
+    for item in INSTANCE_DIR.iterdir():
         if item.is_dir():
             item.chmod(0o700)
         elif item.is_file():
             item.chmod(0o600)
 
 
+def _migrate_to_instances() -> None:
+    """One-time migration: move databases from DB_DIR root into instances/default/."""
+    default_dir = DB_DIR / "instances" / "default"
+    if default_dir.exists():
+        return  # Already migrated
+    # Check if there are any databases in the old location
+    old_dbs = list(DB_DIR.glob("*.db"))
+    old_locks = list(DB_DIR.glob("*.lock"))
+    old_addrs = list(DB_DIR.glob("*.addr"))
+    old_json = DB_DIR / "last_opened.json"
+    old_attachments = DB_DIR / "attachments"
+    old_backups = DB_DIR / "backups"
+    if not old_dbs and not old_json.exists():
+        return  # Fresh install, nothing to migrate
+    _ensure_data_dir(default_dir)
+    for f in old_dbs:
+        dest = default_dir / f.name
+        if f.stem == "__global":
+            dest = default_dir / "__instance.db"
+        f.rename(dest)
+        logger.info("Migrated %s → instances/default/%s", f.name, dest.name)
+    for f in old_locks + old_addrs:
+        f.rename(default_dir / f.name)
+    if old_json.exists():
+        old_json.rename(default_dir / old_json.name)
+    if old_attachments.exists():
+        old_attachments.rename(default_dir / "attachments")
+        logger.info("Migrated attachments/ → instances/default/attachments/")
+    if old_backups.exists():
+        old_backups.rename(default_dir / "backups")
+        logger.info("Migrated backups/ → instances/default/backups/")
+    logger.info("Migration to instances directory complete")
+
+
 async def init_db() -> None:
     _ensure_data_dir(DB_DIR)
+    _migrate_to_instances()
+    _ensure_data_dir(INSTANCE_DIR)
     _secure_existing_data()
     cleanup_stale_locks()
-    await db_manager.open_global()
+    await db_manager.open_instance()
     if db_manager.picker_mode:
         return
     db_path = db_manager.default_db_path
@@ -785,9 +842,9 @@ def _add_missing_columns(conn):
                 )
 
 
-def _add_missing_columns_global(conn):
+def _add_missing_columns_instance(conn):
     insp = inspect(conn)
-    for table_name, table in GlobalBase.metadata.tables.items():
+    for table_name, table in InstanceBase.metadata.tables.items():
         if not insp.has_table(table_name):
             continue
         existing = {c["name"] for c in insp.get_columns(table_name)}
@@ -806,8 +863,8 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
         yield session
 
 
-async def get_global_session() -> AsyncGenerator[AsyncSession, None]:
-    if db_manager._global_session_factory is None:
-        raise HTTPException(status_code=503, detail="Global database is not open")
-    async with db_manager._global_session_factory() as session:
+async def get_instance_session() -> AsyncGenerator[AsyncSession, None]:
+    if db_manager._instance_session_factory is None:
+        raise HTTPException(status_code=503, detail="Instance database is not open")
+    async with db_manager._instance_session_factory() as session:
         yield session

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -20,13 +20,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from guidebook.db import (
     DatabaseLockError,
     DatabaseTooNewError,
-    GlobalCache,
+    InstanceCache,
     Setting,
     db_manager,
-    get_global_session,
+    get_instance_session,
     get_session,
     init_db,
-    global_async_session,
+    instance_async_session,
 )
 from guidebook.routes.auth import router as auth_router
 import guidebook.routes.auth as _auth_module
@@ -44,7 +44,7 @@ from guidebook.routes.settings import (
     stop_auto_backup,
 )
 from guidebook.routes.query import router as query_router
-from guidebook.routes.global_settings import router as global_settings_router
+from guidebook.routes.instance_settings import router as instance_settings_router
 from guidebook.routes.update import router as update_router
 from guidebook.routes.scratchpad import router as scratchpad_router
 from guidebook.routes.media import router as media_router
@@ -113,11 +113,11 @@ async def lifespan(app: FastAPI):
         yield
         return
     # Clear update check cache so we always check once on startup
-    async with global_async_session() as gdb:
+    async with instance_async_session() as gdb:
         await gdb.execute(
-            delete(GlobalCache).where(
-                GlobalCache.namespace == UPDATE_CACHE_NS,
-                GlobalCache.key == UPDATE_CACHE_KEY,
+            delete(InstanceCache).where(
+                InstanceCache.namespace == UPDATE_CACHE_NS,
+                InstanceCache.key == UPDATE_CACHE_KEY,
             )
         )
         await gdb.commit()
@@ -133,7 +133,7 @@ async def lifespan(app: FastAPI):
     await stop_sse_auto_shutdown()
     await stop_auto_backup()
     await db_manager.close()
-    await db_manager.close_global()
+    await db_manager.close_instance()
 
 
 app = FastAPI(title="Guidebook", version=version("guidebook"), lifespan=lifespan)
@@ -247,8 +247,8 @@ async def http_middleware(request: Request, call_next):
         from guidebook.routes.auth import check_auth, MTLS_MODE, _is_auth_enabled
         from guidebook.db import db_manager
 
-        if db_manager._global_session_factory:
-            async with db_manager._global_session_factory() as gdb:
+        if db_manager._instance_session_factory:
+            async with db_manager._instance_session_factory() as gdb:
                 auth_enabled = await _is_auth_enabled(gdb)
                 if not auth_enabled:
                     ok = True
@@ -273,7 +273,7 @@ async def http_middleware(request: Request, call_next):
         from guidebook.db import db_manager
 
         auth_token = request.query_params.get("auth_token")
-        if auth_token and db_manager._global_session_factory:
+        if auth_token and db_manager._instance_session_factory:
             from guidebook.routes.auth import (
                 server_side_check_token,
                 server_side_login,
@@ -281,7 +281,7 @@ async def http_middleware(request: Request, call_next):
             from fastapi.responses import HTMLResponse, RedirectResponse
             from urllib.parse import urlencode
 
-            async with db_manager._global_session_factory() as gdb:
+            async with db_manager._instance_session_factory() as gdb:
                 err = await server_side_check_token(gdb, auth_token)
             if err:
                 return HTMLResponse(
@@ -289,7 +289,7 @@ async def http_middleware(request: Request, call_next):
                     content=_inline_page(f"<p>{err}</p>"),
                 )
             if request.method == "POST":
-                async with db_manager._global_session_factory() as gdb:
+                async with db_manager._instance_session_factory() as gdb:
                     redirect = RedirectResponse(url="/", status_code=303)
                     login_err = await server_side_login(
                         gdb, request, redirect, auth_token
@@ -312,10 +312,10 @@ async def http_middleware(request: Request, call_next):
             )
 
         # Auth check for non-API routes (HTML pages and static assets)
-        if db_manager._global_session_factory:
+        if db_manager._instance_session_factory:
             from guidebook.routes.auth import check_auth, MTLS_MODE, _is_auth_enabled
 
-            async with db_manager._global_session_factory() as gdb:
+            async with db_manager._instance_session_factory() as gdb:
                 auth_enabled = await _is_auth_enabled(gdb)
                 if not auth_enabled:
                     ok = True
@@ -416,7 +416,7 @@ UPDATE_CACHE_TTL = 3600  # 1 hour
 
 @app.get("/api/update-check")
 async def check_for_update(
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
     session: AsyncSession = Depends(get_session),
     bust: bool = False,
 ):
@@ -439,9 +439,9 @@ async def check_for_update(
     # Bust cache if requested
     if bust:
         await gdb.execute(
-            delete(GlobalCache).where(
-                GlobalCache.namespace == UPDATE_CACHE_NS,
-                GlobalCache.key == UPDATE_CACHE_KEY,
+            delete(InstanceCache).where(
+                InstanceCache.namespace == UPDATE_CACHE_NS,
+                InstanceCache.key == UPDATE_CACHE_KEY,
             )
         )
         await gdb.commit()
@@ -449,10 +449,10 @@ async def check_for_update(
     # Check cache
     cached = (
         await gdb.execute(
-            select(GlobalCache).where(
-                GlobalCache.namespace == UPDATE_CACHE_NS,
-                GlobalCache.key == UPDATE_CACHE_KEY,
-                GlobalCache.expires_at > time.time(),
+            select(InstanceCache).where(
+                InstanceCache.namespace == UPDATE_CACHE_NS,
+                InstanceCache.key == UPDATE_CACHE_KEY,
+                InstanceCache.expires_at > time.time(),
             )
         )
     ).scalar_one_or_none()
@@ -491,13 +491,13 @@ async def check_for_update(
 
         # Store in cache
         await gdb.execute(
-            delete(GlobalCache).where(
-                GlobalCache.namespace == UPDATE_CACHE_NS,
-                GlobalCache.key == UPDATE_CACHE_KEY,
+            delete(InstanceCache).where(
+                InstanceCache.namespace == UPDATE_CACHE_NS,
+                InstanceCache.key == UPDATE_CACHE_KEY,
             )
         )
         gdb.add(
-            GlobalCache(
+            InstanceCache(
                 namespace=UPDATE_CACHE_NS,
                 key=UPDATE_CACHE_KEY,
                 value=json.dumps(
@@ -550,15 +550,15 @@ async def check_for_update(
 
 @app.post("/api/update-check/skip")
 async def skip_update(
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
     session: AsyncSession = Depends(get_session),
 ):
     """Skip the currently available update version."""
     cached = (
         await gdb.execute(
-            select(GlobalCache).where(
-                GlobalCache.namespace == UPDATE_CACHE_NS,
-                GlobalCache.key == UPDATE_CACHE_KEY,
+            select(InstanceCache).where(
+                InstanceCache.namespace == UPDATE_CACHE_NS,
+                InstanceCache.key == UPDATE_CACHE_KEY,
             )
         )
     ).scalar_one_or_none()
@@ -588,7 +588,7 @@ app.include_router(databases_router)
 app.include_router(records_router)
 app.include_router(attachments_router)
 app.include_router(settings_router)
-app.include_router(global_settings_router)
+app.include_router(instance_settings_router)
 app.include_router(notifications_router)
 app.include_router(query_router)
 app.include_router(update_router)
@@ -762,6 +762,7 @@ def run() -> None:
 
     env_help = """
 environment variables (overridden by command line options):
+  GUIDEBOOK_INSTANCE              Instance name (default: default)
   GUIDEBOOK_DB                    Database name to open (default: guidebook)
   GUIDEBOOK_PICKER                Enable database picker mode (default: false)
   GUIDEBOOK_NO_BROWSER            Skip opening browser (default: false)
@@ -795,6 +796,11 @@ environment variables (overridden by command line options):
         nargs="?",
         default=None,
         help="Database name to open (e.g. my-project, default: guidebook)",
+    )
+    parser.add_argument(
+        "--instance",
+        default=None,
+        help="Instance name (default: 'default', env: GUIDEBOOK_INSTANCE)",
     )
     parser.add_argument(
         "--pick",
@@ -939,6 +945,11 @@ environment variables (overridden by command line options):
     proxy_mode = bool(trusted_proxy_networks)
     _auth_module.PROXY_MODE = proxy_mode
     _auth_module.TLS_ENABLED = not no_tls
+    # Apply --instance / GUIDEBOOK_INSTANCE
+    if args.instance:
+        from guidebook.db import set_instance
+
+        set_instance(args.instance)
     if args.name and args.name.startswith("__"):
         print(
             "Error: database name must not start with '__' (reserved for system databases)"
@@ -953,10 +964,10 @@ environment variables (overridden by command line options):
         import secrets
         import sqlite3
 
-        from guidebook.db import META_DB_PATH, _ensure_data_dir
+        from guidebook.db import INSTANCE_DB_PATH, _ensure_data_dir
 
-        _ensure_data_dir(META_DB_PATH.parent)
-        conn = sqlite3.connect(str(META_DB_PATH))
+        _ensure_data_dir(INSTANCE_DB_PATH.parent)
+        conn = sqlite3.connect(str(INSTANCE_DB_PATH))
         conn.execute(
             "CREATE TABLE IF NOT EXISTS auth_tokens "
             "(id INTEGER PRIMARY KEY, token TEXT UNIQUE NOT NULL, label TEXT NOT NULL DEFAULT '', "
@@ -1192,11 +1203,11 @@ environment variables (overridden by command line options):
     if not no_tls:
         import ssl as _ssl
 
-        from guidebook.db import META_DB_PATH
+        from guidebook.db import INSTANCE_DB_PATH
         from guidebook.tls import ensure_ca_cert, ensure_tls_cert, write_tls_temp_files
 
-        ensure_ca_cert(str(META_DB_PATH))
-        cert_pem, key_pem = ensure_tls_cert(str(META_DB_PATH))
+        ensure_ca_cert(str(INSTANCE_DB_PATH))
+        cert_pem, key_pem = ensure_tls_cert(str(INSTANCE_DB_PATH))
         certfile, keyfile = write_tls_temp_files(cert_pem, key_pem)
         ssl_kwargs = {"ssl_certfile": certfile, "ssl_keyfile": keyfile}
         logger.info("TLS enabled (CA-signed certificate)")
@@ -1204,7 +1215,7 @@ environment variables (overridden by command line options):
         # mTLS configuration
         import sqlite3 as _sq
 
-        _mconn = _sq.connect(str(META_DB_PATH))
+        _mconn = _sq.connect(str(INSTANCE_DB_PATH))
         _mrow = _mconn.execute(
             "SELECT value FROM settings WHERE key = 'mtls_mode'"
         ).fetchone()
@@ -1221,7 +1232,7 @@ environment variables (overridden by command line options):
                 write_ca_temp_file,
             )
 
-            ca_cert_pem, ca_key_pem = ensure_ca_cert(str(META_DB_PATH))
+            ca_cert_pem, ca_key_pem = ensure_ca_cert(str(INSTANCE_DB_PATH))
             ca_certfile = write_ca_temp_file(ca_cert_pem)
             ssl_kwargs["ssl_ca_certs"] = ca_certfile
             ssl_kwargs["ssl_cert_reqs"] = (
@@ -1229,7 +1240,7 @@ environment variables (overridden by command line options):
             )
 
             # Build CRL from revoked certs
-            _cconn = _sq.connect(str(META_DB_PATH))
+            _cconn = _sq.connect(str(INSTANCE_DB_PATH))
             _revoked = _cconn.execute(
                 "SELECT serial_number, revoked_at FROM client_certs WHERE revoked_at IS NOT NULL"
             ).fetchall()

--- a/src/guidebook/nats_client.py
+++ b/src/guidebook/nats_client.py
@@ -49,7 +49,7 @@ def extract_cn(cert_pem: str) -> str | None:
 async def _read_nats_settings() -> dict:
     from sqlalchemy import select
 
-    from guidebook.db import GlobalSetting, global_async_session
+    from guidebook.db import InstanceSetting, instance_async_session
 
     keys = [
         "nats_enabled",
@@ -59,10 +59,12 @@ async def _read_nats_settings() -> dict:
         "nats_client_key",
     ]
     result = {}
-    async with global_async_session() as gdb:
+    async with instance_async_session() as gdb:
         for key in keys:
             row = (
-                await gdb.execute(select(GlobalSetting).where(GlobalSetting.key == key))
+                await gdb.execute(
+                    select(InstanceSetting).where(InstanceSetting.key == key)
+                )
             ).scalar_one_or_none()
             result[key] = row.value if row else None
     return result

--- a/src/guidebook/routes/attachments.py
+++ b/src/guidebook/routes/attachments.py
@@ -9,7 +9,8 @@ from pydantic import BaseModel, field_serializer
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from guidebook.db import Attachment, Record, DB_DIR, db_manager, get_session, _ensure_data_dir
+import guidebook.db as _db
+from guidebook.db import Attachment, Record, db_manager, get_session, _ensure_data_dir
 from guidebook.routes.records import _broadcast_records_changed
 
 router = APIRouter(
@@ -21,7 +22,7 @@ MAX_FILE_SIZE = 50 * 1024 * 1024  # 50 MB
 
 def _attachments_dir(record_uuid: str) -> Path:
     db_name = db_manager.db_name or "guidebook"
-    return DB_DIR / "attachments" / db_name / record_uuid
+    return _db.INSTANCE_DIR / "attachments" / db_name / record_uuid
 
 
 def _safe_filename(name: str, existing: set[str]) -> str:

--- a/src/guidebook/routes/auth.py
+++ b/src/guidebook/routes/auth.py
@@ -17,7 +17,12 @@ logger = logging.getLogger("guidebook")
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
-AUTH_COOKIE_NAME = "guidebook_token"
+def _cookie_name() -> str:
+    from guidebook.db import get_instance_name
+    instance = get_instance_name()
+    if instance == "default":
+        return "guidebook_token"
+    return f"guidebook_token_{instance}"
 AUTH_TTL_DEFAULT = 30 * 24 * 3600  # 30 days
 AUTH_RENEW_COOLDOWN_DEFAULT = 24 * 3600  # 24 hours
 LOGIN_LINK_TTL = 300  # 5 minutes (hardcoded)
@@ -100,7 +105,7 @@ def _decode_jwt(token_str: str) -> dict | None:
 
 
 def _get_jwt_claims(request: Request) -> dict | None:
-    cookie = request.cookies.get(AUTH_COOKIE_NAME)
+    cookie = request.cookies.get(_cookie_name())
     if not cookie:
         return None
     return _decode_jwt(cookie)
@@ -496,7 +501,7 @@ def _is_secure(request: Request) -> bool:
 
 def _set_auth_cookie(response: Response, request: Request, jwt_token: str) -> None:
     response.set_cookie(
-        AUTH_COOKIE_NAME,
+        _cookie_name(),
         jwt_token,
         max_age=AUTH_TTL,
         httponly=True,
@@ -589,5 +594,5 @@ async def logout(
             await gdb.delete(tok)
             await gdb.commit()
             logger.info("Session logged out")
-    response.delete_cookie(AUTH_COOKIE_NAME, path="/")
+    response.delete_cookie(_cookie_name(), path="/")
     return {"status": "logged_out"}

--- a/src/guidebook/routes/auth.py
+++ b/src/guidebook/routes/auth.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from guidebook.db import AuthToken, GlobalSetting, get_global_session
+from guidebook.db import AuthToken, InstanceSetting, get_instance_session
 from guidebook.routes.notifications import create_notification
 from guidebook.sse import broadcast
 
@@ -58,7 +58,7 @@ def _env_disable_auth() -> bool:
 
 async def _get_setting(gdb: AsyncSession, key: str) -> str | None:
     row = (
-        await gdb.execute(select(GlobalSetting).where(GlobalSetting.key == key))
+        await gdb.execute(select(InstanceSetting).where(InstanceSetting.key == key))
     ).scalar_one_or_none()
     return row.value if row else None
 
@@ -66,7 +66,7 @@ async def _get_setting(gdb: AsyncSession, key: str) -> str | None:
 async def _set_setting(gdb: AsyncSession, key: str, value: str) -> None:
     from sqlalchemy.dialects.sqlite import insert
 
-    stmt = insert(GlobalSetting).values(key=key, value=value)
+    stmt = insert(InstanceSetting).values(key=key, value=value)
     stmt = stmt.on_conflict_do_update(index_elements=["key"], set_={"value": value})
     await gdb.execute(stmt)
 
@@ -170,7 +170,7 @@ class AuthStatusResponse(BaseModel):
 @router.get("/status")
 async def auth_status(
     request: Request,
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     enabled = await _is_auth_enabled(gdb)
     session_id = _get_current_session_id(request)
@@ -210,7 +210,7 @@ class SessionResponse(BaseModel):
 @router.get("/sessions")
 async def list_sessions(
     request: Request,
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     from guidebook.sse import connected_session_ids
 
@@ -249,7 +249,7 @@ class GenerateTokenResponse(BaseModel):
 async def generate_token(
     request: Request,
     body: GenerateTokenRequest,
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     """Generate a login token for a new session. Auth enforced by middleware."""
     if MTLS_MODE == "required":
@@ -291,7 +291,7 @@ async def generate_token(
 @router.post("/transfer")
 async def transfer_session(
     request: Request,
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     """Generate a transfer token — logs out current session when new one logs in.
     Auth enforced by middleware."""
@@ -327,7 +327,7 @@ async def transfer_session(
 @router.post("/check-token")
 async def check_token(
     request: Request,
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     """Check if a login token is still valid (without consuming it)."""
     body = await request.json()
@@ -352,7 +352,7 @@ class LoginResponse(BaseModel):
 async def login_with_token(
     request: Request,
     response: Response,
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     """Login with a token (from URL parameter)."""
     body = await request.json()
@@ -510,7 +510,7 @@ def _set_auth_cookie(response: Response, request: Request, jwt_token: str) -> No
 async def renew_session(
     request: Request,
     response: Response,
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     """Renew the current session cookie if eligible."""
     if not await _is_auth_enabled(gdb):
@@ -554,7 +554,7 @@ async def renew_session(
 async def delete_session(
     session_id: int,
     request: Request,
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     """Delete (logout) a session. Cannot delete current session."""
     current_sid = _get_current_session_id(request)
@@ -578,7 +578,7 @@ async def delete_session(
 async def logout(
     request: Request,
     response: Response,
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     """Log out the current session. Auth enforced by middleware."""
     session_id = _get_current_session_id(request)

--- a/src/guidebook/routes/databases.py
+++ b/src/guidebook/routes/databases.py
@@ -43,6 +43,7 @@ def _validate_name(name: str) -> None:
 async def get_mode():
     from guidebook.main import NO_SHUTDOWN
 
+    instance_name = _db.get_instance_name()
     has_databases = any(
         f.stem != "__instance" for f in _db.INSTANCE_DIR.glob("*.db")
     )
@@ -51,6 +52,8 @@ async def get_mode():
         "db_override": db_manager._db_override is not None,
         "no_shutdown": NO_SHUTDOWN,
         "has_databases": has_databases,
+        "instance_name": instance_name,
+        "default_app_name": "Guidebook" if instance_name == "default" else instance_name,
     }
 
 

--- a/src/guidebook/routes/databases.py
+++ b/src/guidebook/routes/databases.py
@@ -5,8 +5,8 @@ import signal
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+import guidebook.db as _db
 from guidebook.db import (
-    DB_DIR,
     DatabaseLockError,
     DatabaseTooNewError,
     _lock_exclusive,
@@ -44,7 +44,7 @@ async def get_mode():
     from guidebook.main import NO_SHUTDOWN
 
     has_databases = any(
-        f.stem != "__global" for f in DB_DIR.glob("*.db")
+        f.stem != "__instance" for f in _db.INSTANCE_DIR.glob("*.db")
     )
     return {
         "picker": db_manager.picker_mode,
@@ -78,8 +78,8 @@ def _is_locked(db_path) -> bool:
 async def list_databases():
     last_opened = await db_manager.read_last_opened()
     dbs = []
-    for f in DB_DIR.glob("*.db"):
-        if f.stem == "__global":
+    for f in _db.INSTANCE_DIR.glob("*.db"):
+        if f.stem == "__instance":
             continue
         dbs.append(
             {
@@ -107,7 +107,7 @@ async def confirm_create():
         raise HTTPException(status_code=400, detail="No pending database to confirm")
     name = db_manager.pending_name
     db_manager.pending_name = None
-    db_path = DB_DIR / f"{name}.db"
+    db_path = _db.INSTANCE_DIR / f"{name}.db"
     try:
         await db_manager.open(db_path)
     except DatabaseLockError as e:
@@ -157,7 +157,7 @@ async def shutdown_server():
 @router.post("/open")
 async def open_database(body: DatabaseName):
     _validate_name(body.name)
-    db_path = DB_DIR / f"{body.name}.db"
+    db_path = _db.INSTANCE_DIR / f"{body.name}.db"
     if not db_path.exists():
         raise HTTPException(status_code=404, detail="Database not found")
     await stop_auto_backup()
@@ -192,7 +192,7 @@ async def delete_database(body: DatabaseName):
         raise HTTPException(
             status_code=400, detail="Can only delete the currently open database"
         )
-    db_path = DB_DIR / f"{body.name}.db"
+    db_path = _db.INSTANCE_DIR / f"{body.name}.db"
     await stop_auto_backup()
     await db_manager.close()
     if db_path.exists():
@@ -208,7 +208,7 @@ async def delete_database(body: DatabaseName):
 @router.post("/create")
 async def create_database(body: DatabaseName):
     _validate_name(body.name)
-    db_path = DB_DIR / f"{body.name}.db"
+    db_path = _db.INSTANCE_DIR / f"{body.name}.db"
     if db_path.exists():
         raise HTTPException(status_code=409, detail="Database already exists")
     try:

--- a/src/guidebook/routes/instance_settings.py
+++ b/src/guidebook/routes/instance_settings.py
@@ -6,17 +6,17 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from guidebook.db import (
-    GLOBAL_DEFAULTABLE_KEYS,
-    GLOBAL_ONLY_KEYS,
-    GlobalSetting,
-    get_global_session,
+    INSTANCE_DEFAULTABLE_KEYS,
+    INSTANCE_ONLY_KEYS,
+    InstanceSetting,
+    get_instance_session,
 )
 
 logger = logging.getLogger("guidebook")
 
-router = APIRouter(prefix="/api/global-settings", tags=["global-settings"])
+router = APIRouter(prefix="/api/instance-settings", tags=["instance-settings"])
 
-ALLOWED_KEYS = GLOBAL_DEFAULTABLE_KEYS | GLOBAL_ONLY_KEYS
+ALLOWED_KEYS = INSTANCE_DEFAULTABLE_KEYS | INSTANCE_ONLY_KEYS
 HIDDEN_KEYS: set[str] = {"nats_ca_cert", "nats_client_cert", "nats_client_key"}
 
 
@@ -31,21 +31,21 @@ class SettingResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
-def _redact(setting: GlobalSetting) -> SettingResponse:
+def _redact(setting: InstanceSetting) -> SettingResponse:
     if setting.key in HIDDEN_KEYS:
         return SettingResponse(key=setting.key, value="***" if setting.value else None)
     return SettingResponse.model_validate(setting)
 
 
 @router.get("/", response_model=list[SettingResponse])
-async def list_global_settings(gdb: AsyncSession = Depends(get_global_session)):
-    result = await gdb.execute(select(GlobalSetting))
+async def list_instance_settings(gdb: AsyncSession = Depends(get_instance_session)):
+    result = await gdb.execute(select(InstanceSetting))
     return [_redact(s) for s in result.scalars().all() if s is not None]
 
 
 @router.get("/{key}", response_model=SettingResponse)
-async def get_global_setting(key: str, gdb: AsyncSession = Depends(get_global_session)):
-    result = await gdb.execute(select(GlobalSetting).where(GlobalSetting.key == key))
+async def get_instance_setting(key: str, gdb: AsyncSession = Depends(get_instance_session)):
+    result = await gdb.execute(select(InstanceSetting).where(InstanceSetting.key == key))
     setting = result.scalar_one_or_none()
     if not setting:
         return SettingResponse(key=key, value=None)
@@ -53,10 +53,10 @@ async def get_global_setting(key: str, gdb: AsyncSession = Depends(get_global_se
 
 
 @router.put("/{key}", response_model=SettingResponse)
-async def upsert_global_setting(
+async def upsert_instance_setting(
     key: str,
     data: SettingValue,
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     if key not in ALLOWED_KEYS:
         raise HTTPException(
@@ -65,7 +65,7 @@ async def upsert_global_setting(
         )
     from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
-    stmt = sqlite_insert(GlobalSetting).values(key=key, value=data.value)
+    stmt = sqlite_insert(InstanceSetting).values(key=key, value=data.value)
     stmt = stmt.on_conflict_do_update(index_elements=["key"], set_={"value": data.value})
     await gdb.execute(stmt)
     await gdb.commit()

--- a/src/guidebook/routes/mtls.py
+++ b/src/guidebook/routes/mtls.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from guidebook.db import ClientCert, GlobalSetting, get_global_session
+from guidebook.db import ClientCert, InstanceSetting, get_instance_session
 
 logger = logging.getLogger("guidebook")
 
@@ -50,7 +50,7 @@ def _cleanup_expired() -> None:
 
 async def _get_setting(gdb: AsyncSession, key: str) -> str | None:
     row = (
-        await gdb.execute(select(GlobalSetting).where(GlobalSetting.key == key))
+        await gdb.execute(select(InstanceSetting).where(InstanceSetting.key == key))
     ).scalar_one_or_none()
     return row.value if row else None
 
@@ -58,7 +58,7 @@ async def _get_setting(gdb: AsyncSession, key: str) -> str | None:
 async def _set_setting(gdb: AsyncSession, key: str, value: str) -> None:
     from sqlalchemy.dialects.sqlite import insert
 
-    stmt = insert(GlobalSetting).values(key=key, value=value)
+    stmt = insert(InstanceSetting).values(key=key, value=value)
     stmt = stmt.on_conflict_do_update(index_elements=["key"], set_={"value": value})
     await gdb.execute(stmt)
 
@@ -89,7 +89,7 @@ def _get_peer_cert_serial(request: Request) -> str | None:
 @router.get("/status")
 async def mtls_status(
     request: Request,
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     from guidebook.routes.auth import TLS_ENABLED, PROXY_MODE
     from guidebook.sse import connected_cert_serials
@@ -139,7 +139,7 @@ async def mtls_status(
 
 @router.get("/ca.pem")
 async def download_ca_cert(
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     """Download the CA public certificate in PEM format."""
     _check_auth_enabled()
@@ -171,7 +171,7 @@ class GenerateCertResponse(BaseModel):
 async def generate_cert(
     request: Request,
     body: GenerateCertRequest,
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     """Generate a client certificate. Returns download token and password (shown once)."""
     _check_auth_enabled()
@@ -188,10 +188,10 @@ async def generate_cert(
         _token_count,
     )
 
-    from guidebook.db import META_DB_PATH
+    from guidebook.db import INSTANCE_DB_PATH
     from guidebook.tls import ensure_ca_cert, generate_client_cert
 
-    ca_cert_pem, ca_key_pem = ensure_ca_cert(str(META_DB_PATH))
+    ca_cert_pem, ca_key_pem = ensure_ca_cert(str(INSTANCE_DB_PATH))
 
     # Count active (non-revoked) certs (exclude pending-upgrade certs from count)
     result = await gdb.execute(
@@ -291,7 +291,7 @@ async def download_cert(download_token: str):
 
 @router.get("/certs")
 async def list_certs(
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     """List all issued client certificates."""
     result = await gdb.execute(select(ClientCert).order_by(ClientCert.issued_at.desc()))
@@ -312,7 +312,7 @@ async def list_certs(
 @router.delete("/certs/{cert_id}")
 async def revoke_cert(
     cert_id: int,
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     """Revoke a client certificate."""
     _check_auth_enabled()
@@ -338,7 +338,7 @@ class ActivateRequest(BaseModel):
 @router.post("/activate")
 async def activate_mtls(
     body: ActivateRequest,
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     """Set mTLS mode. Requires server restart to take effect."""
     _check_auth_enabled()
@@ -361,7 +361,7 @@ async def activate_mtls(
 async def mtls_logout(
     request: Request,
     response: Response,
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     """Revoke the client certificate and clear the cookie session."""
     _check_auth_enabled()

--- a/src/guidebook/routes/nats.py
+++ b/src/guidebook/routes/nats.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from guidebook.db import GlobalSetting, get_global_session
+from guidebook.db import InstanceSetting, get_instance_session
 from guidebook.nats_client import (
     compute_fingerprint,
     extract_cn,
@@ -21,15 +21,15 @@ async def nats_status():
 
 
 @router.get("/certs")
-async def nats_certs(gdb: AsyncSession = Depends(get_global_session)):
+async def nats_certs(gdb: AsyncSession = Depends(get_instance_session)):
     ca_pem = (
         await gdb.execute(
-            select(GlobalSetting).where(GlobalSetting.key == "nats_ca_cert")
+            select(InstanceSetting).where(InstanceSetting.key == "nats_ca_cert")
         )
     ).scalar_one_or_none()
     client_pem = (
         await gdb.execute(
-            select(GlobalSetting).where(GlobalSetting.key == "nats_client_cert")
+            select(InstanceSetting).where(InstanceSetting.key == "nats_client_cert")
         )
     ).scalar_one_or_none()
 
@@ -45,7 +45,7 @@ async def nats_certs(gdb: AsyncSession = Depends(get_global_session)):
 
     has_key = (
         await gdb.execute(
-            select(GlobalSetting).where(GlobalSetting.key == "nats_client_key")
+            select(InstanceSetting).where(InstanceSetting.key == "nats_client_key")
         )
     ).scalar_one_or_none()
 

--- a/src/guidebook/routes/query.py
+++ b/src/guidebook/routes/query.py
@@ -12,7 +12,8 @@ from fastapi import Depends
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from guidebook.db import META_DB_PATH, Setting, db_manager, get_session
+import guidebook.db as _db
+from guidebook.db import Setting, db_manager, get_session
 
 logger = logging.getLogger("guidebook")
 
@@ -66,8 +67,8 @@ def _execute_query(
     try:
         conn.set_authorizer(_authorizer)
         # Attach global database for cross-DB queries
-        if META_DB_PATH.exists():
-            conn.execute(f"ATTACH DATABASE 'file:{META_DB_PATH}?mode=ro' AS meta")
+        if _db.INSTANCE_DB_PATH.exists():
+            conn.execute(f"ATTACH DATABASE 'file:{_db.INSTANCE_DB_PATH}?mode=ro' AS meta")
         ops = [0]
 
         def progress():
@@ -112,8 +113,8 @@ async def get_schema(session: AsyncSession = Depends(get_session)):
         conn.close()
 
     # Add global database tables
-    if META_DB_PATH.exists():
-        meta_conn = sqlite3.connect(f"file:{META_DB_PATH}?mode=ro", uri=True)
+    if _db.INSTANCE_DB_PATH.exists():
+        meta_conn = sqlite3.connect(f"file:{_db.INSTANCE_DB_PATH}?mode=ro", uri=True)
         try:
             for table in sorted(META_ALLOWED_TABLES):
                 cursor = meta_conn.execute(f"PRAGMA table_info('{table}')")

--- a/src/guidebook/routes/scratchpad.py
+++ b/src/guidebook/routes/scratchpad.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from guidebook.db import AuthToken, ClientCert, get_global_session
+from guidebook.db import AuthToken, ClientCert, get_instance_session
 from guidebook.sse import _get_shutdown_event
 
 logger = logging.getLogger("guidebook")
@@ -151,7 +151,7 @@ async def _sse_generator(queue: asyncio.Queue[str], request: Request):
 @router.get("/stream")
 async def scratchpad_stream(
     request: Request,
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     queue: asyncio.Queue[str] = asyncio.Queue(maxsize=64)
     queue_id = id(queue)

--- a/src/guidebook/routes/settings.py
+++ b/src/guidebook/routes/settings.py
@@ -9,12 +9,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from guidebook.db import (
-    GLOBAL_DEFAULTABLE_KEYS,
-    GlobalSetting,
+    INSTANCE_DEFAULTABLE_KEYS,
+    InstanceSetting,
     Setting,
     _ensure_data_dir,
     db_manager,
-    get_global_session,
+    get_instance_session,
     get_session,
 )
 
@@ -65,7 +65,7 @@ def _redact(setting: Setting, source: str = "database") -> SettingResponse:
 @router.get("/", response_model=list[SettingResponse])
 async def list_settings(
     session: AsyncSession = Depends(get_session),
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     result = await session.execute(select(Setting))
     db_settings = result.scalars().all()
@@ -73,7 +73,7 @@ async def list_settings(
     db_filled = {
         s.key
         for s in db_settings
-        if s.key not in GLOBAL_DEFAULTABLE_KEYS or s.value
+        if s.key not in INSTANCE_DEFAULTABLE_KEYS or s.value
     }
     responses = [
         _redact(s, "database") for s in db_settings if s.key in db_filled
@@ -81,12 +81,12 @@ async def list_settings(
 
     # Fill in global defaults for defaultable keys that are missing or blank
     meta_result = await gdb.execute(
-        select(GlobalSetting).where(GlobalSetting.key.in_(GLOBAL_DEFAULTABLE_KEYS))
+        select(InstanceSetting).where(InstanceSetting.key.in_(INSTANCE_DEFAULTABLE_KEYS))
     )
     for ms in meta_result.scalars().all():
         if ms.key not in db_filled and ms.value:
             responses.append(
-                _redact(Setting(key=ms.key, value=ms.value), source="global")
+                _redact(Setting(key=ms.key, value=ms.value), source="instance")
             )
 
     return responses
@@ -96,22 +96,22 @@ async def list_settings(
 async def get_setting(
     key: str,
     session: AsyncSession = Depends(get_session),
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     result = await session.execute(select(Setting).where(Setting.key == key))
     setting = result.scalar_one_or_none()
     if setting and setting.value:
         return _redact(setting, "database")
     # Fall back to global default if applicable
-    if key in GLOBAL_DEFAULTABLE_KEYS:
+    if key in INSTANCE_DEFAULTABLE_KEYS:
         meta_result = await gdb.execute(
-            select(GlobalSetting).where(GlobalSetting.key == key)
+            select(InstanceSetting).where(InstanceSetting.key == key)
         )
         meta_setting = meta_result.scalar_one_or_none()
         if meta_setting and meta_setting.value:
             return _redact(
                 Setting(key=meta_setting.key, value=meta_setting.value),
-                source="global",
+                source="instance",
             )
     if setting:
         return _redact(setting, "database")

--- a/src/guidebook/routes/tls.py
+++ b/src/guidebook/routes/tls.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from guidebook.db import GlobalSetting, get_global_session
+from guidebook.db import InstanceSetting, get_instance_session
 
 logger = logging.getLogger("guidebook")
 
@@ -22,7 +22,7 @@ router = APIRouter(prefix="/api/tls", tags=["tls"])
 
 async def _get_setting(gdb: AsyncSession, key: str) -> str | None:
     row = (
-        await gdb.execute(select(GlobalSetting).where(GlobalSetting.key == key))
+        await gdb.execute(select(InstanceSetting).where(InstanceSetting.key == key))
     ).scalar_one_or_none()
     return row.value if row else None
 
@@ -30,14 +30,14 @@ async def _get_setting(gdb: AsyncSession, key: str) -> str | None:
 async def _set_setting(gdb: AsyncSession, key: str, value: str) -> None:
     from sqlalchemy.dialects.sqlite import insert
 
-    stmt = insert(GlobalSetting).values(key=key, value=value)
+    stmt = insert(InstanceSetting).values(key=key, value=value)
     stmt = stmt.on_conflict_do_update(index_elements=["key"], set_={"value": value})
     await gdb.execute(stmt)
 
 
 async def _delete_setting(gdb: AsyncSession, key: str) -> None:
     row = (
-        await gdb.execute(select(GlobalSetting).where(GlobalSetting.key == key))
+        await gdb.execute(select(InstanceSetting).where(InstanceSetting.key == key))
     ).scalar_one_or_none()
     if row:
         await gdb.delete(row)
@@ -72,7 +72,7 @@ class TlsStatusResponse(BaseModel):
 
 @router.get("/status")
 async def tls_status(
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ) -> TlsStatusResponse:
     from guidebook.routes.auth import TLS_ENABLED
 
@@ -132,7 +132,7 @@ async def tls_status(
 
 @router.get("/ca.pem")
 async def download_ca_pem(
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     from guidebook.routes.auth import TLS_ENABLED
 
@@ -162,7 +162,7 @@ class AcmeConfigureRequest(BaseModel):
 @router.post("/acme/configure")
 async def acme_configure(
     body: AcmeConfigureRequest,
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     from guidebook.routes.auth import TLS_ENABLED
 
@@ -197,7 +197,7 @@ async def acme_configure(
 
 @router.post("/acme/register")
 async def acme_register(
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     from guidebook.routes.auth import TLS_ENABLED
 
@@ -240,7 +240,7 @@ async def acme_register(
 
 @router.post("/acme/verify-cname")
 async def acme_verify_cname(
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     from guidebook.routes.auth import TLS_ENABLED
 
@@ -319,7 +319,7 @@ _provision_lock = asyncio.Lock()
 
 @router.post("/acme/provision")
 async def acme_provision(
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     from guidebook.routes.auth import TLS_ENABLED
 
@@ -415,14 +415,14 @@ async def acme_provision(
 
 @router.post("/acme/revert")
 async def acme_revert(
-    gdb: AsyncSession = Depends(get_global_session),
+    gdb: AsyncSession = Depends(get_instance_session),
 ):
     from guidebook.routes.auth import TLS_ENABLED
 
     if not TLS_ENABLED:
         raise HTTPException(400, "TLS is disabled")
 
-    from guidebook.db import META_DB_PATH
+    from guidebook.db import INSTANCE_DB_PATH
     from guidebook.tls import ensure_tls_cert
 
     # Delete the ACME cert and regenerate self-signed
@@ -432,7 +432,7 @@ async def acme_revert(
     await gdb.commit()
 
     # Regenerate self-signed cert (synchronous, uses sqlite3 directly)
-    cert_pem, _key_pem = ensure_tls_cert(str(META_DB_PATH))
+    cert_pem, _key_pem = ensure_tls_cert(str(INSTANCE_DB_PATH))
 
     from guidebook.sse import broadcast
 
@@ -468,9 +468,9 @@ async def _acme_renewal_loop(initial_delay: float = 300):
 
 async def _check_and_renew():
     """Check if renewal is needed and run the ACME flow if so."""
-    from guidebook.db import global_async_session
+    from guidebook.db import instance_async_session
 
-    async with global_async_session() as gdb:
+    async with instance_async_session() as gdb:
         tls_mode = await _get_setting(gdb, "tls_mode")
         if tls_mode != "acme":
             return

--- a/src/guidebook/sse.py
+++ b/src/guidebook/sse.py
@@ -108,15 +108,15 @@ async def start_auto_shutdown() -> None:
         return
     # Read delay from global DB
     try:
-        from guidebook.db import GlobalSetting, global_async_session
+        from guidebook.db import InstanceSetting, instance_async_session
 
-        async with global_async_session() as gdb:
+        async with instance_async_session() as gdb:
             from sqlalchemy import select
 
             row = (
                 await gdb.execute(
-                    select(GlobalSetting.value).where(
-                        GlobalSetting.key == "auto_shutdown_delay"
+                    select(InstanceSetting.value).where(
+                        InstanceSetting.key == "auto_shutdown_delay"
                     )
                 )
             ).scalar_one_or_none()


### PR DESCRIPTION
## Summary

- Restructure data directory to use `instances/<name>/` subdirectory for all databases, attachments, and backups
- Rename `__global.db` to `__instance.db` and refactor all Global* references to Instance* throughout backend and frontend
- Add `--instance` CLI arg and `GUIDEBOOK_INSTANCE` env var to select instance (default: `default`)
- Display instance name on Data settings tab with configurable "Instance Display Name" for the app header
- Scope auth cookie name per instance to prevent cross-instance logout on same host

Fixes #27