### PR TITLE
P2P WebRTC connections via NATS signaling

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -607,7 +607,7 @@
       const data = JSON.parse(e.data);
       natsChatEnabled = data.enabled;
     });
-    for (const evt of ["chat-message", "chat-peers", "chat-verify-request", "chat-verify-complete", "chat-rooms", "chat-defriended"]) {
+    for (const evt of ["chat-message", "chat-peers", "chat-verify-request", "chat-verify-complete", "chat-rooms", "chat-defriended", "webrtc-offer", "webrtc-answer", "webrtc-ice", "webrtc-hangup"]) {
       eventSource.addEventListener(evt, (e) => {
         window.dispatchEvent(new CustomEvent(evt, { detail: JSON.parse(e.data) }));
       });

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -17,6 +17,7 @@
   import iconCamera from "@iconify-icons/twemoji/camera";
   import { setDatabase, storageGet, storageSet, migrateStorage } from "./storage.js";
   import { applyThemeVars, applyCustomThemeVars, resolveDefaultTheme } from "./themes.js";
+  import * as p2p from "./p2p.js";
 
   const DUAL_RIGHT_PAGES = new Set(["notifications", "media"]);
 
@@ -609,7 +610,20 @@
     });
     for (const evt of ["chat-message", "chat-peers", "chat-verify-request", "chat-verify-complete", "chat-rooms", "chat-defriended", "webrtc-offer", "webrtc-answer", "webrtc-ice", "webrtc-hangup"]) {
       eventSource.addEventListener(evt, (e) => {
-        window.dispatchEvent(new CustomEvent(evt, { detail: JSON.parse(e.data) }));
+        const detail = JSON.parse(e.data);
+        window.dispatchEvent(new CustomEvent(evt, { detail }));
+        if (evt === "webrtc-offer") {
+          (async () => {
+            try {
+              const [roomsRes, statusRes] = await Promise.all([fetch("/api/chat/rooms"), fetch("/api/chat/status")]);
+              if (roomsRes.ok && statusRes.ok) {
+                p2p.handleOffer(detail, await roomsRes.json(), await statusRes.json());
+              }
+            } catch {}
+          })();
+        } else if (evt === "webrtc-answer") { p2p.handleAnswer(detail); }
+        else if (evt === "webrtc-ice") { p2p.handleIce(detail); }
+        else if (evt === "webrtc-hangup") { p2p.handleHangup(detail); }
       });
     }
     eventSource.addEventListener("database-changed", () => {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -168,6 +168,7 @@
   let sqlQueryEnabled = false;
   let natsChatEnabled = false;
   let natsConnected = false;
+  let chatRoomCount = 0;
   let noShutdown = false;
   let unreadCount = 0;
   let prevUnreadCount = -1;
@@ -612,6 +613,7 @@
       eventSource.addEventListener(evt, (e) => {
         const detail = JSON.parse(e.data);
         window.dispatchEvent(new CustomEvent(evt, { detail }));
+        if (evt === "chat-rooms") { chatRoomCount = (detail.rooms || []).length; }
         if (evt === "webrtc-offer") {
           (async () => {
             try {
@@ -813,8 +815,15 @@
         natsConnected = data.state === "connected";
       }
     } catch {}
+    fetchChatRoomCount();
   }
 
+  async function fetchChatRoomCount() {
+    try {
+      const res = await fetch("/api/chat/rooms");
+      if (res.ok) chatRoomCount = (await res.json()).length;
+    } catch {}
+  }
 
   function isWide() {
     return typeof window !== "undefined" && window.innerWidth >= wideBreakpoint;
@@ -1126,7 +1135,7 @@
         <h1 class="app-title"><span class="title-full">{appName}</span><span class="title-short">{appName.slice(0, 2).toUpperCase()}</span>{#if appVersion}<span class="app-version" title={!appFrozen ? "Local build" : updateChecked && updateExact ? "Up to date" : updateChecked && updateDev ? "Development version" : !updateChecked ? "Enable update checker in the settings" : ""} on:click={() => { navigate("about"); }} style="cursor: pointer">v{appVersion}{#if updateSupported && updateChecked && updateExact}<span class="up-to-date-check">✔</span>{/if}{#if (updateChecked && updateDev) || !appFrozen}<span class="dev-version">🚧</span>{/if}{#if updateAvailable} <button class="update-link-btn" title={"v" + updateLatest + " available"} on:click|stopPropagation={() => { settingsTab = "updates"; navigate("settings"); }}>Update Available</button><button class="update-skip-btn" title="Skip this version" on:click|stopPropagation={skipUpdate}>✕</button>{/if}</span>{/if}</h1>
       </div>
       <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-      <span class="client-count" on:click={() => { settingsTab = "auth"; navigate("settings"); }} title="Connected clients">{clientCount} client{clientCount !== 1 ? "s" : ""}</span>
+      <span class="client-count"><span class="client-count-link" on:click={() => { settingsTab = "auth"; navigate("settings"); }} title="Connected clients">{clientCount} client{clientCount !== 1 ? "s" : ""}</span>{#if natsChatEnabled && natsConnected && chatRoomCount > 0}<span class="client-count-sep"> + </span><span class="client-count-link" on:click={() => navigate("chat")} title="Mutual friends">{chatRoomCount} friend{chatRoomCount !== 1 ? "s" : ""}</span>{/if}</span>
     </header>
     <div class="welcome-container">
       <div class="welcome-card">
@@ -1163,7 +1172,7 @@
     <!-- svelte-ignore a11y-click-events-have-key-events -->
     <!-- svelte-ignore a11y-no-static-element-interactions -->
     <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-    <span class="client-count" on:click={() => { settingsTab = "auth"; navigate("settings"); }} title="Connected clients">{clientCount} client{clientCount !== 1 ? "s" : ""}</span>
+    <span class="client-count"><span class="client-count-link" on:click={() => { settingsTab = "auth"; navigate("settings"); }} title="Connected clients">{clientCount} client{clientCount !== 1 ? "s" : ""}</span>{#if natsChatEnabled && natsConnected && chatRoomCount > 0}<span class="client-count-sep"> + </span><span class="client-count-link" on:click={() => navigate("chat")} title="Mutual friends">{chatRoomCount} friend{chatRoomCount !== 1 ? "s" : ""}</span>{/if}</span>
     <div class="hamburger-wrap">
       {#if wide}
         <button class="add-btn dual-btn" class:active-nav={dualRightPage === "media"} on:click={() => { dualRightPage = "media"; navigate("media"); }} title="Records & Media">{#if dualRightPage === "media" && !databaseRight}<Icon icon={iconBook} width={14} />{/if}<Icon icon={iconCamera} width={18} />{#if dualRightPage === "media" && databaseRight}<Icon icon={iconBook} width={14} />{/if}</button>
@@ -1626,11 +1635,16 @@
   .client-count {
     font-size: 0.75rem;
     color: var(--text-dim);
-    cursor: pointer;
     white-space: nowrap;
   }
-  .client-count:hover {
+  .client-count-link {
+    cursor: pointer;
+  }
+  .client-count-link:hover {
     color: var(--text);
+  }
+  .client-count-sep {
+    color: var(--text-dim);
   }
 
   .add-btn {

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -366,6 +366,7 @@
     display: flex;
     align-items: center;
     gap: 0.25em;
+    min-width: 0;
   }
 
   .btn-p2p-connect {
@@ -398,7 +399,8 @@
     display: flex;
     align-items: center;
     gap: 0.5em;
-    width: 100%;
+    flex: 1;
+    min-width: 0;
     padding: 0.5em;
     border: none;
     background: transparent;

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -5,6 +5,7 @@
   import iconPlug from "@iconify-icons/twemoji/electric-plug";
   import iconCross from "@iconify-icons/twemoji/cross-mark";
   import P2P from "./P2P.svelte";
+  import * as p2p from "./p2p.js";
 
   let rooms = [];
   let peers = [];
@@ -19,7 +20,7 @@
   let messageInputEl;
   let p2pRoom = null;
   let p2pPeer = null;
-  let pendingOffer = null;
+  let p2pState = p2p.getState();
 
   async function loadStatus() {
     try {
@@ -191,17 +192,7 @@
     loadRooms();
   }
 
-  function onWebrtcOffer(e) {
-    const detail = e.detail;
-    // If P2P panel is already open for this room, the P2P component handles it
-    if (p2pRoom === detail.room_id) return;
-    // Auto-open P2P panel for the incoming offer's room
-    const room = rooms.find(r => r.id === detail.room_id);
-    if (!room) return;
-    pendingOffer = detail;
-    p2pRoom = room.id;
-    p2pPeer = room;
-  }
+  let unsubP2P;
 
   onMount(() => {
     loadStatus();
@@ -217,7 +208,16 @@
     window.addEventListener("chat-verify-complete", onChatVerifyComplete);
     window.addEventListener("chat-rooms", onChatRooms);
     window.addEventListener("chat-defriended", onChatDefriended);
-    window.addEventListener("webrtc-offer", onWebrtcOffer);
+    unsubP2P = p2p.onChange(s => {
+      p2pState = s;
+      // Auto-open P2P panel when connection is established from any page
+      if (s.roomId && !p2pRoom) {
+        const room = rooms.find(r => r.id === s.roomId);
+        if (room) { p2pRoom = room.id; p2pPeer = room; }
+      }
+      // Clear panel when connection closes
+      if (!s.roomId && p2pRoom) { p2pRoom = null; p2pPeer = null; }
+    });
   });
 
   onDestroy(() => {
@@ -227,7 +227,7 @@
     window.removeEventListener("chat-verify-complete", onChatVerifyComplete);
     window.removeEventListener("chat-rooms", onChatRooms);
     window.removeEventListener("chat-defriended", onChatDefriended);
-    window.removeEventListener("webrtc-offer", onWebrtcOffer);
+    if (unsubP2P) unsubP2P();
   });
 </script>
 
@@ -246,18 +246,18 @@
         </button>
         <button
           class="btn-small btn-p2p-connect"
-          class:btn-p2p-active={p2pRoom === room.id}
-          disabled={p2pRoom && p2pRoom !== room.id}
+          class:btn-p2p-active={p2pState.roomId === room.id}
+          disabled={p2pState.roomId && p2pState.roomId !== room.id}
           on:click|stopPropagation={() => {
-            if (p2pRoom === room.id) {
-              p2pRoom = null;
-              p2pPeer = null;
+            if (p2pState.roomId === room.id) {
+              p2p.hangup();
             } else {
               p2pRoom = room.id;
               p2pPeer = room;
+              p2p.connect(room.id, room.name, chatStatus.fingerprint, room.fingerprint);
             }
           }}
-          title={p2pRoom === room.id ? "Close P2P" : "P2P Connect"}
+          title={p2pState.roomId === room.id ? "Disconnect P2P" : "P2P Connect"}
         ><Icon icon={iconPlug} width={14} /></button>
       </div>
     {/each}
@@ -306,8 +306,6 @@
         peerName={p2pPeer.name}
         ownFingerprint={chatStatus.fingerprint}
         peerFingerprint={p2pPeer.fingerprint}
-        {pendingOffer}
-        on:offer-consumed={() => { pendingOffer = null; }}
       />
     {/if}
     {#if !chatStatus.active}

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -17,6 +17,7 @@
   let messageInputEl;
   let p2pRoom = null;
   let p2pPeer = null;
+  let pendingOffer = null;
 
   async function loadStatus() {
     try {
@@ -188,6 +189,18 @@
     loadRooms();
   }
 
+  function onWebrtcOffer(e) {
+    const detail = e.detail;
+    // If P2P panel is already open for this room, the P2P component handles it
+    if (p2pRoom === detail.room_id) return;
+    // Auto-open P2P panel for the incoming offer's room
+    const room = rooms.find(r => r.id === detail.room_id);
+    if (!room) return;
+    pendingOffer = detail;
+    p2pRoom = room.id;
+    p2pPeer = room;
+  }
+
   onMount(() => {
     loadStatus();
     loadRooms();
@@ -202,6 +215,7 @@
     window.addEventListener("chat-verify-complete", onChatVerifyComplete);
     window.addEventListener("chat-rooms", onChatRooms);
     window.addEventListener("chat-defriended", onChatDefriended);
+    window.addEventListener("webrtc-offer", onWebrtcOffer);
   });
 
   onDestroy(() => {
@@ -211,6 +225,7 @@
     window.removeEventListener("chat-verify-complete", onChatVerifyComplete);
     window.removeEventListener("chat-rooms", onChatRooms);
     window.removeEventListener("chat-defriended", onChatDefriended);
+    window.removeEventListener("webrtc-offer", onWebrtcOffer);
   });
 </script>
 
@@ -289,6 +304,8 @@
         peerName={p2pPeer.name}
         ownFingerprint={chatStatus.fingerprint}
         peerFingerprint={p2pPeer.fingerprint}
+        {pendingOffer}
+        on:offer-consumed={() => { pendingOffer = null; }}
       />
     {/if}
     {#if !chatStatus.active}

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -141,6 +141,13 @@
   }
 
   $: trustedSet = new Set(trusted.map(t => t.fingerprint));
+  $: onlinePeerSet = new Set(peers.map(p => p.fingerprint));
+
+  function peerStatus(room) {
+    if (p2pState.roomId === room.id && p2pState.connectionState === "connected") return "p2p";
+    if (onlinePeerSet.has(room.fingerprint)) return "online";
+    return "offline";
+  }
 
   function isPendingOutgoing(fingerprint) {
     // We don't track this client-side yet, just return false
@@ -241,7 +248,7 @@
           class:active={activeRoom === room.id}
           on:click={() => selectRoom(room.id)}
         >
-          <span class="room-icon"><Icon icon={iconLocked} width={16} /></span>
+          <span class="peer-status-dot" class:status-p2p={peerStatus(room) === "p2p"} class:status-online={peerStatus(room) === "online"} class:status-offline={peerStatus(room) === "offline"}></span>
           <span class="room-name">{room.name}</span>
         </button>
         <button
@@ -384,6 +391,31 @@
     align-items: center;
     gap: 0.25em;
     min-width: 0;
+  }
+
+  .peer-status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .status-offline {
+    background: var(--error, #f44336);
+  }
+
+  .status-online {
+    background: var(--warning, #ff9800);
+  }
+
+  .status-p2p {
+    background: var(--success, #4caf50);
+    animation: pulse-glow 2s ease-in-out infinite;
+  }
+
+  @keyframes pulse-glow {
+    0%, 100% { opacity: 1; box-shadow: 0 0 3px var(--success, #4caf50); }
+    50% { opacity: 0.6; box-shadow: 0 0 8px var(--success, #4caf50); }
   }
 
   .btn-p2p-connect {

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -2,6 +2,7 @@
   import { onMount, onDestroy, tick } from "svelte";
   import Icon from "@iconify/svelte";
   import iconLocked from "@iconify-icons/twemoji/locked";
+  import iconPlug from "@iconify-icons/twemoji/electric-plug";
   import P2P from "./P2P.svelte";
 
   let rooms = [];
@@ -256,7 +257,7 @@
             }
           }}
           title={p2pRoom === room.id ? "Close P2P" : "P2P Connect"}
-        >{p2pRoom === room.id ? "P2P ✕" : "P2P"}</button>
+        ><Icon icon={iconPlug} width={14} /></button>
       </div>
     {/each}
     {#if rooms.length === 0}

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -2,6 +2,7 @@
   import { onMount, onDestroy, tick } from "svelte";
   import Icon from "@iconify/svelte";
   import iconLocked from "@iconify-icons/twemoji/locked";
+  import P2P from "./P2P.svelte";
 
   let rooms = [];
   let peers = [];
@@ -14,6 +15,8 @@
   let chatStatus = { active: false, cn: null, fingerprint: null, lobby_joined: false };
   let messagesEnd;
   let messageInputEl;
+  let p2pRoom = null;
+  let p2pPeer = null;
 
   async function loadStatus() {
     try {
@@ -215,14 +218,31 @@
   <div class="chat-sidebar">
     <div class="sidebar-header">Rooms</div>
     {#each rooms as room}
-      <button
-        class="room-item"
-        class:active={activeRoom === room.id}
-        on:click={() => selectRoom(room.id)}
-      >
-        <span class="room-icon"><Icon icon={iconLocked} width={16} /></span>
-        <span class="room-name">{room.name}</span>
-      </button>
+      <div class="room-row">
+        <button
+          class="room-item"
+          class:active={activeRoom === room.id}
+          on:click={() => selectRoom(room.id)}
+        >
+          <span class="room-icon"><Icon icon={iconLocked} width={16} /></span>
+          <span class="room-name">{room.name}</span>
+        </button>
+        <button
+          class="btn-small btn-p2p-connect"
+          class:btn-p2p-active={p2pRoom === room.id}
+          disabled={p2pRoom && p2pRoom !== room.id}
+          on:click|stopPropagation={() => {
+            if (p2pRoom === room.id) {
+              p2pRoom = null;
+              p2pPeer = null;
+            } else {
+              p2pRoom = room.id;
+              p2pPeer = room;
+            }
+          }}
+          title={p2pRoom === room.id ? "Close P2P" : "P2P Connect"}
+        >{p2pRoom === room.id ? "P2P ✕" : "P2P"}</button>
+      </div>
     {/each}
     {#if rooms.length === 0}
       <p class="sidebar-hint">No rooms yet. Verify a peer to start chatting.</p>
@@ -263,6 +283,14 @@
   </div>
 
   <div class="chat-main">
+    {#if p2pRoom && p2pPeer}
+      <P2P
+        roomId={p2pRoom}
+        peerName={p2pPeer.name}
+        ownFingerprint={chatStatus.fingerprint}
+        peerFingerprint={p2pPeer.fingerprint}
+      />
+    {/if}
     {#if !chatStatus.active}
       <div class="chat-empty">
         <p>Chat is not active. Enable NATS Chat in Settings.</p>
@@ -332,6 +360,38 @@
     color: var(--text-muted, #888);
     padding: 0.25em 0.5em;
     margin: 0;
+  }
+
+  .room-row {
+    display: flex;
+    align-items: center;
+    gap: 0.25em;
+  }
+
+  .btn-p2p-connect {
+    flex-shrink: 0;
+    font-size: 0.65rem;
+    padding: 0.15em 0.4em;
+    border: 1px solid var(--border, #444);
+    border-radius: 3px;
+    background: var(--bg, #222);
+    color: var(--text-muted, #888);
+    cursor: pointer;
+  }
+
+  .btn-p2p-connect:hover:not(:disabled) {
+    background: var(--bg-hover, #2a2a2a);
+    color: var(--text, #ccc);
+  }
+
+  .btn-p2p-connect:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .btn-p2p-active {
+    border-color: var(--accent, #e6a700);
+    color: var(--accent, #e6a700);
   }
 
   .room-item {

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -143,9 +143,9 @@
   $: trustedSet = new Set(trusted.map(t => t.fingerprint));
   $: onlinePeerSet = new Set(peers.map(p => p.fingerprint));
 
-  function peerStatus(room) {
-    if (p2pState.roomId === room.id && p2pState.connectionState === "connected") return "p2p";
-    if (onlinePeerSet.has(room.fingerprint)) return "online";
+  function peerStatus(room, _p2p, _online) {
+    if (_p2p.roomId === room.id && _p2p.connectionState === "connected") return "p2p";
+    if (_online.has(room.fingerprint)) return "online";
     return "offline";
   }
 
@@ -248,7 +248,7 @@
           class:active={activeRoom === room.id}
           on:click={() => selectRoom(room.id)}
         >
-          <span class="peer-status-dot" class:status-p2p={peerStatus(room) === "p2p"} class:status-online={peerStatus(room) === "online"} class:status-offline={peerStatus(room) === "offline"}></span>
+          <span class="peer-status-dot" class:status-p2p={peerStatus(room, p2pState, onlinePeerSet) === "p2p"} class:status-online={peerStatus(room, p2pState, onlinePeerSet) === "online"} class:status-offline={peerStatus(room, p2pState, onlinePeerSet) === "offline"}></span>
           <span class="room-name">{room.name}</span>
         </button>
         <button

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -3,6 +3,7 @@
   import Icon from "@iconify/svelte";
   import iconLocked from "@iconify-icons/twemoji/locked";
   import iconPlug from "@iconify-icons/twemoji/electric-plug";
+  import iconCross from "@iconify-icons/twemoji/cross-mark";
   import P2P from "./P2P.svelte";
 
   let rooms = [];
@@ -272,7 +273,7 @@
           <div class="peer-fp">{shortFingerprint(peer.fingerprint)}</div>
           {#if trustedSet.has(peer.fingerprint)}
             <span class="peer-badge trusted">Friends</span>
-            <button class="btn-small btn-defriend" on:click={() => defriend(peer)} title="Remove friend">✕</button>
+            <button class="btn-small btn-defriend" on:click={() => defriend(peer)} title="Remove friend"><Icon icon={iconCross} width={12} /></button>
           {:else}
             <button class="btn-small" on:click={() => verifyPeer(peer.fingerprint)}>Verify</button>
           {/if}

--- a/frontend/src/P2P.svelte
+++ b/frontend/src/P2P.svelte
@@ -1,253 +1,30 @@
 <script>
-  import { onMount, onDestroy, createEventDispatcher } from "svelte";
-
-  const dispatch = createEventDispatcher();
+  import { onMount, onDestroy } from "svelte";
+  import * as p2p from "./p2p.js";
 
   export let roomId;
   export let peerName;
   export let ownFingerprint;
   export let peerFingerprint;
-  export let pendingOffer = null;
 
-  let pc = null;
-  let dc = null;
-  let connectionState = "idle";
-  let iceState = "";
-  let signalingState = "";
-  let makingOffer = false;
-  let debugLog = [];
+  let s = p2p.getState();
   let debugOpen = false;
-  let pingResults = [];
-  let localCandidates = [];
-  let remoteCandidates = [];
-  let localSdp = "";
-  let remoteSdp = "";
+  let unsubscribe;
 
+  $: active = s.roomId === roomId;
   $: polite = ownFingerprint < peerFingerprint;
-  $: dcOpen = dc && dc.readyState === "open";
-
-  function log(msg) {
-    const ts = new Date().toLocaleTimeString("en-US", { hour12: false, fractionalSecondDigits: 3 });
-    debugLog = [...debugLog, `[${ts}] ${msg}`];
-  }
-
-  async function sendSignal(type, fields = {}) {
-    try {
-      await fetch(`/api/chat/rooms/${roomId}/signal`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ type, ...fields, ts: Date.now() / 1000 }),
-      });
-    } catch (err) {
-      log(`Signal send error: ${err.message}`);
-    }
-  }
-
-  function connect() {
-    if (pc) return;
-    log("Creating RTCPeerConnection");
-    connectionState = "connecting";
-
-    pc = new RTCPeerConnection({
-      iceServers: [{ urls: "stun:stun.l.google.com:19302" }],
-    });
-
-    pc.onicecandidate = ({ candidate }) => {
-      if (candidate) {
-        localCandidates = [...localCandidates, `${candidate.protocol || ""} ${candidate.address || ""}:${candidate.port || ""} ${candidate.type || ""}`];
-        sendSignal("webrtc-ice", {
-          candidate: candidate.candidate,
-          sdpMid: candidate.sdpMid,
-          sdpMLineIndex: candidate.sdpMLineIndex,
-        });
-      }
-    };
-
-    pc.oniceconnectionstatechange = () => {
-      iceState = pc.iceConnectionState;
-      log(`ICE: ${iceState}`);
-    };
-
-    pc.onconnectionstatechange = () => {
-      connectionState = pc.connectionState;
-      log(`Connection: ${connectionState}`);
-      if (connectionState === "failed" || connectionState === "closed") {
-        cleanup(false);
-      }
-    };
-
-    pc.onsignalingstatechange = () => {
-      signalingState = pc.signalingState;
-    };
-
-    pc.onnegotiationneeded = async () => {
-      try {
-        makingOffer = true;
-        await pc.setLocalDescription();
-        localSdp = pc.localDescription.sdp;
-        log("Sending offer");
-        await sendSignal("webrtc-offer", { sdp: pc.localDescription.sdp });
-      } catch (err) {
-        log(`Offer error: ${err.message}`);
-      } finally {
-        makingOffer = false;
-      }
-    };
-
-    pc.ondatachannel = (e) => {
-      log(`Remote data channel: ${e.channel.label}`);
-      setupDataChannel(e.channel);
-    };
-
-    // Create data channel (only the impolite peer creates it to avoid duplicates,
-    // but with perfect negotiation either side can — the offerer creates it)
-    dc = pc.createDataChannel("p2p-test");
-    setupDataChannel(dc);
-    log("Created data channel");
-  }
-
-  function setupDataChannel(channel) {
-    dc = channel;
-    channel.onopen = () => {
-      connectionState = "connected";
-      dc = channel;
-      log("Data channel open");
-    };
-    channel.onclose = () => {
-      log("Data channel closed");
-      dc = null;
-    };
-    channel.onmessage = (e) => {
-      try {
-        const msg = JSON.parse(e.data);
-        if (msg.type === "ping") {
-          channel.send(JSON.stringify({ type: "pong", ts: msg.ts }));
-        } else if (msg.type === "pong") {
-          const rtt = Date.now() - msg.ts;
-          pingResults = [...pingResults, rtt];
-          log(`Pong: ${rtt}ms RTT`);
-        }
-      } catch {}
-    };
-  }
-
-  function sendPing() {
-    if (dc && dc.readyState === "open") {
-      dc.send(JSON.stringify({ type: "ping", ts: Date.now() }));
-      log("Ping sent");
-    }
-  }
-
-  async function handleOffer(detail) {
-    if (detail.room_id !== roomId) return;
-    log("Received offer");
-
-    if (!pc) connect();
-
-    const offerCollision = makingOffer || pc.signalingState !== "stable";
-    const ignoreOffer = !polite && offerCollision;
-    if (ignoreOffer) {
-      log("Ignoring colliding offer (impolite)");
-      return;
-    }
-
-    try {
-      await pc.setRemoteDescription({ type: "offer", sdp: detail.sdp });
-      remoteSdp = detail.sdp;
-      await pc.setLocalDescription();
-      localSdp = pc.localDescription.sdp;
-      log("Sending answer");
-      await sendSignal("webrtc-answer", { sdp: pc.localDescription.sdp });
-    } catch (err) {
-      log(`Handle offer error: ${err.message}`);
-    }
-  }
-
-  async function handleAnswer(detail) {
-    if (detail.room_id !== roomId) return;
-    log("Received answer");
-    try {
-      await pc.setRemoteDescription({ type: "answer", sdp: detail.sdp });
-      remoteSdp = detail.sdp;
-    } catch (err) {
-      log(`Handle answer error: ${err.message}`);
-    }
-  }
-
-  async function handleIce(detail) {
-    if (detail.room_id !== roomId) return;
-    try {
-      const candidate = new RTCIceCandidate({
-        candidate: detail.candidate,
-        sdpMid: detail.sdpMid,
-        sdpMLineIndex: detail.sdpMLineIndex,
-      });
-      remoteCandidates = [...remoteCandidates, `${candidate.protocol || ""} ${candidate.address || ""}:${candidate.port || ""} ${candidate.type || ""}`];
-      await pc.addIceCandidate(candidate);
-    } catch (err) {
-      if (!polite || pc.signalingState !== "stable") return;
-      log(`ICE candidate error: ${err.message}`);
-    }
-  }
-
-  function handleHangup(detail) {
-    if (detail.room_id !== roomId) return;
-    log("Remote peer hung up");
-    cleanup(false);
-  }
-
-  function hangup() {
-    sendSignal("webrtc-hangup");
-    cleanup(false);
-  }
-
-  function cleanup(silent = false) {
-    if (dc) {
-      try { dc.close(); } catch {}
-      dc = null;
-    }
-    if (pc) {
-      try { pc.close(); } catch {}
-      pc = null;
-    }
-    connectionState = "idle";
-    iceState = "";
-    signalingState = "";
-    makingOffer = false;
-    localCandidates = [];
-    remoteCandidates = [];
-    localSdp = "";
-    remoteSdp = "";
-    if (!silent) log("Connection closed");
-  }
-
-  function onOffer(e) { handleOffer(e.detail); }
-  function onAnswer(e) { handleAnswer(e.detail); }
-  function onIce(e) { handleIce(e.detail); }
-  function onHangup(e) { handleHangup(e.detail); }
 
   onMount(() => {
-    window.addEventListener("webrtc-offer", onOffer);
-    window.addEventListener("webrtc-answer", onAnswer);
-    window.addEventListener("webrtc-ice", onIce);
-    window.addEventListener("webrtc-hangup", onHangup);
-    // If opened due to an incoming offer, auto-connect and handle it
-    if (pendingOffer) {
-      handleOffer(pendingOffer);
-      dispatch("offer-consumed");
-    }
+    unsubscribe = p2p.onChange(next => { s = next; });
   });
 
   onDestroy(() => {
-    window.removeEventListener("webrtc-offer", onOffer);
-    window.removeEventListener("webrtc-answer", onAnswer);
-    window.removeEventListener("webrtc-ice", onIce);
-    window.removeEventListener("webrtc-hangup", onHangup);
-    if (pc) {
-      sendSignal("webrtc-hangup");
-      cleanup(true);
-    }
+    if (unsubscribe) unsubscribe();
   });
+
+  function connect() {
+    p2p.connect(roomId, peerName, ownFingerprint, peerFingerprint);
+  }
 
   function stateColor(state) {
     if (state === "connected") return "var(--success, #4caf50)";
@@ -259,78 +36,79 @@
 
 <div class="p2p-panel">
   <div class="p2p-header">
-    <span class="p2p-status-dot" style="background: {stateColor(connectionState)}"></span>
+    <span class="p2p-status-dot" style="background: {stateColor(active ? s.connectionState : 'idle')}"></span>
     <span class="p2p-title">P2P: {peerName}</span>
-    <span class="p2p-state">{connectionState}</span>
+    <span class="p2p-state">{active ? s.connectionState : "idle"}</span>
     <div class="p2p-actions">
-      {#if connectionState === "idle"}
-        <button class="btn-p2p" on:click={connect}>Connect</button>
+      {#if !active || s.connectionState === "idle"}
+        <button class="btn-p2p" on:click={connect} disabled={s.roomId && !active}>Connect</button>
       {:else}
-        <button class="btn-p2p btn-hangup" on:click={hangup}>Hangup</button>
+        <button class="btn-p2p btn-hangup" on:click={p2p.hangup}>Hangup</button>
       {/if}
-      {#if dcOpen}
-        <button class="btn-p2p" on:click={sendPing}>Ping</button>
+      {#if active && s.dcOpen}
+        <button class="btn-p2p" on:click={p2p.sendPing}>Ping</button>
       {/if}
-      <button class="btn-p2p btn-close" on:click={() => { if (pc) hangup(); }}>Close</button>
     </div>
   </div>
 
-  {#if pingResults.length > 0}
+  {#if active && s.pingResults.length > 0}
     <div class="ping-results">
       <span class="ping-label">RTT:</span>
-      {#each pingResults.slice(-10) as rtt}
+      {#each s.pingResults.slice(-10) as rtt}
         <span class="ping-value">{rtt}ms</span>
       {/each}
     </div>
   {/if}
 
-  <button class="debug-toggle" on:click={() => debugOpen = !debugOpen}>
-    {debugOpen ? "Hide" : "Show"} Debug {debugLog.length > 0 ? `(${debugLog.length})` : ""}
-  </button>
+  {#if active}
+    <button class="debug-toggle" on:click={() => debugOpen = !debugOpen}>
+      {debugOpen ? "Hide" : "Show"} Debug {s.debugLog.length > 0 ? `(${s.debugLog.length})` : ""}
+    </button>
 
-  {#if debugOpen}
-    <div class="debug-panel">
-      <div class="debug-section">
-        <div class="debug-row"><strong>Role:</strong> {polite ? "polite" : "impolite"}</div>
-        <div class="debug-row"><strong>Connection:</strong> {connectionState}</div>
-        <div class="debug-row"><strong>ICE:</strong> {iceState || "n/a"}</div>
-        <div class="debug-row"><strong>Signaling:</strong> {signalingState || "n/a"}</div>
-      </div>
-
-      {#if localCandidates.length > 0}
+    {#if debugOpen}
+      <div class="debug-panel">
         <div class="debug-section">
-          <strong>Local candidates ({localCandidates.length}):</strong>
-          <div class="candidate-list">{#each localCandidates as c}<div class="candidate">{c}</div>{/each}</div>
+          <div class="debug-row"><strong>Role:</strong> {polite ? "polite" : "impolite"}</div>
+          <div class="debug-row"><strong>Connection:</strong> {s.connectionState}</div>
+          <div class="debug-row"><strong>ICE:</strong> {s.iceState || "n/a"}</div>
+          <div class="debug-row"><strong>Signaling:</strong> {s.signalingState || "n/a"}</div>
         </div>
-      {/if}
 
-      {#if remoteCandidates.length > 0}
-        <div class="debug-section">
-          <strong>Remote candidates ({remoteCandidates.length}):</strong>
-          <div class="candidate-list">{#each remoteCandidates as c}<div class="candidate">{c}</div>{/each}</div>
+        {#if s.localCandidates.length > 0}
+          <div class="debug-section">
+            <strong>Local candidates ({s.localCandidates.length}):</strong>
+            <div class="candidate-list">{#each s.localCandidates as c}<div class="candidate">{c}</div>{/each}</div>
+          </div>
+        {/if}
+
+        {#if s.remoteCandidates.length > 0}
+          <div class="debug-section">
+            <strong>Remote candidates ({s.remoteCandidates.length}):</strong>
+            <div class="candidate-list">{#each s.remoteCandidates as c}<div class="candidate">{c}</div>{/each}</div>
+          </div>
+        {/if}
+
+        {#if s.localSdp}
+          <details class="debug-section">
+            <summary>Local SDP</summary>
+            <pre class="sdp">{s.localSdp}</pre>
+          </details>
+        {/if}
+
+        {#if s.remoteSdp}
+          <details class="debug-section">
+            <summary>Remote SDP</summary>
+            <pre class="sdp">{s.remoteSdp}</pre>
+          </details>
+        {/if}
+
+        <div class="debug-log">
+          {#each s.debugLog as entry}
+            <div class="log-entry">{entry}</div>
+          {/each}
         </div>
-      {/if}
-
-      {#if localSdp}
-        <details class="debug-section">
-          <summary>Local SDP</summary>
-          <pre class="sdp">{localSdp}</pre>
-        </details>
-      {/if}
-
-      {#if remoteSdp}
-        <details class="debug-section">
-          <summary>Remote SDP</summary>
-          <pre class="sdp">{remoteSdp}</pre>
-        </details>
-      {/if}
-
-      <div class="debug-log">
-        {#each debugLog as entry}
-          <div class="log-entry">{entry}</div>
-        {/each}
       </div>
-    </div>
+    {/if}
   {/if}
 </div>
 
@@ -389,14 +167,14 @@
     background: var(--bg-hover, #2a2a2a);
   }
 
+  .btn-p2p:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
   .btn-hangup {
     border-color: var(--error, #f44336);
     color: var(--error, #f44336);
-  }
-
-  .btn-close {
-    border-color: var(--text-muted, #666);
-    color: var(--text-muted, #888);
   }
 
   .ping-results {

--- a/frontend/src/P2P.svelte
+++ b/frontend/src/P2P.svelte
@@ -1,0 +1,485 @@
+<script>
+  import { onMount, onDestroy } from "svelte";
+
+  export let roomId;
+  export let peerName;
+  export let ownFingerprint;
+  export let peerFingerprint;
+
+  let pc = null;
+  let dc = null;
+  let connectionState = "idle";
+  let iceState = "";
+  let signalingState = "";
+  let makingOffer = false;
+  let debugLog = [];
+  let debugOpen = false;
+  let pingResults = [];
+  let localCandidates = [];
+  let remoteCandidates = [];
+  let localSdp = "";
+  let remoteSdp = "";
+
+  $: polite = ownFingerprint < peerFingerprint;
+  $: dcOpen = dc && dc.readyState === "open";
+
+  function log(msg) {
+    const ts = new Date().toLocaleTimeString("en-US", { hour12: false, fractionalSecondDigits: 3 });
+    debugLog = [...debugLog, `[${ts}] ${msg}`];
+  }
+
+  async function sendSignal(type, fields = {}) {
+    try {
+      await fetch(`/api/chat/rooms/${roomId}/signal`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type, ...fields, ts: Date.now() / 1000 }),
+      });
+    } catch (err) {
+      log(`Signal send error: ${err.message}`);
+    }
+  }
+
+  function connect() {
+    if (pc) return;
+    log("Creating RTCPeerConnection");
+    connectionState = "connecting";
+
+    pc = new RTCPeerConnection({
+      iceServers: [{ urls: "stun:stun.l.google.com:19302" }],
+    });
+
+    pc.onicecandidate = ({ candidate }) => {
+      if (candidate) {
+        localCandidates = [...localCandidates, `${candidate.protocol || ""} ${candidate.address || ""}:${candidate.port || ""} ${candidate.type || ""}`];
+        sendSignal("webrtc-ice", {
+          candidate: candidate.candidate,
+          sdpMid: candidate.sdpMid,
+          sdpMLineIndex: candidate.sdpMLineIndex,
+        });
+      }
+    };
+
+    pc.oniceconnectionstatechange = () => {
+      iceState = pc.iceConnectionState;
+      log(`ICE: ${iceState}`);
+    };
+
+    pc.onconnectionstatechange = () => {
+      connectionState = pc.connectionState;
+      log(`Connection: ${connectionState}`);
+      if (connectionState === "failed" || connectionState === "closed") {
+        cleanup(false);
+      }
+    };
+
+    pc.onsignalingstatechange = () => {
+      signalingState = pc.signalingState;
+    };
+
+    pc.onnegotiationneeded = async () => {
+      try {
+        makingOffer = true;
+        await pc.setLocalDescription();
+        localSdp = pc.localDescription.sdp;
+        log("Sending offer");
+        await sendSignal("webrtc-offer", { sdp: pc.localDescription.sdp });
+      } catch (err) {
+        log(`Offer error: ${err.message}`);
+      } finally {
+        makingOffer = false;
+      }
+    };
+
+    pc.ondatachannel = (e) => {
+      log(`Remote data channel: ${e.channel.label}`);
+      setupDataChannel(e.channel);
+    };
+
+    // Create data channel (only the impolite peer creates it to avoid duplicates,
+    // but with perfect negotiation either side can — the offerer creates it)
+    dc = pc.createDataChannel("p2p-test");
+    setupDataChannel(dc);
+    log("Created data channel");
+  }
+
+  function setupDataChannel(channel) {
+    dc = channel;
+    channel.onopen = () => {
+      connectionState = "connected";
+      dc = channel;
+      log("Data channel open");
+    };
+    channel.onclose = () => {
+      log("Data channel closed");
+      dc = null;
+    };
+    channel.onmessage = (e) => {
+      try {
+        const msg = JSON.parse(e.data);
+        if (msg.type === "ping") {
+          channel.send(JSON.stringify({ type: "pong", ts: msg.ts }));
+        } else if (msg.type === "pong") {
+          const rtt = Date.now() - msg.ts;
+          pingResults = [...pingResults, rtt];
+          log(`Pong: ${rtt}ms RTT`);
+        }
+      } catch {}
+    };
+  }
+
+  function sendPing() {
+    if (dc && dc.readyState === "open") {
+      dc.send(JSON.stringify({ type: "ping", ts: Date.now() }));
+      log("Ping sent");
+    }
+  }
+
+  async function handleOffer(detail) {
+    if (detail.room_id !== roomId) return;
+    log("Received offer");
+
+    if (!pc) connect();
+
+    const offerCollision = makingOffer || pc.signalingState !== "stable";
+    const ignoreOffer = !polite && offerCollision;
+    if (ignoreOffer) {
+      log("Ignoring colliding offer (impolite)");
+      return;
+    }
+
+    try {
+      await pc.setRemoteDescription({ type: "offer", sdp: detail.sdp });
+      remoteSdp = detail.sdp;
+      await pc.setLocalDescription();
+      localSdp = pc.localDescription.sdp;
+      log("Sending answer");
+      await sendSignal("webrtc-answer", { sdp: pc.localDescription.sdp });
+    } catch (err) {
+      log(`Handle offer error: ${err.message}`);
+    }
+  }
+
+  async function handleAnswer(detail) {
+    if (detail.room_id !== roomId) return;
+    log("Received answer");
+    try {
+      await pc.setRemoteDescription({ type: "answer", sdp: detail.sdp });
+      remoteSdp = detail.sdp;
+    } catch (err) {
+      log(`Handle answer error: ${err.message}`);
+    }
+  }
+
+  async function handleIce(detail) {
+    if (detail.room_id !== roomId) return;
+    try {
+      const candidate = new RTCIceCandidate({
+        candidate: detail.candidate,
+        sdpMid: detail.sdpMid,
+        sdpMLineIndex: detail.sdpMLineIndex,
+      });
+      remoteCandidates = [...remoteCandidates, `${candidate.protocol || ""} ${candidate.address || ""}:${candidate.port || ""} ${candidate.type || ""}`];
+      await pc.addIceCandidate(candidate);
+    } catch (err) {
+      if (!polite || pc.signalingState !== "stable") return;
+      log(`ICE candidate error: ${err.message}`);
+    }
+  }
+
+  function handleHangup(detail) {
+    if (detail.room_id !== roomId) return;
+    log("Remote peer hung up");
+    cleanup(false);
+  }
+
+  function hangup() {
+    sendSignal("webrtc-hangup");
+    cleanup(false);
+  }
+
+  function cleanup(silent = false) {
+    if (dc) {
+      try { dc.close(); } catch {}
+      dc = null;
+    }
+    if (pc) {
+      try { pc.close(); } catch {}
+      pc = null;
+    }
+    connectionState = "idle";
+    iceState = "";
+    signalingState = "";
+    makingOffer = false;
+    localCandidates = [];
+    remoteCandidates = [];
+    localSdp = "";
+    remoteSdp = "";
+    if (!silent) log("Connection closed");
+  }
+
+  function onOffer(e) { handleOffer(e.detail); }
+  function onAnswer(e) { handleAnswer(e.detail); }
+  function onIce(e) { handleIce(e.detail); }
+  function onHangup(e) { handleHangup(e.detail); }
+
+  onMount(() => {
+    window.addEventListener("webrtc-offer", onOffer);
+    window.addEventListener("webrtc-answer", onAnswer);
+    window.addEventListener("webrtc-ice", onIce);
+    window.addEventListener("webrtc-hangup", onHangup);
+  });
+
+  onDestroy(() => {
+    window.removeEventListener("webrtc-offer", onOffer);
+    window.removeEventListener("webrtc-answer", onAnswer);
+    window.removeEventListener("webrtc-ice", onIce);
+    window.removeEventListener("webrtc-hangup", onHangup);
+    if (pc) {
+      sendSignal("webrtc-hangup");
+      cleanup(true);
+    }
+  });
+
+  function stateColor(state) {
+    if (state === "connected") return "var(--success, #4caf50)";
+    if (state === "connecting") return "var(--warning, #ff9800)";
+    if (state === "failed") return "var(--error, #f44336)";
+    return "var(--text-muted, #888)";
+  }
+</script>
+
+<div class="p2p-panel">
+  <div class="p2p-header">
+    <span class="p2p-status-dot" style="background: {stateColor(connectionState)}"></span>
+    <span class="p2p-title">P2P: {peerName}</span>
+    <span class="p2p-state">{connectionState}</span>
+    <div class="p2p-actions">
+      {#if connectionState === "idle"}
+        <button class="btn-p2p" on:click={connect}>Connect</button>
+      {:else}
+        <button class="btn-p2p btn-hangup" on:click={hangup}>Hangup</button>
+      {/if}
+      {#if dcOpen}
+        <button class="btn-p2p" on:click={sendPing}>Ping</button>
+      {/if}
+      <button class="btn-p2p btn-close" on:click={() => { if (pc) hangup(); }}>Close</button>
+    </div>
+  </div>
+
+  {#if pingResults.length > 0}
+    <div class="ping-results">
+      <span class="ping-label">RTT:</span>
+      {#each pingResults.slice(-10) as rtt}
+        <span class="ping-value">{rtt}ms</span>
+      {/each}
+    </div>
+  {/if}
+
+  <button class="debug-toggle" on:click={() => debugOpen = !debugOpen}>
+    {debugOpen ? "Hide" : "Show"} Debug {debugLog.length > 0 ? `(${debugLog.length})` : ""}
+  </button>
+
+  {#if debugOpen}
+    <div class="debug-panel">
+      <div class="debug-section">
+        <div class="debug-row"><strong>Role:</strong> {polite ? "polite" : "impolite"}</div>
+        <div class="debug-row"><strong>Connection:</strong> {connectionState}</div>
+        <div class="debug-row"><strong>ICE:</strong> {iceState || "n/a"}</div>
+        <div class="debug-row"><strong>Signaling:</strong> {signalingState || "n/a"}</div>
+      </div>
+
+      {#if localCandidates.length > 0}
+        <div class="debug-section">
+          <strong>Local candidates ({localCandidates.length}):</strong>
+          <div class="candidate-list">{#each localCandidates as c}<div class="candidate">{c}</div>{/each}</div>
+        </div>
+      {/if}
+
+      {#if remoteCandidates.length > 0}
+        <div class="debug-section">
+          <strong>Remote candidates ({remoteCandidates.length}):</strong>
+          <div class="candidate-list">{#each remoteCandidates as c}<div class="candidate">{c}</div>{/each}</div>
+        </div>
+      {/if}
+
+      {#if localSdp}
+        <details class="debug-section">
+          <summary>Local SDP</summary>
+          <pre class="sdp">{localSdp}</pre>
+        </details>
+      {/if}
+
+      {#if remoteSdp}
+        <details class="debug-section">
+          <summary>Remote SDP</summary>
+          <pre class="sdp">{remoteSdp}</pre>
+        </details>
+      {/if}
+
+      <div class="debug-log">
+        {#each debugLog as entry}
+          <div class="log-entry">{entry}</div>
+        {/each}
+      </div>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .p2p-panel {
+    border: 1px solid var(--border, #333);
+    border-radius: 6px;
+    margin: 0.5em;
+    background: var(--bg-sidebar, var(--bg, #1a1a1a));
+    overflow: hidden;
+  }
+
+  .p2p-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    padding: 0.5em 0.75em;
+    border-bottom: 1px solid var(--border, #333);
+  }
+
+  .p2p-status-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .p2p-title {
+    font-weight: bold;
+    font-size: 0.9rem;
+    color: var(--text, #ccc);
+  }
+
+  .p2p-state {
+    font-size: 0.75rem;
+    color: var(--text-muted, #888);
+    flex: 1;
+  }
+
+  .p2p-actions {
+    display: flex;
+    gap: 0.25em;
+  }
+
+  .btn-p2p {
+    padding: 0.2em 0.6em;
+    border: 1px solid var(--border, #444);
+    border-radius: 4px;
+    background: var(--bg, #222);
+    color: var(--text, #ccc);
+    cursor: pointer;
+    font-size: 0.8rem;
+  }
+
+  .btn-p2p:hover {
+    background: var(--bg-hover, #2a2a2a);
+  }
+
+  .btn-hangup {
+    border-color: var(--error, #f44336);
+    color: var(--error, #f44336);
+  }
+
+  .btn-close {
+    border-color: var(--text-muted, #666);
+    color: var(--text-muted, #888);
+  }
+
+  .ping-results {
+    display: flex;
+    gap: 0.5em;
+    padding: 0.25em 0.75em;
+    font-size: 0.8rem;
+    color: var(--text-muted, #888);
+    flex-wrap: wrap;
+    align-items: center;
+  }
+
+  .ping-label {
+    font-weight: bold;
+  }
+
+  .ping-value {
+    background: var(--bg, #222);
+    padding: 0.1em 0.4em;
+    border-radius: 3px;
+    font-family: monospace;
+    font-size: 0.75rem;
+  }
+
+  .debug-toggle {
+    display: block;
+    width: 100%;
+    padding: 0.25em 0.75em;
+    border: none;
+    border-top: 1px solid var(--border, #333);
+    background: transparent;
+    color: var(--text-muted, #888);
+    cursor: pointer;
+    font-size: 0.75rem;
+    text-align: left;
+  }
+
+  .debug-toggle:hover {
+    background: var(--bg-hover, #2a2a2a);
+  }
+
+  .debug-panel {
+    border-top: 1px solid var(--border, #333);
+    padding: 0.5em 0.75em;
+    font-size: 0.75rem;
+    max-height: 300px;
+    overflow-y: auto;
+  }
+
+  .debug-section {
+    margin-bottom: 0.5em;
+    color: var(--text, #ccc);
+  }
+
+  .debug-row {
+    margin: 0.15em 0;
+  }
+
+  .candidate-list {
+    margin-top: 0.15em;
+  }
+
+  .candidate {
+    font-family: monospace;
+    font-size: 0.7rem;
+    color: var(--text-muted, #888);
+    padding: 0.1em 0;
+  }
+
+  .sdp {
+    font-size: 0.65rem;
+    white-space: pre-wrap;
+    word-break: break-all;
+    max-height: 150px;
+    overflow-y: auto;
+    background: var(--bg, #111);
+    padding: 0.5em;
+    border-radius: 4px;
+    margin-top: 0.25em;
+  }
+
+  .debug-log {
+    border-top: 1px solid var(--border, #333);
+    padding-top: 0.25em;
+    margin-top: 0.5em;
+  }
+
+  .log-entry {
+    font-family: monospace;
+    font-size: 0.7rem;
+    color: var(--text-muted, #888);
+    padding: 0.1em 0;
+  }
+</style>

--- a/frontend/src/P2P.svelte
+++ b/frontend/src/P2P.svelte
@@ -1,10 +1,13 @@
 <script>
-  import { onMount, onDestroy } from "svelte";
+  import { onMount, onDestroy, createEventDispatcher } from "svelte";
+
+  const dispatch = createEventDispatcher();
 
   export let roomId;
   export let peerName;
   export let ownFingerprint;
   export let peerFingerprint;
+  export let pendingOffer = null;
 
   let pc = null;
   let dc = null;
@@ -228,6 +231,11 @@
     window.addEventListener("webrtc-answer", onAnswer);
     window.addEventListener("webrtc-ice", onIce);
     window.addEventListener("webrtc-hangup", onHangup);
+    // If opened due to an incoming offer, auto-connect and handle it
+    if (pendingOffer) {
+      handleOffer(pendingOffer);
+      dispatch("offer-consumed");
+    }
   });
 
   onDestroy(() => {

--- a/frontend/src/p2p.js
+++ b/frontend/src/p2p.js
@@ -13,6 +13,7 @@ let roomId = null;
 let peerName = null;
 let ownFingerprint = null;
 let peerFingerprint = null;
+let iceDisconnectTimer = null;
 
 let state = {
   connectionState: "idle",
@@ -120,12 +121,21 @@ function createPC() {
   pc.oniceconnectionstatechange = () => {
     state.iceState = pc.iceConnectionState;
     log(`ICE: ${state.iceState}`);
+    if (iceDisconnectTimer) { clearTimeout(iceDisconnectTimer); iceDisconnectTimer = null; }
+    if (state.iceState === "disconnected") {
+      iceDisconnectTimer = setTimeout(() => {
+        if (pc && pc.iceConnectionState === "disconnected") {
+          log("ICE disconnected timeout — closing");
+          cleanup(false);
+        }
+      }, 5000);
+    }
   };
 
   pc.onconnectionstatechange = () => {
     state.connectionState = pc.connectionState;
     log(`Connection: ${state.connectionState}`);
-    if (state.connectionState === "failed" || state.connectionState === "closed") {
+    if (state.connectionState === "failed" || state.connectionState === "closed" || state.connectionState === "disconnected") {
       cleanup(false);
     }
   };
@@ -159,8 +169,17 @@ function createPC() {
   log("Created data channel");
 }
 
+function isStale() {
+  if (!pc) return false;
+  const cs = pc.connectionState;
+  const ice = pc.iceConnectionState;
+  return cs === "failed" || cs === "closed" || cs === "disconnected"
+    || ice === "failed" || ice === "closed" || ice === "disconnected";
+}
+
 /** Start a P2P connection to a peer (called from UI). */
 export function connect(rid, name, ownFp, peerFp) {
+  if (pc && isStale()) { log("Clearing stale connection"); cleanup(true); }
   if (pc) return;
   roomId = rid;
   peerName = name;
@@ -187,6 +206,7 @@ export function hangup() {
 }
 
 function cleanup(silent) {
+  if (iceDisconnectTimer) { clearTimeout(iceDisconnectTimer); iceDisconnectTimer = null; }
   if (dc) { try { dc.close(); } catch {} dc = null; }
   if (pc) { try { pc.close(); } catch {} pc = null; }
   roomId = null;
@@ -215,11 +235,18 @@ function cleanup(silent) {
 
 export function handleOffer(detail, rooms, chatStatus) {
   if (detail.room_id === roomId && pc) {
-    // Already connected to this room — handle normally
-    _handleOfferInternal(detail);
-    return;
+    if (isStale()) {
+      // Stale connection to same room — tear down and reconnect
+      log("Tearing down stale connection for re-offer");
+      cleanup(true);
+    } else {
+      // Active connection to this room — handle as renegotiation
+      _handleOfferInternal(detail);
+      return;
+    }
   }
-  if (pc) return; // busy with another connection
+  if (pc && isStale()) { log("Clearing stale connection"); cleanup(true); }
+  if (pc) return; // busy with a healthy connection to another peer
 
   // Auto-connect: find the room to get peer info
   const room = rooms.find(r => r.id === detail.room_id);

--- a/frontend/src/p2p.js
+++ b/frontend/src/p2p.js
@@ -1,0 +1,289 @@
+/**
+ * P2P WebRTC connection manager.
+ *
+ * Runs at the app level — handles signaling events regardless of which
+ * page is active.  Exposes state via onChange callbacks and the getState()
+ * snapshot so UI components can subscribe without owning the connection.
+ */
+
+let pc = null;
+let dc = null;
+let makingOffer = false;
+let roomId = null;
+let peerName = null;
+let ownFingerprint = null;
+let peerFingerprint = null;
+
+let state = {
+  connectionState: "idle",
+  iceState: "",
+  signalingState: "",
+  dcOpen: false,
+  roomId: null,
+  peerName: null,
+  ownFingerprint: null,
+  peerFingerprint: null,
+  polite: false,
+  debugLog: [],
+  pingResults: [],
+  localCandidates: [],
+  remoteCandidates: [],
+  localSdp: "",
+  remoteSdp: "",
+};
+
+const listeners = new Set();
+
+function notify() {
+  state = { ...state };
+  for (const fn of listeners) fn(state);
+}
+
+export function onChange(fn) {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+export function getState() {
+  return state;
+}
+
+function log(msg) {
+  const ts = new Date().toLocaleTimeString("en-US", { hour12: false, fractionalSecondDigits: 3 });
+  state.debugLog = [...state.debugLog, `[${ts}] ${msg}`];
+  notify();
+}
+
+async function sendSignal(type, fields = {}) {
+  if (!roomId) return;
+  try {
+    await fetch(`/api/chat/rooms/${roomId}/signal`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type, ...fields, ts: Date.now() / 1000 }),
+    });
+  } catch (err) {
+    log(`Signal send error: ${err.message}`);
+  }
+}
+
+function setupDataChannel(channel) {
+  dc = channel;
+  channel.onopen = () => {
+    state.connectionState = "connected";
+    state.dcOpen = true;
+    dc = channel;
+    log("Data channel open");
+  };
+  channel.onclose = () => {
+    log("Data channel closed");
+    dc = null;
+    state.dcOpen = false;
+    notify();
+  };
+  channel.onmessage = (e) => {
+    try {
+      const msg = JSON.parse(e.data);
+      if (msg.type === "ping") {
+        channel.send(JSON.stringify({ type: "pong", ts: msg.ts }));
+      } else if (msg.type === "pong") {
+        const rtt = Date.now() - msg.ts;
+        state.pingResults = [...state.pingResults, rtt];
+        log(`Pong: ${rtt}ms RTT`);
+      }
+    } catch {}
+  };
+}
+
+function createPC() {
+  if (pc) return;
+  log("Creating RTCPeerConnection");
+  state.connectionState = "connecting";
+  notify();
+
+  pc = new RTCPeerConnection({
+    iceServers: [{ urls: "stun:stun.l.google.com:19302" }],
+  });
+
+  pc.onicecandidate = ({ candidate }) => {
+    if (candidate) {
+      state.localCandidates = [...state.localCandidates, `${candidate.protocol || ""} ${candidate.address || ""}:${candidate.port || ""} ${candidate.type || ""}`];
+      notify();
+      sendSignal("webrtc-ice", {
+        candidate: candidate.candidate,
+        sdpMid: candidate.sdpMid,
+        sdpMLineIndex: candidate.sdpMLineIndex,
+      });
+    }
+  };
+
+  pc.oniceconnectionstatechange = () => {
+    state.iceState = pc.iceConnectionState;
+    log(`ICE: ${state.iceState}`);
+  };
+
+  pc.onconnectionstatechange = () => {
+    state.connectionState = pc.connectionState;
+    log(`Connection: ${state.connectionState}`);
+    if (state.connectionState === "failed" || state.connectionState === "closed") {
+      cleanup(false);
+    }
+  };
+
+  pc.onsignalingstatechange = () => {
+    state.signalingState = pc.signalingState;
+    notify();
+  };
+
+  pc.onnegotiationneeded = async () => {
+    try {
+      makingOffer = true;
+      await pc.setLocalDescription();
+      state.localSdp = pc.localDescription.sdp;
+      log("Sending offer");
+      await sendSignal("webrtc-offer", { sdp: pc.localDescription.sdp });
+    } catch (err) {
+      log(`Offer error: ${err.message}`);
+    } finally {
+      makingOffer = false;
+    }
+  };
+
+  pc.ondatachannel = (e) => {
+    log(`Remote data channel: ${e.channel.label}`);
+    setupDataChannel(e.channel);
+  };
+
+  dc = pc.createDataChannel("p2p-test");
+  setupDataChannel(dc);
+  log("Created data channel");
+}
+
+/** Start a P2P connection to a peer (called from UI). */
+export function connect(rid, name, ownFp, peerFp) {
+  if (pc) return;
+  roomId = rid;
+  peerName = name;
+  ownFingerprint = ownFp;
+  peerFingerprint = peerFp;
+  state.roomId = rid;
+  state.peerName = name;
+  state.ownFingerprint = ownFp;
+  state.peerFingerprint = peerFp;
+  state.polite = ownFp < peerFp;
+  createPC();
+}
+
+export function sendPing() {
+  if (dc && dc.readyState === "open") {
+    dc.send(JSON.stringify({ type: "ping", ts: Date.now() }));
+    log("Ping sent");
+  }
+}
+
+export function hangup() {
+  sendSignal("webrtc-hangup");
+  cleanup(false);
+}
+
+function cleanup(silent) {
+  if (dc) { try { dc.close(); } catch {} dc = null; }
+  if (pc) { try { pc.close(); } catch {} pc = null; }
+  roomId = null;
+  peerName = null;
+  ownFingerprint = null;
+  peerFingerprint = null;
+  makingOffer = false;
+  state.connectionState = "idle";
+  state.iceState = "";
+  state.signalingState = "";
+  state.dcOpen = false;
+  state.roomId = null;
+  state.peerName = null;
+  state.ownFingerprint = null;
+  state.peerFingerprint = null;
+  state.polite = false;
+  state.localCandidates = [];
+  state.remoteCandidates = [];
+  state.localSdp = "";
+  state.remoteSdp = "";
+  if (!silent) log("Connection closed");
+  else notify();
+}
+
+// --- Event handlers called from App.svelte SSE dispatch ---
+
+export function handleOffer(detail, rooms, chatStatus) {
+  if (detail.room_id === roomId && pc) {
+    // Already connected to this room — handle normally
+    _handleOfferInternal(detail);
+    return;
+  }
+  if (pc) return; // busy with another connection
+
+  // Auto-connect: find the room to get peer info
+  const room = rooms.find(r => r.id === detail.room_id);
+  if (!room) return;
+  roomId = room.id;
+  peerName = room.name;
+  ownFingerprint = chatStatus.fingerprint;
+  peerFingerprint = room.fingerprint;
+  state.roomId = roomId;
+  state.peerName = peerName;
+  state.ownFingerprint = ownFingerprint;
+  state.peerFingerprint = peerFingerprint;
+  state.polite = ownFingerprint < peerFingerprint;
+  createPC();
+  _handleOfferInternal(detail);
+}
+
+async function _handleOfferInternal(detail) {
+  log("Received offer");
+  const polite = ownFingerprint < peerFingerprint;
+  const offerCollision = makingOffer || pc.signalingState !== "stable";
+  const ignoreOffer = !polite && offerCollision;
+  if (ignoreOffer) {
+    log("Ignoring colliding offer (impolite)");
+    return;
+  }
+  try {
+    await pc.setRemoteDescription({ type: "offer", sdp: detail.sdp });
+    state.remoteSdp = detail.sdp;
+    await pc.setLocalDescription();
+    state.localSdp = pc.localDescription.sdp;
+    log("Sending answer");
+    await sendSignal("webrtc-answer", { sdp: pc.localDescription.sdp });
+  } catch (err) {
+    log(`Handle offer error: ${err.message}`);
+  }
+}
+
+export function handleAnswer(detail) {
+  if (!pc || detail.room_id !== roomId) return;
+  log("Received answer");
+  pc.setRemoteDescription({ type: "answer", sdp: detail.sdp })
+    .then(() => { state.remoteSdp = detail.sdp; notify(); })
+    .catch(err => log(`Handle answer error: ${err.message}`));
+}
+
+export function handleIce(detail) {
+  if (!pc || detail.room_id !== roomId) return;
+  const polite = ownFingerprint < peerFingerprint;
+  const candidate = new RTCIceCandidate({
+    candidate: detail.candidate,
+    sdpMid: detail.sdpMid,
+    sdpMLineIndex: detail.sdpMLineIndex,
+  });
+  state.remoteCandidates = [...state.remoteCandidates, `${candidate.protocol || ""} ${candidate.address || ""}:${candidate.port || ""} ${candidate.type || ""}`];
+  notify();
+  pc.addIceCandidate(candidate).catch(err => {
+    if (!polite || pc.signalingState !== "stable") return;
+    log(`ICE candidate error: ${err.message}`);
+  });
+}
+
+export function handleHangup(detail) {
+  if (detail.room_id !== roomId) return;
+  log("Remote peer hung up");
+  cleanup(false);
+}

--- a/src/guidebook/chat.py
+++ b/src/guidebook/chat.py
@@ -24,11 +24,15 @@ _dm_subs: dict[str, object] = {}  # room_id -> NATS subscription
 _peers: dict[str, dict] = {}  # fingerprint -> {cn, last_seen, cert_pem}
 _trusted: dict[str, dict] = {}  # fingerprint -> {cn, cert_pem, verified_at, mutual}
 _pending_challenges: dict[str, dict] = {}  # fingerprint -> {nonce, timestamp}
-_pending_incoming: dict[str, dict] = {}  # fingerprint -> {from_cn, from_fingerprint, nonce}
+_pending_incoming: dict[
+    str, dict
+] = {}  # fingerprint -> {from_cn, from_fingerprint, nonce}
 
 _chat_buffers: dict[str, deque] = {}  # room_id -> deque of messages
 _buffer_sizes: dict[str, int] = {}  # room_id -> current buffer size in bytes
 BUFFER_MAX_BYTES = 100_000  # 100KB per room
+
+WEBRTC_SIGNAL_TYPES = {"webrtc-offer", "webrtc-answer", "webrtc-ice", "webrtc-hangup"}
 
 _lobby_enabled = False
 _own_cn: str | None = None
@@ -276,7 +280,9 @@ async def _on_verify_message(msg):
             return
 
         if not _verify_signature(cert_pem, nonce, signature):
-            logger.warning("Invalid signature in verification response from %s", from_cn)
+            logger.warning(
+                "Invalid signature in verification response from %s", from_cn
+            )
             return
 
         # Verify fingerprint matches the cert they provided
@@ -351,7 +357,9 @@ def _verify_signature(cert_pem: str, nonce: str, signature_b64: str) -> bool:
         nonce_bytes = nonce.encode()
 
         if isinstance(public_key, rsa.RSAPublicKey):
-            public_key.verify(sig_bytes, nonce_bytes, padding.PKCS1v15(), hashes.SHA256())
+            public_key.verify(
+                sig_bytes, nonce_bytes, padding.PKCS1v15(), hashes.SHA256()
+            )
         elif isinstance(public_key, ec.EllipticCurvePublicKey):
             public_key.verify(sig_bytes, nonce_bytes, ec.ECDSA(hashes.SHA256()))
         else:
@@ -526,6 +534,21 @@ async def send_dm_message(room_id: str, text: str):
     _broadcast_chat_event("chat-message", chat_msg)
 
 
+async def send_signal(room_id: str, signal: dict):
+    """Send a WebRTC signaling message over a DM room."""
+    from guidebook.nats_client import get_client
+
+    nc = get_client()
+    if not nc or not nc.is_connected:
+        return
+    msg_type = signal.get("type")
+    if msg_type not in WEBRTC_SIGNAL_TYPES:
+        return
+    signal["cn"] = _own_cn
+    signal["fingerprint"] = _own_fingerprint
+    await nc.publish(f"guidebook.chat.dm.{room_id}", json.dumps(signal).encode())
+
+
 async def remove_trusted(peer_fingerprint: str):
     """Remove a trusted peer, notify them, and unsubscribe from their DM room."""
     if peer_fingerprint not in _trusted:
@@ -558,7 +581,9 @@ async def remove_trusted(peer_fingerprint: str):
     _chat_buffers.pop(room_id, None)
     _buffer_sizes.pop(room_id, None)
     _broadcast_chat_event("chat-rooms", {"rooms": get_rooms()})
-    logger.info("Removed trusted peer %s, left room %s", peer_fingerprint[:16], room_id[:16])
+    logger.info(
+        "Removed trusted peer %s, left room %s", peer_fingerprint[:16], room_id[:16]
+    )
 
 
 async def _on_dm_message(room_id: str):
@@ -569,6 +594,23 @@ async def _on_dm_message(room_id: str):
             return
         # Skip our own messages
         if data.get("fingerprint") == _own_fingerprint:
+            return
+        msg_type = data.get("type", "message")
+        if msg_type in WEBRTC_SIGNAL_TYPES:
+            # Forward signaling messages as SSE events without buffering
+            signal_event = {
+                "room_id": room_id,
+                "cn": data.get("cn"),
+                "fingerprint": data.get("fingerprint"),
+                "ts": data.get("ts"),
+            }
+            if msg_type in ("webrtc-offer", "webrtc-answer"):
+                signal_event["sdp"] = data.get("sdp")
+            elif msg_type == "webrtc-ice":
+                signal_event["candidate"] = data.get("candidate")
+                signal_event["sdpMid"] = data.get("sdpMid")
+                signal_event["sdpMLineIndex"] = data.get("sdpMLineIndex")
+            _broadcast_chat_event(msg_type, signal_event)
             return
         chat_msg = {
             "room": room_id,
@@ -715,7 +757,9 @@ async def start_chat():
     async with instance_async_session() as db:
         row = (
             await db.execute(
-                select(InstanceSetting).where(InstanceSetting.key == "nats_lobby_enabled")
+                select(InstanceSetting).where(
+                    InstanceSetting.key == "nats_lobby_enabled"
+                )
             )
         ).scalar_one_or_none()
         lobby_enabled = row and row.value == "true"

--- a/src/guidebook/routes/chat.py
+++ b/src/guidebook/routes/chat.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from guidebook.chat import (
+    WEBRTC_SIGNAL_TYPES,
     accept_verification,
     get_messages,
     get_peers,
@@ -14,6 +15,7 @@ from guidebook.chat import (
     reject_verification,
     remove_trusted,
     send_dm_message,
+    send_signal,
 )
 
 logger = logging.getLogger("guidebook.chat")
@@ -23,6 +25,15 @@ router = APIRouter(prefix="/api/chat", tags=["chat"])
 
 class SendMessage(BaseModel):
     text: str
+
+
+class SignalMessage(BaseModel):
+    type: str
+    sdp: str | None = None
+    candidate: str | None = None
+    sdpMid: str | None = None
+    sdpMLineIndex: int | None = None
+    ts: float | None = None
 
 
 @router.get("/status")
@@ -61,6 +72,14 @@ async def send_message(room_id: str, data: SendMessage):
     if room_id == "lobby":
         raise HTTPException(status_code=403, detail="Lobby is for peer discovery only")
     await send_dm_message(room_id, data.text)
+    return {"ok": True}
+
+
+@router.post("/rooms/{room_id}/signal")
+async def send_signal_endpoint(room_id: str, data: SignalMessage):
+    if data.type not in WEBRTC_SIGNAL_TYPES:
+        raise HTTPException(status_code=400, detail="Invalid signal type")
+    await send_signal(room_id, data.model_dump(exclude_none=True))
     return {"ok": True}
 
 


### PR DESCRIPTION
## Summary

- WebRTC peer-to-peer connections using existing NATS DM channels as signaling relay
- Backend: new `webrtc-*` message types in DM handler, `POST /api/chat/rooms/{room_id}/signal` endpoint
- Frontend: app-level `p2p.js` module manages connections in the background across all pages
- Auto-connect: incoming offers automatically establish P2P without manual action
- Stale connection recovery: detects dead connections via ICE disconnect timeout and accepts re-offers
- Chat sidebar: peer status indicators (red=offline, orange=NATS online, green pulsing=P2P connected)
- Top bar: shows remote friend count alongside local client count
- Perfect negotiation pattern for glare-free simultaneous connect attempts
- STUN only (no TURN) with full debug panel for diagnosing connection failures

Closes #31