### PR TITLE
P2P file transfer, record sync, and ICE server config

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -99,7 +99,7 @@
     if (e.target.closest?.(".attachments-section")) return;
     const files = e.dataTransfer.files;
 
-    // If on chat page with an active P2P connection, send files via WebRTC
+    // If on chat page with an active room, send files via WebRTC (auto-connects if needed)
     if (page === "chat" && chatRef && chatRef.canDropFiles()) {
       chatRef.dropFiles(files);
       return;

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -169,6 +169,9 @@
   let natsChatEnabled = false;
   let natsConnected = false;
   let chatRoomCount = 0;
+  let chatRooms = [];
+  let chatPeers = [];
+  $: onlineFriendCount = chatRooms.filter(r => chatPeers.some(p => p.fingerprint === r.fingerprint)).length;
   let noShutdown = false;
   let unreadCount = 0;
   let prevUnreadCount = -1;
@@ -613,7 +616,8 @@
       eventSource.addEventListener(evt, (e) => {
         const detail = JSON.parse(e.data);
         window.dispatchEvent(new CustomEvent(evt, { detail }));
-        if (evt === "chat-rooms") { chatRoomCount = (detail.rooms || []).length; }
+        if (evt === "chat-rooms") { chatRooms = detail.rooms || []; chatRoomCount = chatRooms.length; }
+        if (evt === "chat-peers") { chatPeers = detail.peers || []; }
         if (evt === "webrtc-offer") {
           (async () => {
             try {
@@ -820,8 +824,12 @@
 
   async function fetchChatRoomCount() {
     try {
-      const res = await fetch("/api/chat/rooms");
-      if (res.ok) chatRoomCount = (await res.json()).length;
+      const [roomsRes, peersRes] = await Promise.all([
+        fetch("/api/chat/rooms"),
+        fetch("/api/chat/peers"),
+      ]);
+      if (roomsRes.ok) { chatRooms = await roomsRes.json(); chatRoomCount = chatRooms.length; }
+      if (peersRes.ok) { chatPeers = await peersRes.json(); }
     } catch {}
   }
 
@@ -1135,7 +1143,7 @@
         <h1 class="app-title"><span class="title-full">{appName}</span><span class="title-short">{appName.slice(0, 2).toUpperCase()}</span>{#if appVersion}<span class="app-version" title={!appFrozen ? "Local build" : updateChecked && updateExact ? "Up to date" : updateChecked && updateDev ? "Development version" : !updateChecked ? "Enable update checker in the settings" : ""} on:click={() => { navigate("about"); }} style="cursor: pointer">v{appVersion}{#if updateSupported && updateChecked && updateExact}<span class="up-to-date-check">✔</span>{/if}{#if (updateChecked && updateDev) || !appFrozen}<span class="dev-version">🚧</span>{/if}{#if updateAvailable} <button class="update-link-btn" title={"v" + updateLatest + " available"} on:click|stopPropagation={() => { settingsTab = "updates"; navigate("settings"); }}>Update Available</button><button class="update-skip-btn" title="Skip this version" on:click|stopPropagation={skipUpdate}>✕</button>{/if}</span>{/if}</h1>
       </div>
       <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-      <span class="client-count"><span class="client-count-link" on:click={() => { settingsTab = "auth"; navigate("settings"); }} title="Connected clients">{clientCount} client{clientCount !== 1 ? "s" : ""}</span>{#if natsChatEnabled && natsConnected && chatRoomCount > 0}<span class="client-count-sep"> + </span><span class="client-count-link" on:click={() => navigate("chat")} title="Mutual friends">{chatRoomCount} friend{chatRoomCount !== 1 ? "s" : ""}</span>{/if}</span>
+      <span class="client-count"><span class="client-count-link" on:click={() => { settingsTab = "auth"; navigate("settings"); }} title="Connected clients">{clientCount} client{clientCount !== 1 ? "s" : ""}</span>{#if natsChatEnabled && natsConnected && onlineFriendCount > 0}<span class="client-count-sep"> + </span><span class="client-count-link" on:click={() => navigate("chat")} title="Online friends">{onlineFriendCount} friend{onlineFriendCount !== 1 ? "s" : ""}</span>{/if}</span>
     </header>
     <div class="welcome-container">
       <div class="welcome-card">
@@ -1172,7 +1180,7 @@
     <!-- svelte-ignore a11y-click-events-have-key-events -->
     <!-- svelte-ignore a11y-no-static-element-interactions -->
     <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-    <span class="client-count"><span class="client-count-link" on:click={() => { settingsTab = "auth"; navigate("settings"); }} title="Connected clients">{clientCount} client{clientCount !== 1 ? "s" : ""}</span>{#if natsChatEnabled && natsConnected && chatRoomCount > 0}<span class="client-count-sep"> + </span><span class="client-count-link" on:click={() => navigate("chat")} title="Mutual friends">{chatRoomCount} friend{chatRoomCount !== 1 ? "s" : ""}</span>{/if}</span>
+    <span class="client-count"><span class="client-count-link" on:click={() => { settingsTab = "auth"; navigate("settings"); }} title="Connected clients">{clientCount} client{clientCount !== 1 ? "s" : ""}</span>{#if natsChatEnabled && natsConnected && onlineFriendCount > 0}<span class="client-count-sep"> + </span><span class="client-count-link" on:click={() => navigate("chat")} title="Online friends">{onlineFriendCount} friend{onlineFriendCount !== 1 ? "s" : ""}</span>{/if}</span>
     <div class="hamburger-wrap">
       {#if wide}
         <button class="add-btn dual-btn" class:active-nav={dualRightPage === "media"} on:click={() => { dualRightPage = "media"; navigate("media"); }} title="Records & Media">{#if dualRightPage === "media" && !databaseRight}<Icon icon={iconBook} width={14} />{/if}<Icon icon={iconCamera} width={18} />{#if dualRightPage === "media" && databaseRight}<Icon icon={iconBook} width={14} />{/if}</button>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -65,6 +65,7 @@
   let formDirty = false;
   let dualShowForm = !!editId || (page === "dual" && (window.location.hash.slice(1) === "/add"));
   let recordsRef = null;
+  let chatRef = null;
   let recordAutoCreated = false;
   let databaseRight = false;
   let mediaSearchQuery = "";
@@ -97,6 +98,12 @@
     // If dropped on the attachments section, Records already handled the upload
     if (e.target.closest?.(".attachments-section")) return;
     const files = e.dataTransfer.files;
+
+    // If on chat page with an active P2P connection, send files via WebRTC
+    if (page === "chat" && chatRef && chatRef.canDropFiles()) {
+      chatRef.dropFiles(files);
+      return;
+    }
 
     // If Records component exists and has a form open, upload to it
     if (recordsRef) {
@@ -1117,7 +1124,7 @@
 <main class:picker-mode={pickerMode && !databaseOpen} class:dual-mode={page === "dual"} class:records-mode={page === "records" || page === "add"} class:query-mode={page === "query"} class:scratchpad-mode={page === "scratchpad"} class:chat-mode={page === "chat"} class:settings-mode={page === "settings"}>
   {#if globalDragOver && databaseOpen}
     <div class="global-drop-overlay">
-      <div class="global-drop-message">Drop files to attach</div>
+      <div class="global-drop-message">{page === "chat" && chatRef && chatRef.canDropFiles() ? "Drop files to send via P2P" : "Drop files to attach"}</div>
     </div>
   {/if}
   {#if authBlocked}
@@ -1261,7 +1268,7 @@
     {:else if page === "scratchpad"}
       <Scratchpad />
     {:else if page === "chat"}
-      <Chat />
+      <Chat bind:this={chatRef} />
     {:else if page === "about"}
       <About />
     {/if}

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -400,8 +400,20 @@
               <span class="message-time">{formatTime(msg.ts)}</span>
             </div>
             {#if msg.file}
+              {@const url = msg.file._url || (msg.file._url = b64ToObjectUrl(msg.file.data, msg.file.content_type))}
               <div class="message-file">
-                <a class="file-download" href={b64ToObjectUrl(msg.file.data, msg.file.content_type)} download={msg.file.filename}>
+                {#if msg.file.content_type.startsWith("image/")}
+                  <img class="file-preview-img" src={url} alt={msg.file.filename} />
+                {:else if msg.file.content_type.startsWith("video/")}
+                  <video class="file-preview-video" controls preload="metadata">
+                    <source src={url} type={msg.file.content_type} />
+                  </video>
+                {:else if msg.file.content_type.startsWith("audio/")}
+                  <audio class="file-preview-audio" controls preload="metadata">
+                    <source src={url} type={msg.file.content_type} />
+                  </audio>
+                {/if}
+                <a class="file-download" href={url} download={msg.file.filename}>
                   <span class="file-icon">📎</span>
                   <span class="file-name">{msg.file.filename}</span>
                   <span class="file-size">({formatFileSize(msg.file.size)})</span>
@@ -729,6 +741,29 @@
 
   .message.own .file-download:hover {
     background: rgba(0,0,0,0.2);
+  }
+
+  .file-preview-img {
+    max-width: 100%;
+    max-height: 300px;
+    border-radius: 4px;
+    display: block;
+    margin-bottom: 0.3em;
+  }
+
+  .file-preview-video {
+    max-width: 100%;
+    max-height: 300px;
+    border-radius: 4px;
+    display: block;
+    margin-bottom: 0.3em;
+  }
+
+  .file-preview-audio {
+    width: 100%;
+    max-width: 300px;
+    display: block;
+    margin-bottom: 0.3em;
   }
 
   .file-icon {

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -144,7 +144,9 @@
   $: onlinePeerSet = new Set(peers.map(p => p.fingerprint));
 
   function peerStatus(room, _p2p, _online) {
-    if (_p2p.roomId === room.id && _p2p.connectionState === "connected") return "p2p";
+    if (_p2p.roomId === room.id && _p2p.connectionState === "connected") {
+      return _p2p.routeType === "relay" ? "p2p-relay" : "p2p";
+    }
     if (_online.has(room.fingerprint)) return "online";
     return "offline";
   }
@@ -248,7 +250,7 @@
           class:active={activeRoom === room.id}
           on:click={() => selectRoom(room.id)}
         >
-          <span class="peer-status-dot" class:status-p2p={peerStatus(room, p2pState, onlinePeerSet) === "p2p"} class:status-online={peerStatus(room, p2pState, onlinePeerSet) === "online"} class:status-offline={peerStatus(room, p2pState, onlinePeerSet) === "offline"}></span>
+          <span class="peer-status-dot" class:status-p2p={peerStatus(room, p2pState, onlinePeerSet) === "p2p"} class:status-p2p-relay={peerStatus(room, p2pState, onlinePeerSet) === "p2p-relay"} class:status-online={peerStatus(room, p2pState, onlinePeerSet) === "online"} class:status-offline={peerStatus(room, p2pState, onlinePeerSet) === "offline"}></span>
           <span class="room-name">{room.name}</span>
         </button>
         <button
@@ -410,12 +412,22 @@
 
   .status-p2p {
     background: var(--success, #4caf50);
-    animation: pulse-glow 2s ease-in-out infinite;
+    animation: pulse-glow-green 2s ease-in-out infinite;
   }
 
-  @keyframes pulse-glow {
+  .status-p2p-relay {
+    background: #42a5f5;
+    animation: pulse-glow-blue 2s ease-in-out infinite;
+  }
+
+  @keyframes pulse-glow-green {
     0%, 100% { opacity: 1; box-shadow: 0 0 3px var(--success, #4caf50); }
     50% { opacity: 0.6; box-shadow: 0 0 8px var(--success, #4caf50); }
+  }
+
+  @keyframes pulse-glow-blue {
+    0%, 100% { opacity: 1; box-shadow: 0 0 3px #42a5f5; }
+    50% { opacity: 0.6; box-shadow: 0 0 8px #42a5f5; }
   }
 
   .btn-p2p-connect {

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -179,7 +179,8 @@
   function formatFileSize(bytes) {
     if (bytes < 1024) return `${bytes} B`;
     if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+    if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+    return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
   }
 
   function b64ToObjectUrl(b64, contentType) {
@@ -194,22 +195,40 @@
 
   function sendFileNow(file) {
     p2p.sendChatFile(file).then((msg) => {
-      messages = [...messages, {
-        cn: chatStatus.cn || "You",
-        fingerprint: chatStatus.fingerprint,
-        ts: Date.now() / 1000,
-        text: null,
-        fileId: msg.fileId,
-        file: { filename: msg.filename, content_type: msg.content_type, size: msg.size, data: msg.data },
-        room: activeRoom,
-      }];
-      tick().then(scrollToBottom);
-    }).catch(() => {});
+      // Small file — msg.data is present; large file — no data, already tracked via transfer messages
+      if (msg.data) {
+        messages = [...messages, {
+          cn: chatStatus.cn || "You",
+          fingerprint: chatStatus.fingerprint,
+          ts: Date.now() / 1000,
+          text: null,
+          fileId: msg.fileId,
+          file: { filename: msg.filename, content_type: msg.content_type, size: msg.size, data: msg.data },
+          room: activeRoom,
+        }];
+        tick().then(scrollToBottom);
+      } else {
+        // Large file complete — update the transfer message
+        const idx = messages.findIndex(m => m.fileId === msg.fileId);
+        if (idx !== -1) {
+          messages[idx] = { ...messages[idx], transfer: { ...messages[idx].transfer, status: "sent" } };
+          messages = messages;
+        }
+      }
+    }).catch((err) => {
+      // Update transfer message on failure
+      const idx = messages.findIndex(m => m.fileId === err?.fileId);
+      if (idx !== -1) {
+        messages[idx] = { ...messages[idx], transfer: { ...messages[idx].transfer, status: "failed" } };
+        messages = messages;
+      }
+    });
   }
 
   function deleteChatFile(msg) {
     if (msg.fileId) p2p.sendChatFileDelete(msg.fileId);
     if (msg.file?._url) URL.revokeObjectURL(msg.file._url);
+    if (msg.transfer?.blobUrl) URL.revokeObjectURL(msg.transfer.blobUrl);
     messages = messages.filter(m => m !== msg);
   }
 
@@ -238,7 +257,47 @@
     return !!activeRoom && !!activeRoomObj;
   }
 
+  // --- Small file received (inline base64) ---
   function onChatFileReceived(e) {
+    const detail = e.detail;
+    // Inline small file has detail.data; large file complete has detail.blobUrl
+    if (detail.data) {
+      if (detail.roomId !== activeRoom) return;
+      messages = [...messages, {
+        cn: detail.peerName || "Peer",
+        fingerprint: detail.peerFingerprint,
+        ts: Date.now() / 1000,
+        text: null,
+        fileId: detail.fileId,
+        file: { filename: detail.filename, content_type: detail.content_type, size: detail.size, data: detail.data },
+        room: detail.roomId,
+      }];
+    } else if (detail.blobUrl) {
+      // Large file transfer complete — update the existing transfer message
+      if (detail.roomId !== activeRoom) return;
+      const idx = messages.findIndex(m => m.fileId === detail.fileId);
+      if (idx !== -1) {
+        messages[idx] = { ...messages[idx],
+          transfer: { ...messages[idx].transfer, status: "complete", blobUrl: detail.blobUrl },
+        };
+        messages = messages;
+      } else {
+        messages = [...messages, {
+          cn: detail.peerName || "Peer",
+          fingerprint: detail.peerFingerprint,
+          ts: Date.now() / 1000,
+          text: null,
+          fileId: detail.fileId,
+          transfer: { filename: detail.filename, content_type: detail.content_type, size: detail.size, status: "complete", blobUrl: detail.blobUrl },
+          room: detail.roomId,
+        }];
+      }
+    }
+    tick().then(scrollToBottom);
+  }
+
+  // --- Large file offer from peer ---
+  function onChatFileOfferIncoming(e) {
     const detail = e.detail;
     if (detail.roomId !== activeRoom) return;
     messages = [...messages, {
@@ -247,16 +306,83 @@
       ts: Date.now() / 1000,
       text: null,
       fileId: detail.fileId,
-      file: { filename: detail.filename, content_type: detail.content_type, size: detail.size, data: detail.data },
+      transfer: {
+        filename: detail.filename,
+        content_type: detail.content_type,
+        size: detail.size,
+        status: "offered", // offered → receiving → complete | rejected
+        progress: 0,
+        direction: "incoming",
+      },
       room: detail.roomId,
     }];
     tick().then(scrollToBottom);
+  }
+
+  // --- Sender's own large file offer sent ---
+  function onChatFileOfferSent(e) {
+    const detail = e.detail;
+    messages = [...messages, {
+      cn: chatStatus.cn || "You",
+      fingerprint: chatStatus.fingerprint,
+      ts: Date.now() / 1000,
+      text: null,
+      fileId: detail.fileId,
+      transfer: {
+        filename: detail.filename,
+        content_type: detail.content_type,
+        size: detail.size,
+        status: "waiting", // waiting → sending → sent | failed
+        progress: 0,
+        direction: "outgoing",
+      },
+      room: activeRoom,
+    }];
+    tick().then(scrollToBottom);
+  }
+
+  function acceptTransfer(msg) {
+    p2p.acceptFileTransfer(msg.fileId);
+    const idx = messages.indexOf(msg);
+    if (idx !== -1) {
+      messages[idx] = { ...messages[idx], transfer: { ...messages[idx].transfer, status: "receiving" } };
+      messages = messages;
+    }
+  }
+
+  function rejectTransfer(msg) {
+    p2p.rejectFileTransfer(msg.fileId);
+    messages = messages.filter(m => m !== msg);
+  }
+
+  // --- Progress events ---
+  function onChatFileSendProgress(e) {
+    const { fileId, sentBytes, totalBytes } = e.detail;
+    const idx = messages.findIndex(m => m.fileId === fileId);
+    if (idx !== -1 && messages[idx].transfer) {
+      messages[idx] = { ...messages[idx],
+        transfer: { ...messages[idx].transfer, status: "sending", progress: sentBytes / totalBytes },
+      };
+      messages = messages;
+    }
+  }
+
+  function onChatFileRecvProgress(e) {
+    const { fileId, receivedBytes, totalBytes } = e.detail;
+    const idx = messages.findIndex(m => m.fileId === fileId);
+    if (idx !== -1 && messages[idx].transfer) {
+      messages[idx] = { ...messages[idx],
+        transfer: { ...messages[idx].transfer, progress: receivedBytes / totalBytes },
+      };
+      messages = messages;
+    }
   }
 
   function onChatFileDeleted(e) {
     const { fileId } = e.detail;
     const msg = messages.find(m => m.fileId === fileId);
     if (msg?.file?._url) URL.revokeObjectURL(msg.file._url);
+    if (msg?.transfer?.blobUrl) URL.revokeObjectURL(msg.transfer.blobUrl);
     messages = messages.filter(m => m.fileId !== fileId);
   }
 
@@ -316,6 +442,10 @@
     window.addEventListener("chat-defriended", onChatDefriended);
     window.addEventListener("chat-file-received", onChatFileReceived);
     window.addEventListener("chat-file-deleted", onChatFileDeleted);
+    window.addEventListener("chat-file-offer-incoming", onChatFileOfferIncoming);
+    window.addEventListener("chat-file-offer-sent", onChatFileOfferSent);
+    window.addEventListener("chat-file-send-progress", onChatFileSendProgress);
+    window.addEventListener("chat-file-recv-progress", onChatFileRecvProgress);
     unsubP2P = p2p.onChange(s => {
       const wasOpen = p2pState.dcOpen;
       p2pState = s;
@@ -341,6 +471,10 @@
     window.removeEventListener("chat-rooms", onChatRooms);
     window.removeEventListener("chat-file-received", onChatFileReceived);
     window.removeEventListener("chat-file-deleted", onChatFileDeleted);
+    window.removeEventListener("chat-file-offer-incoming", onChatFileOfferIncoming);
+    window.removeEventListener("chat-file-offer-sent", onChatFileOfferSent);
+    window.removeEventListener("chat-file-send-progress", onChatFileSendProgress);
+    window.removeEventListener("chat-file-recv-progress", onChatFileRecvProgress);
     window.removeEventListener("chat-defriended", onChatDefriended);
     if (unsubP2P) unsubP2P();
   });
@@ -461,6 +595,72 @@
                   </a>
                   <button class="file-delete-btn" on:click={() => deleteChatFile(msg)} title="Delete file">✕</button>
                 </div>
+              </div>
+            {:else if msg.transfer}
+              <div class="message-file">
+                {#if msg.transfer.status === "offered"}
+                  <div class="transfer-offer">
+                    <span class="file-icon">📎</span>
+                    <span class="file-name">{msg.transfer.filename}</span>
+                    <span class="file-size">({formatFileSize(msg.transfer.size)})</span>
+                    <div class="transfer-actions">
+                      <button class="btn-small btn-accept" on:click={() => acceptTransfer(msg)}>Accept</button>
+                      <button class="btn-small btn-reject" on:click={() => rejectTransfer(msg)}>Reject</button>
+                    </div>
+                  </div>
+                {:else if msg.transfer.status === "waiting"}
+                  <div class="transfer-progress">
+                    <span class="file-icon">📎</span>
+                    <span class="file-name">{msg.transfer.filename}</span>
+                    <span class="file-size">({formatFileSize(msg.transfer.size)})</span>
+                    <div class="transfer-status">Waiting for acceptance...</div>
+                  </div>
+                {:else if msg.transfer.status === "sending" || msg.transfer.status === "receiving"}
+                  <div class="transfer-progress">
+                    <span class="file-icon">📎</span>
+                    <span class="file-name">{msg.transfer.filename}</span>
+                    <span class="file-size">({formatFileSize(msg.transfer.size)})</span>
+                    <div class="progress-bar-container">
+                      <div class="progress-bar-fill" style="width: {(msg.transfer.progress * 100).toFixed(1)}%"></div>
+                    </div>
+                    <div class="transfer-status">{msg.transfer.status === "sending" ? "Sending" : "Receiving"} {(msg.transfer.progress * 100).toFixed(0)}%</div>
+                  </div>
+                {:else if msg.transfer.status === "complete" || msg.transfer.status === "sent"}
+                  {@const tUrl = msg.transfer.blobUrl}
+                  {#if tUrl && msg.transfer.content_type.startsWith("image/")}
+                    <img class="file-preview-img" src={tUrl} alt={msg.transfer.filename} />
+                  {:else if tUrl && msg.transfer.content_type.startsWith("video/")}
+                    <video class="file-preview-video" controls preload="metadata">
+                      <source src={tUrl} type={msg.transfer.content_type} />
+                    </video>
+                  {:else if tUrl && msg.transfer.content_type.startsWith("audio/")}
+                    <audio class="file-preview-audio" controls preload="metadata">
+                      <source src={tUrl} type={msg.transfer.content_type} />
+                    </audio>
+                  {/if}
+                  <div class="file-actions">
+                    {#if tUrl}
+                      <a class="file-download" href={tUrl} download={msg.transfer.filename}>
+                        <span class="file-icon">📎</span>
+                        <span class="file-name">{msg.transfer.filename}</span>
+                        <span class="file-size">({formatFileSize(msg.transfer.size)})</span>
+                      </a>
+                    {:else}
+                      <span class="file-download">
+                        <span class="file-icon">📎</span>
+                        <span class="file-name">{msg.transfer.filename}</span>
+                        <span class="file-size">({formatFileSize(msg.transfer.size)}) — sent</span>
+                      </span>
+                    {/if}
+                    <button class="file-delete-btn" on:click={() => deleteChatFile(msg)} title="Delete file">✕</button>
+                  </div>
+                {:else if msg.transfer.status === "failed"}
+                  <div class="transfer-progress">
+                    <span class="file-icon">📎</span>
+                    <span class="file-name">{msg.transfer.filename}</span>
+                    <span class="transfer-status transfer-failed">Transfer failed</span>
+                  </div>
+                {/if}
               </div>
             {:else}
               <div class="message-text">{msg.text}</div>
@@ -821,6 +1021,55 @@
   .file-size {
     font-size: 0.8em;
     opacity: 0.7;
+  }
+
+  .transfer-offer, .transfer-progress {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.3em;
+    font-size: 0.9rem;
+  }
+
+  .transfer-actions {
+    display: flex;
+    gap: 0.3em;
+    margin-left: 0.3em;
+  }
+
+  .transfer-status {
+    width: 100%;
+    font-size: 0.75rem;
+    color: var(--text-muted, #888);
+    margin-top: 0.15em;
+  }
+
+  .message.own .transfer-status {
+    color: var(--bg, #555);
+  }
+
+  .transfer-failed {
+    color: var(--error, #f44336) !important;
+  }
+
+  .progress-bar-container {
+    width: 100%;
+    height: 6px;
+    background: rgba(255,255,255,0.1);
+    border-radius: 3px;
+    margin-top: 0.3em;
+    overflow: hidden;
+  }
+
+  .message.own .progress-bar-container {
+    background: rgba(0,0,0,0.15);
+  }
+
+  .progress-bar-fill {
+    height: 100%;
+    background: var(--accent, #e6a700);
+    border-radius: 3px;
+    transition: width 0.2s;
   }
 
   .file-actions {

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -199,11 +199,18 @@
         fingerprint: chatStatus.fingerprint,
         ts: Date.now() / 1000,
         text: null,
+        fileId: msg.fileId,
         file: { filename: msg.filename, content_type: msg.content_type, size: msg.size, data: msg.data },
         room: activeRoom,
       }];
       tick().then(scrollToBottom);
     }).catch(() => {});
+  }
+
+  function deleteChatFile(msg) {
+    if (msg.fileId) p2p.sendChatFileDelete(msg.fileId);
+    if (msg.file?._url) URL.revokeObjectURL(msg.file._url);
+    messages = messages.filter(m => m !== msg);
   }
 
   function flushPendingFiles() {
@@ -239,10 +246,18 @@
       fingerprint: detail.peerFingerprint,
       ts: Date.now() / 1000,
       text: null,
+      fileId: detail.fileId,
       file: { filename: detail.filename, content_type: detail.content_type, size: detail.size, data: detail.data },
       room: detail.roomId,
     }];
     tick().then(scrollToBottom);
+  }
+
+  function onChatFileDeleted(e) {
+    const { fileId } = e.detail;
+    const msg = messages.find(m => m.fileId === fileId);
+    if (msg?.file?._url) URL.revokeObjectURL(msg.file._url);
+    messages = messages.filter(m => m.fileId !== fileId);
   }
 
   function onChatMessage(e) {
@@ -300,6 +315,7 @@
     window.addEventListener("chat-rooms", onChatRooms);
     window.addEventListener("chat-defriended", onChatDefriended);
     window.addEventListener("chat-file-received", onChatFileReceived);
+    window.addEventListener("chat-file-deleted", onChatFileDeleted);
     unsubP2P = p2p.onChange(s => {
       const wasOpen = p2pState.dcOpen;
       p2pState = s;
@@ -324,6 +340,7 @@
     window.removeEventListener("chat-verify-complete", onChatVerifyComplete);
     window.removeEventListener("chat-rooms", onChatRooms);
     window.removeEventListener("chat-file-received", onChatFileReceived);
+    window.removeEventListener("chat-file-deleted", onChatFileDeleted);
     window.removeEventListener("chat-defriended", onChatDefriended);
     if (unsubP2P) unsubP2P();
   });
@@ -436,11 +453,14 @@
                     <source src={url} type={msg.file.content_type} />
                   </audio>
                 {/if}
-                <a class="file-download" href={url} download={msg.file.filename}>
-                  <span class="file-icon">📎</span>
-                  <span class="file-name">{msg.file.filename}</span>
-                  <span class="file-size">({formatFileSize(msg.file.size)})</span>
-                </a>
+                <div class="file-actions">
+                  <a class="file-download" href={url} download={msg.file.filename}>
+                    <span class="file-icon">📎</span>
+                    <span class="file-name">{msg.file.filename}</span>
+                    <span class="file-size">({formatFileSize(msg.file.size)})</span>
+                  </a>
+                  <button class="file-delete-btn" on:click={() => deleteChatFile(msg)} title="Delete file">✕</button>
+                </div>
               </div>
             {:else}
               <div class="message-text">{msg.text}</div>
@@ -801,6 +821,40 @@
   .file-size {
     font-size: 0.8em;
     opacity: 0.7;
+  }
+
+  .file-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.4em;
+  }
+
+  .file-delete-btn {
+    background: none;
+    border: 1px solid transparent;
+    border-radius: 3px;
+    color: var(--text-muted, #888);
+    cursor: pointer;
+    font-size: 0.85rem;
+    padding: 0.1em 0.35em;
+    line-height: 1;
+    opacity: 0.5;
+    transition: opacity 0.15s;
+  }
+
+  .file-delete-btn:hover {
+    opacity: 1;
+    color: var(--error, #f44336);
+    border-color: var(--error, #f44336);
+  }
+
+  .message.own .file-delete-btn {
+    color: var(--bg, #333);
+  }
+
+  .message.own .file-delete-btn:hover {
+    color: var(--error, #f44336);
+    border-color: var(--error, #f44336);
   }
 
   .chat-input {

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -142,6 +142,7 @@
 
   $: trustedSet = new Set(trusted.map(t => t.fingerprint));
   $: onlinePeerSet = new Set(peers.map(p => p.fingerprint));
+  $: activeRoomObj = rooms.find(r => r.id === activeRoom) || null;
 
   function peerStatus(room, _p2p, _online) {
     if (_p2p.roomId === room.id && _p2p.connectionState === "connected") {
@@ -173,6 +174,57 @@
       e.preventDefault();
       sendMessage();
     }
+  }
+
+  function formatFileSize(bytes) {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+
+  function b64ToObjectUrl(b64, contentType) {
+    const binary = atob(b64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    const blob = new Blob([bytes], { type: contentType });
+    return URL.createObjectURL(blob);
+  }
+
+  export function dropFiles(files) {
+    if (!activeRoom || !p2pState.dcOpen || p2pState.roomId !== activeRoomObj?.id) return;
+    for (const file of files) {
+      p2p.sendChatFile(file).then((msg) => {
+        messages = [...messages, {
+          cn: chatStatus.cn || "You",
+          fingerprint: chatStatus.fingerprint,
+          ts: Date.now() / 1000,
+          text: null,
+          file: { filename: msg.filename, content_type: msg.content_type, size: msg.size, data: msg.data },
+          room: activeRoom,
+        }];
+        tick().then(scrollToBottom);
+      }).catch(() => {});
+    }
+  }
+
+  export function canDropFiles() {
+    if (!activeRoom) return false;
+    const room = rooms.find(r => r.id === activeRoom);
+    return room && p2pState.dcOpen && p2pState.roomId === room.id;
+  }
+
+  function onChatFileReceived(e) {
+    const detail = e.detail;
+    if (detail.roomId !== activeRoom) return;
+    messages = [...messages, {
+      cn: detail.peerName || "Peer",
+      fingerprint: detail.peerFingerprint,
+      ts: Date.now() / 1000,
+      text: null,
+      file: { filename: detail.filename, content_type: detail.content_type, size: detail.size, data: detail.data },
+      room: detail.roomId,
+    }];
+    tick().then(scrollToBottom);
   }
 
   function onChatMessage(e) {
@@ -229,6 +281,7 @@
     window.addEventListener("chat-verify-complete", onChatVerifyComplete);
     window.addEventListener("chat-rooms", onChatRooms);
     window.addEventListener("chat-defriended", onChatDefriended);
+    window.addEventListener("chat-file-received", onChatFileReceived);
     unsubP2P = p2p.onChange(s => {
       p2pState = s;
       // Auto-open P2P panel when connection is established from any page
@@ -247,6 +300,7 @@
     window.removeEventListener("chat-verify-request", onChatVerifyRequest);
     window.removeEventListener("chat-verify-complete", onChatVerifyComplete);
     window.removeEventListener("chat-rooms", onChatRooms);
+    window.removeEventListener("chat-file-received", onChatFileReceived);
     window.removeEventListener("chat-defriended", onChatDefriended);
     if (unsubP2P) unsubP2P();
   });
@@ -345,7 +399,17 @@
               <span class="message-cn" class:own-cn={isOwnMessage(msg)}>{msg.cn}</span>
               <span class="message-time">{formatTime(msg.ts)}</span>
             </div>
-            <div class="message-text">{msg.text}</div>
+            {#if msg.file}
+              <div class="message-file">
+                <a class="file-download" href={b64ToObjectUrl(msg.file.data, msg.file.content_type)} download={msg.file.filename}>
+                  <span class="file-icon">📎</span>
+                  <span class="file-name">{msg.file.filename}</span>
+                  <span class="file-size">({formatFileSize(msg.file.size)})</span>
+                </a>
+              </div>
+            {:else}
+              <div class="message-text">{msg.text}</div>
+            {/if}
           </div>
         {/each}
         <div bind:this={messagesEnd}></div>
@@ -637,6 +701,48 @@
     font-size: 0.9rem;
     word-break: break-word;
     white-space: pre-wrap;
+  }
+
+  .message-file {
+    font-size: 0.9rem;
+  }
+
+  .file-download {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3em;
+    color: inherit;
+    text-decoration: none;
+    padding: 0.2em 0.4em;
+    border-radius: 4px;
+    background: rgba(255,255,255,0.08);
+  }
+
+  .file-download:hover {
+    background: rgba(255,255,255,0.15);
+    text-decoration: underline;
+  }
+
+  .message.own .file-download {
+    background: rgba(0,0,0,0.1);
+  }
+
+  .message.own .file-download:hover {
+    background: rgba(0,0,0,0.2);
+  }
+
+  .file-icon {
+    font-size: 1.1em;
+  }
+
+  .file-name {
+    font-weight: 500;
+    word-break: break-all;
+  }
+
+  .file-size {
+    font-size: 0.8em;
+    opacity: 0.7;
   }
 
   .chat-input {

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -145,7 +145,8 @@
 
   function peerStatus(room, _p2p, _online) {
     if (_p2p.roomId === room.id && _p2p.connectionState === "connected") {
-      return _p2p.routeType === "relay" ? "p2p-relay" : "p2p";
+      if (_p2p.routeType === "relay") return "p2p-relay";
+      return "p2p";
     }
     if (_online.has(room.fingerprint)) return "online";
     return "offline";
@@ -153,9 +154,12 @@
 
   function peerStatusTooltip(room, _p2p, _online) {
     const status = peerStatus(room, _p2p, _online);
-    if (status === "p2p") return "Connected via direct P2P (WebRTC)";
-    if (status === "p2p-relay") return "Connected via TURN relay (WebRTC)";
-    if (status === "online") return "Online via NATS (no P2P connection)";
+    if (status === "p2p") {
+      if (_p2p.routeType === "srflx") return "Direct P2P via NAT traversal (STUN)";
+      return "Direct P2P via LAN";
+    }
+    if (status === "p2p-relay") return "P2P via TURN relay";
+    if (status === "online") return "Online via NATS (no P2P)";
     return "Offline";
   }
 

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -190,27 +190,45 @@
     return URL.createObjectURL(blob);
   }
 
+  let pendingFiles = [];
+
+  function sendFileNow(file) {
+    p2p.sendChatFile(file).then((msg) => {
+      messages = [...messages, {
+        cn: chatStatus.cn || "You",
+        fingerprint: chatStatus.fingerprint,
+        ts: Date.now() / 1000,
+        text: null,
+        file: { filename: msg.filename, content_type: msg.content_type, size: msg.size, data: msg.data },
+        room: activeRoom,
+      }];
+      tick().then(scrollToBottom);
+    }).catch(() => {});
+  }
+
+  function flushPendingFiles() {
+    const files = pendingFiles;
+    pendingFiles = [];
+    for (const file of files) sendFileNow(file);
+  }
+
   export function dropFiles(files) {
-    if (!activeRoom || !p2pState.dcOpen || p2pState.roomId !== activeRoomObj?.id) return;
-    for (const file of files) {
-      p2p.sendChatFile(file).then((msg) => {
-        messages = [...messages, {
-          cn: chatStatus.cn || "You",
-          fingerprint: chatStatus.fingerprint,
-          ts: Date.now() / 1000,
-          text: null,
-          file: { filename: msg.filename, content_type: msg.content_type, size: msg.size, data: msg.data },
-          room: activeRoom,
-        }];
-        tick().then(scrollToBottom);
-      }).catch(() => {});
+    if (!activeRoom || !activeRoomObj) return;
+    const room = activeRoomObj;
+
+    // P2P already connected to this room — send immediately
+    if (p2pState.dcOpen && p2pState.roomId === room.id) {
+      for (const file of files) sendFileNow(file);
+      return;
     }
+
+    // Queue files and initiate P2P connection
+    pendingFiles = [...pendingFiles, ...files];
+    p2p.connect(room.id, room.name, chatStatus.fingerprint, room.fingerprint);
   }
 
   export function canDropFiles() {
-    if (!activeRoom) return false;
-    const room = rooms.find(r => r.id === activeRoom);
-    return room && p2pState.dcOpen && p2pState.roomId === room.id;
+    return !!activeRoom && !!activeRoomObj;
   }
 
   function onChatFileReceived(e) {
@@ -283,6 +301,7 @@
     window.addEventListener("chat-defriended", onChatDefriended);
     window.addEventListener("chat-file-received", onChatFileReceived);
     unsubP2P = p2p.onChange(s => {
+      const wasOpen = p2pState.dcOpen;
       p2pState = s;
       // Auto-open P2P panel when connection is established from any page
       if (s.roomId && !p2pRoom) {
@@ -291,6 +310,10 @@
       }
       // Clear panel when connection closes
       if (!s.roomId && p2pRoom) { p2pRoom = null; p2pPeer = null; }
+      // Flush queued files when data channel opens
+      if (s.dcOpen && !wasOpen && pendingFiles.length > 0) {
+        flushPendingFiles();
+      }
     });
   });
 

--- a/frontend/src/Chat.svelte
+++ b/frontend/src/Chat.svelte
@@ -151,6 +151,14 @@
     return "offline";
   }
 
+  function peerStatusTooltip(room, _p2p, _online) {
+    const status = peerStatus(room, _p2p, _online);
+    if (status === "p2p") return "Connected via direct P2P (WebRTC)";
+    if (status === "p2p-relay") return "Connected via TURN relay (WebRTC)";
+    if (status === "online") return "Online via NATS (no P2P connection)";
+    return "Offline";
+  }
+
   function isPendingOutgoing(fingerprint) {
     // We don't track this client-side yet, just return false
     return false;
@@ -244,7 +252,7 @@
   <div class="chat-sidebar">
     <div class="sidebar-header">Rooms</div>
     {#each rooms as room}
-      <div class="room-row">
+      <div class="room-row" title={peerStatusTooltip(room, p2pState, onlinePeerSet)}>
         <button
           class="room-item"
           class:active={activeRoom === room.id}

--- a/frontend/src/P2P.svelte
+++ b/frontend/src/P2P.svelte
@@ -26,8 +26,8 @@
     p2p.connect(roomId, peerName, ownFingerprint, peerFingerprint);
   }
 
-  function stateColor(state) {
-    if (state === "connected") return "var(--success, #4caf50)";
+  function stateColor(state, routeType) {
+    if (state === "connected") return routeType === "relay" ? "#42a5f5" : "var(--success, #4caf50)";
     if (state === "connecting") return "var(--warning, #ff9800)";
     if (state === "failed") return "var(--error, #f44336)";
     return "var(--text-muted, #888)";
@@ -36,9 +36,9 @@
 
 <div class="p2p-panel">
   <div class="p2p-header">
-    <span class="p2p-status-dot" style="background: {stateColor(active ? s.connectionState : 'idle')}"></span>
+    <span class="p2p-status-dot" style="background: {stateColor(active ? s.connectionState : 'idle', s.routeType)}"></span>
     <span class="p2p-title">P2P: {peerName}</span>
-    <span class="p2p-state">{active ? s.connectionState : "idle"}</span>
+    <span class="p2p-state">{active ? (s.connectionState === "connected" && s.routeType ? `${s.connectionState} (${s.routeType})` : s.connectionState) : "idle"}</span>
     <div class="p2p-actions">
       {#if !active || s.connectionState === "idle"}
         <button class="btn-p2p" on:click={connect} disabled={s.roomId && !active}>Connect</button>

--- a/frontend/src/P2P.svelte
+++ b/frontend/src/P2P.svelte
@@ -38,7 +38,7 @@
   <div class="p2p-header">
     <span class="p2p-status-dot" style="background: {stateColor(active ? s.connectionState : 'idle', s.routeType)}"></span>
     <span class="p2p-title">P2P: {peerName}</span>
-    <span class="p2p-state">{active ? (s.connectionState === "connected" && s.routeType ? `${s.connectionState} (${s.routeType})` : s.connectionState) : "idle"}</span>
+    <span class="p2p-state">{active ? (s.connectionState === "connected" && s.routeType ? `${s.connectionState} (${s.routeType === "host" ? "LAN" : s.routeType === "srflx" ? "STUN" : "TURN"})` : s.connectionState) : "idle"}</span>
     <div class="p2p-actions">
       {#if !active || s.connectionState === "idle"}
         <button class="btn-p2p" on:click={connect} disabled={s.roomId && !active}>Connect</button>

--- a/frontend/src/Records.svelte
+++ b/frontend/src/Records.svelte
@@ -1,7 +1,7 @@
 <script>
   import { onMount, onDestroy, createEventDispatcher, tick } from "svelte";
   import { storageGet, storageSet } from "./storage.js";
-  import { pushRecord, pushDeleteAttachment } from "./p2p.js";
+  import { pushRecord, pushDeleteAttachment, pushDeleteRecord } from "./p2p.js";
   import Icon from "@iconify/svelte";
   import iconPencil from "@iconify-icons/twemoji/pencil";
 
@@ -530,8 +530,12 @@
 
   async function deleteRecord(id) {
     if (!confirm("Delete this record?")) return;
+    const rec = records.find(r => r.id === id);
     try {
       await fetch(`/api/records/${id}`, { method: "DELETE" });
+      if (rec && rec.uuid && rec.recipients) {
+        pushDeleteRecord(rec.uuid, rec.recipients);
+      }
       if (formId === id) cancelForm();
       await fetchRecords();
     } catch {}

--- a/frontend/src/Records.svelte
+++ b/frontend/src/Records.svelte
@@ -1,6 +1,7 @@
 <script>
   import { onMount, onDestroy, createEventDispatcher, tick } from "svelte";
   import { storageGet, storageSet } from "./storage.js";
+  import { pushRecord } from "./p2p.js";
   import Icon from "@iconify/svelte";
   import iconPencil from "@iconify-icons/twemoji/pencil";
 
@@ -508,6 +509,8 @@
         });
       }
       if (res.ok) {
+        const saved = await res.json();
+        pushRecord(saved);
         formAutoCreated = false;
         cancelForm();
         await fetchRecords();

--- a/frontend/src/Records.svelte
+++ b/frontend/src/Records.svelte
@@ -1,7 +1,7 @@
 <script>
   import { onMount, onDestroy, createEventDispatcher, tick } from "svelte";
   import { storageGet, storageSet } from "./storage.js";
-  import { pushRecord } from "./p2p.js";
+  import { pushRecord, pushDeleteAttachment } from "./p2p.js";
   import Icon from "@iconify/svelte";
   import iconPencil from "@iconify-icons/twemoji/pencil";
 
@@ -22,6 +22,7 @@
   let formContent = "";
   let formTags = "";
   let formId = null;
+  let formUuid = null;
   let formAutoCreated = false;
   let saving = false;
   let error = "";
@@ -433,6 +434,7 @@
 
   async function startNew() {
     formId = null;
+    formUuid = null;
     formTitle = "";
     formContent = "";
     formTags = "";
@@ -453,6 +455,7 @@
       if (res.ok) {
         const r = await res.json();
         formId = r.id;
+        formUuid = r.uuid;
         formTitle = origTitle = r.title || "";
         formContent = origContent = r.content || "";
         formTags = origTags = r.tags || "";
@@ -467,6 +470,7 @@
 
   function editRecord(r) {
     formId = r.id;
+    formUuid = r.uuid;
     formTitle = origTitle = r.title || "";
     formContent = origContent = r.content || "";
     formTags = origTags = r.tags || "";
@@ -543,6 +547,7 @@
     editId = null;
     showForm = false;
     formId = null;
+    formUuid = null;
     formAutoCreated = false;
     selectedIndex = -1;
     dispatch("editchange", null);
@@ -620,8 +625,12 @@
 
   async function deleteAttachment(attId) {
     if (!confirm("Delete this attachment? This cannot be undone.")) return;
+    const att = attachments.find(a => a.id === attId);
     try {
       await fetch(`/api/records/${formId}/attachments/${attId}`, { method: "DELETE" });
+      if (att && formUuid) {
+        pushDeleteAttachment(formUuid, att.filename, formRecipients);
+      }
       await fetchAttachments(formId);
     } catch {}
   }

--- a/frontend/src/Records.svelte
+++ b/frontend/src/Records.svelte
@@ -37,6 +37,9 @@
   let attDragCounter = 0;
   let previewIndex = -1;
   let selectedTags = new Set();
+  let formRecipients = [];
+  let origRecipients = [];
+  let trustedPeers = [];
 
   $: previewableAttachments = attachments.filter(a =>
     a.content_type.startsWith("image/") ||
@@ -300,7 +303,7 @@
   $: if (showForm && !formId && (formTitle || formContent || formTags)) {
     formDirty = true;
   }
-  $: if (showForm && formId && (formTitle !== origTitle || formContent !== origContent || formTags !== origTags)) {
+  $: if (showForm && formId && (formTitle !== origTitle || formContent !== origContent || formTags !== origTags || JSON.stringify(formRecipients) !== JSON.stringify(origRecipients))) {
     formDirty = true;
   }
 
@@ -376,6 +379,7 @@
   onMount(() => {
     fetchRecords();
     connectRecordsSSE();
+    fetchTrustedPeers();
     document.addEventListener("drop", onDocDrop);
     document.addEventListener("dragend", onDocDragEnd);
   });
@@ -402,6 +406,24 @@
     loading = false;
   }
 
+  async function fetchTrustedPeers() {
+    try {
+      const res = await fetch("/api/chat/trusted");
+      if (res.ok) {
+        const peers = await res.json();
+        trustedPeers = peers.filter(p => p.mutual);
+      }
+    } catch {}
+  }
+
+  function toggleRecipient(fp, checked) {
+    if (checked) {
+      formRecipients = [...formRecipients, fp];
+    } else {
+      formRecipients = formRecipients.filter(f => f !== fp);
+    }
+  }
+
   function onSearchInput() {
     clearTimeout(searchTimeout);
     searchTimeout = setTimeout(fetchRecords, 300);
@@ -413,6 +435,8 @@
     formTitle = "";
     formContent = "";
     formTags = "";
+    formRecipients = [];
+    origRecipients = [];
     error = "";
     attachments = [];
     attachmentError = "";
@@ -431,6 +455,8 @@
         formTitle = origTitle = r.title || "";
         formContent = origContent = r.content || "";
         formTags = origTags = r.tags || "";
+        formRecipients = r.recipients || [];
+        origRecipients = [...formRecipients];
         showForm = true;
         formDirty = false;
         fetchAttachments(r.id);
@@ -443,6 +469,8 @@
     formTitle = origTitle = r.title || "";
     formContent = origContent = r.content || "";
     formTags = origTags = r.tags || "";
+    formRecipients = r.recipients || [];
+    origRecipients = [...formRecipients];
     error = "";
     attachmentError = "";
     showForm = true;
@@ -462,6 +490,7 @@
       title: formTitle.trim(),
       content: formContent.trim() || null,
       tags: formTags.trim() || null,
+      recipients: formRecipients.length > 0 ? formRecipients : null,
     };
     try {
       let res;
@@ -518,6 +547,8 @@
     formTitle = "";
     formContent = "";
     formTags = "";
+    formRecipients = [];
+    origRecipients = [];
     error = "";
     attachments = [];
     attachmentError = "";
@@ -717,6 +748,22 @@
         <label for="rec-tags">Tags</label>
         <input id="rec-tags" type="text" bind:value={formTags} placeholder="Tags (optional, comma-separated)" />
       </div>
+      {#if trustedPeers.length > 0}
+        <div class="form-field">
+          <!-- svelte-ignore a11y-label-has-associated-control -->
+          <label>Recipients</label>
+          <div class="recipients-list">
+            {#each trustedPeers as peer (peer.fingerprint)}
+              <label class="recipient-checkbox">
+                <input type="checkbox"
+                  checked={formRecipients.includes(peer.fingerprint)}
+                  on:change={e => toggleRecipient(peer.fingerprint, e.target.checked)} />
+                {peer.cn}
+              </label>
+            {/each}
+          </div>
+        </div>
+      {/if}
       {#if formId}
         <!-- svelte-ignore a11y-no-static-element-interactions -->
         <div class="attachments-section" class:drag-active={dragOver}
@@ -977,6 +1024,25 @@
     font-size: 0.9rem;
     font-family: inherit;
     resize: vertical;
+  }
+
+  .recipients-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem 1rem;
+  }
+
+  .recipient-checkbox {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-size: 0.85rem;
+    color: var(--text, #eaeaea);
+    cursor: pointer;
+  }
+
+  .recipient-checkbox input[type="checkbox"] {
+    margin: 0;
   }
 
   .error {

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -444,10 +444,9 @@
   let natsReplacing = { ca: false, cert: false, key: false };
   let natsChatEnabled = false;
   let natsLobbyEnabled = false;
-  let iceTurnServer = "";
-  let iceTurnUsername = "";
-  let iceTurnCredential = "";
-  let iceServersSaving = false;
+  let turnServer = "";
+  let turnSecret = "";
+  let turnSaving = false;
   let iceTestResult = null;
   let iceTestRunning = false;
 
@@ -1378,18 +1377,8 @@
           if (s.key === "update_check_enabled") update_check_enabled = s.value !== "false";
           if (s.key === "nats_enabled") natsEnabled = s.value === "true";
           if (s.key === "nats_endpoint") natsEndpoint = s.value || "";
-          if (s.key === "ice_servers" && s.value) {
-            try {
-              const arr = JSON.parse(s.value);
-              if (arr.length > 0) {
-                const srv = arr[0];
-                const urls = (typeof srv.urls === "string" ? srv.urls : (srv.urls || [])[0]) || "";
-                iceTurnServer = urls.replace(/^turn:/, "");
-                iceTurnUsername = srv.username || "";
-                iceTurnCredential = srv.credential || "";
-              }
-            } catch {}
-          }
+          if (s.key === "turn_server") turnServer = s.value || "";
+          if (s.key === "turn_secret") turnSecret = s.value || "";
         }
         globalSettingsLoaded = true;
       }
@@ -1411,33 +1400,36 @@
     dispatch("app-name-changed");
   }
 
-  function buildIceServers() {
-    const server = iceTurnServer.trim();
-    if (!server) return [];
-    const entry = { urls: `turn:${server}` };
-    if (iceTurnUsername.trim()) entry.username = iceTurnUsername.trim();
-    if (iceTurnCredential.trim()) entry.credential = iceTurnCredential.trim();
-    return [entry];
-  }
-
-  async function saveIceServers() {
-    iceServersSaving = true;
+  async function saveTurnSettings() {
+    turnSaving = true;
     iceTestResult = null;
     try {
-      const servers = buildIceServers();
-      await saveGlobalSetting("ice_servers", servers.length > 0 ? JSON.stringify(servers) : "");
+      await saveGlobalSetting("turn_server", turnServer.trim());
+      await saveGlobalSetting("turn_secret", turnSecret.trim());
     } finally {
-      iceServersSaving = false;
+      turnSaving = false;
     }
   }
 
-  async function saveAndTestIceServers() {
-    await saveIceServers();
+  async function saveAndTestTurn() {
+    await saveTurnSettings();
     await testIceServers();
   }
 
   async function testIceServers() {
-    const iceServers = buildIceServers();
+    // Fetch computed credentials from server
+    let iceServers = [];
+    try {
+      const res = await fetch("/api/chat/ice-servers");
+      if (res.ok) iceServers = await res.json();
+    } catch (err) {
+      iceTestResult = { status: "error", error: err.message };
+      return;
+    }
+    if (iceServers.length === 0) {
+      iceTestResult = { status: "ok", host: 0, srflx: 0, relay: 0, candidates: [], detail: "No TURN server configured (LAN-only)" };
+      return;
+    }
 
     iceTestRunning = true;
     iceTestResult = null;
@@ -2623,22 +2615,18 @@
 
     <section class="settings-section">
       <h3>TURN Server (WebRTC)</h3>
-      <p class="hint">Configure a TURN relay server for P2P connections across the internet. Leave empty for LAN-only connections.</p>
+      <p class="hint">Configure a TURN relay server for P2P connections across the internet. Credentials are generated automatically from the shared secret. Leave empty for LAN-only connections.</p>
       <div class="setting-row">
-        <label for="ice-turn-server">Server:Port</label>
-        <input id="ice-turn-server" type="text" bind:value={iceTurnServer} placeholder="turn.example.com:3478" />
+        <label for="turn-server">Server:Port</label>
+        <input id="turn-server" type="text" bind:value={turnServer} placeholder="turn.example.com:3478" />
       </div>
       <div class="setting-row">
-        <label for="ice-turn-user">Username</label>
-        <input id="ice-turn-user" type="text" bind:value={iceTurnUsername} placeholder="username" />
-      </div>
-      <div class="setting-row">
-        <label for="ice-turn-cred">Credential</label>
-        <input id="ice-turn-cred" type="password" bind:value={iceTurnCredential} placeholder="credential" />
+        <label for="turn-secret">Shared Secret</label>
+        <input id="turn-secret" type="password" bind:value={turnSecret} placeholder="coturn static-auth-secret" />
       </div>
       <div class="button-row">
-        <button class="save-btn" on:click={saveAndTestIceServers} disabled={iceServersSaving || iceTestRunning}>
-          {iceServersSaving ? "Saving..." : iceTestRunning ? "Testing..." : "Save & Test"}
+        <button class="save-btn" on:click={saveAndTestTurn} disabled={turnSaving || iceTestRunning}>
+          {turnSaving ? "Saving..." : iceTestRunning ? "Testing..." : "Save & Test"}
         </button>
         <button class="cancel-btn" on:click={testIceServers} disabled={iceTestRunning}>
           {iceTestRunning ? "Testing..." : "Test Only"}

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -444,6 +444,8 @@
   let natsReplacing = { ca: false, cert: false, key: false };
   let natsChatEnabled = false;
   let natsLobbyEnabled = false;
+  let iceServersText = "";
+  let iceServersSaving = false;
 
   async function loadNatsStatus() {
     try {
@@ -1372,6 +1374,7 @@
           if (s.key === "update_check_enabled") update_check_enabled = s.value !== "false";
           if (s.key === "nats_enabled") natsEnabled = s.value === "true";
           if (s.key === "nats_endpoint") natsEndpoint = s.value || "";
+          if (s.key === "ice_servers") iceServersText = s.value || "";
         }
         globalSettingsLoaded = true;
       }
@@ -1391,6 +1394,15 @@
   async function saveAppName() {
     await saveGlobalSetting("app_name", appNameInput);
     dispatch("app-name-changed");
+  }
+
+  async function saveIceServers() {
+    iceServersSaving = true;
+    try {
+      await saveGlobalSetting("ice_servers", iceServersText.trim());
+    } finally {
+      iceServersSaving = false;
+    }
   }
 
   async function saveGlobalSetting(key, value) {
@@ -2516,6 +2528,20 @@
       {/if}
     </section>
     {/if}
+
+    <section class="settings-section">
+      <h3>ICE Servers (WebRTC)</h3>
+      <p class="hint">JSON array of ICE server objects for WebRTC peer connections. Leave empty for LAN-only (no external STUN/TURN). Example:</p>
+      <pre class="hint" style="margin: 0.3rem 0; font-size: 0.75rem;">[{{"urls":"turn:example.com:3478","username":"user","credential":"pass"}}]</pre>
+      <div class="form-field">
+        <textarea bind:value={iceServersText} rows="3" placeholder='[{"urls":"turn:your-server:3478","username":"user","credential":"pass"}]'></textarea>
+      </div>
+      <div class="button-row">
+        <button class="save-btn" on:click={saveIceServers} disabled={iceServersSaving}>
+          {iceServersSaving ? "Saving..." : "Save"}
+        </button>
+      </div>
+    </section>
 
     {/if}
   </div></div>

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -1378,7 +1378,7 @@
           if (s.key === "nats_enabled") natsEnabled = s.value === "true";
           if (s.key === "nats_endpoint") natsEndpoint = s.value || "";
           if (s.key === "turn_server") turnServer = s.value || "";
-          if (s.key === "turn_secret") turnSecret = s.value || "";
+          if (s.key === "turn_secret") turnSecret = s.value === "***" ? "" : (s.value || "");
         }
         globalSettingsLoaded = true;
       }
@@ -1405,7 +1405,10 @@
     iceTestResult = null;
     try {
       await saveGlobalSetting("turn_server", turnServer.trim());
-      await saveGlobalSetting("turn_secret", turnSecret.trim());
+      // Only update the secret if the user entered a new value
+      if (turnSecret.trim()) {
+        await saveGlobalSetting("turn_secret", turnSecret.trim());
+      }
     } finally {
       turnSaving = false;
     }

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -2532,9 +2532,9 @@
     <section class="settings-section">
       <h3>ICE Servers (WebRTC)</h3>
       <p class="hint">JSON array of ICE server objects for WebRTC peer connections. Leave empty for LAN-only (no external STUN/TURN). Example:</p>
-      <pre class="hint" style="margin: 0.3rem 0; font-size: 0.75rem;">[{{"urls":"turn:example.com:3478","username":"user","credential":"pass"}}]</pre>
+      <pre class="hint" style="margin: 0.3rem 0; font-size: 0.75rem;">[{'{"urls":"turn:example.com:3478","username":"user","credential":"pass"}'}]</pre>
       <div class="form-field">
-        <textarea bind:value={iceServersText} rows="3" placeholder='[{"urls":"turn:your-server:3478","username":"user","credential":"pass"}]'></textarea>
+        <textarea bind:value={iceServersText} rows="3" placeholder={'[{"urls":"turn:your-server:3478","username":"user","credential":"pass"}]'}></textarea>
       </div>
       <div class="button-row">
         <button class="save-btn" on:click={saveIceServers} disabled={iceServersSaving}>

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -2518,9 +2518,6 @@
       {#if natsStatus.cn}
         <p class="hint">Client CN: {natsStatus.cn}</p>
       {/if}
-      <div class="setting-row" style="margin-top: 0.5em;">
-        <button class="btn" on:click={async () => { await fetch("/api/nats/restart", { method: "POST" }); }}>Reconnect</button>
-      </div>
     </section>
 
     <section class="settings-section">

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -444,8 +444,12 @@
   let natsReplacing = { ca: false, cert: false, key: false };
   let natsChatEnabled = false;
   let natsLobbyEnabled = false;
-  let iceServersText = "";
+  let iceTurnServer = "";
+  let iceTurnUsername = "";
+  let iceTurnCredential = "";
   let iceServersSaving = false;
+  let iceTestResult = null;
+  let iceTestRunning = false;
 
   async function loadNatsStatus() {
     try {
@@ -1374,7 +1378,18 @@
           if (s.key === "update_check_enabled") update_check_enabled = s.value !== "false";
           if (s.key === "nats_enabled") natsEnabled = s.value === "true";
           if (s.key === "nats_endpoint") natsEndpoint = s.value || "";
-          if (s.key === "ice_servers") iceServersText = s.value || "";
+          if (s.key === "ice_servers" && s.value) {
+            try {
+              const arr = JSON.parse(s.value);
+              if (arr.length > 0) {
+                const srv = arr[0];
+                const urls = (typeof srv.urls === "string" ? srv.urls : (srv.urls || [])[0]) || "";
+                iceTurnServer = urls.replace(/^turn:/, "");
+                iceTurnUsername = srv.username || "";
+                iceTurnCredential = srv.credential || "";
+              }
+            } catch {}
+          }
         }
         globalSettingsLoaded = true;
       }
@@ -1396,12 +1411,89 @@
     dispatch("app-name-changed");
   }
 
+  function buildIceServers() {
+    const server = iceTurnServer.trim();
+    if (!server) return [];
+    const entry = { urls: `turn:${server}` };
+    if (iceTurnUsername.trim()) entry.username = iceTurnUsername.trim();
+    if (iceTurnCredential.trim()) entry.credential = iceTurnCredential.trim();
+    return [entry];
+  }
+
   async function saveIceServers() {
     iceServersSaving = true;
+    iceTestResult = null;
     try {
-      await saveGlobalSetting("ice_servers", iceServersText.trim());
+      const servers = buildIceServers();
+      await saveGlobalSetting("ice_servers", servers.length > 0 ? JSON.stringify(servers) : "");
     } finally {
       iceServersSaving = false;
+    }
+  }
+
+  async function saveAndTestIceServers() {
+    await saveIceServers();
+    await testIceServers();
+  }
+
+  async function testIceServers() {
+    const iceServers = buildIceServers();
+
+    iceTestRunning = true;
+    iceTestResult = null;
+
+    const result = { host: 0, srflx: 0, relay: 0, candidates: [] };
+    let testPc;
+    try {
+      testPc = new RTCPeerConnection({ iceServers });
+      testPc.createDataChannel("ice-test");
+
+      const gatherDone = new Promise((resolve) => {
+        const timeout = setTimeout(resolve, 5000);
+        testPc.onicecandidate = ({ candidate }) => {
+          if (!candidate) { clearTimeout(timeout); resolve(); return; }
+          const typ = candidate.type;
+          if (typ === "host") result.host++;
+          else if (typ === "srflx") result.srflx++;
+          else if (typ === "relay") result.relay++;
+          result.candidates.push(
+            `${typ} ${candidate.protocol || ""} ${candidate.address || "?"}:${candidate.port || "?"}`
+          );
+        };
+      });
+
+      const offer = await testPc.createOffer();
+      await testPc.setLocalDescription(offer);
+      await gatherDone;
+
+      if (iceServers.length === 0) {
+        iceTestResult = { status: "ok", ...result, detail: "No ICE servers configured (LAN-only)" };
+      } else {
+        const hasTurn = iceServers.some(s => (s.urls || "").toString().startsWith("turn:"));
+        const hasStun = iceServers.some(s => (s.urls || "").toString().startsWith("stun:"));
+        let status = "ok";
+        let detail = "";
+        const parts = [];
+        if (result.host > 0) parts.push(`${result.host} host`);
+        if (result.srflx > 0) parts.push(`${result.srflx} srflx`);
+        if (result.relay > 0) parts.push(`${result.relay} relay`);
+        detail = `Candidates: ${parts.join(", ") || "none"}`;
+
+        if (hasStun && result.srflx === 0) {
+          status = "warning";
+          detail += " — STUN server did not return srflx candidates";
+        }
+        if (hasTurn && result.relay === 0) {
+          status = "error";
+          detail += " — TURN server did not return relay candidates (check credentials)";
+        }
+        iceTestResult = { status, ...result, detail };
+      }
+    } catch (err) {
+      iceTestResult = { status: "error", error: err.message, ...result };
+    } finally {
+      if (testPc) { try { testPc.close(); } catch {} }
+      iceTestRunning = false;
     }
   }
 
@@ -2530,17 +2622,54 @@
     {/if}
 
     <section class="settings-section">
-      <h3>ICE Servers (WebRTC)</h3>
-      <p class="hint">JSON array of ICE server objects for WebRTC peer connections. Leave empty for LAN-only (no external STUN/TURN). Example:</p>
-      <pre class="hint" style="margin: 0.3rem 0; font-size: 0.75rem;">[{'{"urls":"turn:example.com:3478","username":"user","credential":"pass"}'}]</pre>
+      <h3>TURN Server (WebRTC)</h3>
+      <p class="hint">Configure a TURN relay server for P2P connections across the internet. Leave empty for LAN-only connections.</p>
       <div class="form-field">
-        <textarea bind:value={iceServersText} rows="3" placeholder={'[{"urls":"turn:your-server:3478","username":"user","credential":"pass"}]'}></textarea>
+        <!-- svelte-ignore a11y-label-has-associated-control -->
+        <label>Server:Port</label>
+        <input type="text" bind:value={iceTurnServer} placeholder="turn.example.com:3478" />
+      </div>
+      <div class="form-field">
+        <!-- svelte-ignore a11y-label-has-associated-control -->
+        <label>Username</label>
+        <input type="text" bind:value={iceTurnUsername} placeholder="username" />
+      </div>
+      <div class="form-field">
+        <!-- svelte-ignore a11y-label-has-associated-control -->
+        <label>Credential</label>
+        <input type="password" bind:value={iceTurnCredential} placeholder="credential" />
       </div>
       <div class="button-row">
-        <button class="save-btn" on:click={saveIceServers} disabled={iceServersSaving}>
-          {iceServersSaving ? "Saving..." : "Save"}
+        <button class="save-btn" on:click={saveAndTestIceServers} disabled={iceServersSaving || iceTestRunning}>
+          {iceServersSaving ? "Saving..." : iceTestRunning ? "Testing..." : "Save & Test"}
+        </button>
+        <button class="cancel-btn" on:click={testIceServers} disabled={iceTestRunning}>
+          {iceTestRunning ? "Testing..." : "Test Only"}
         </button>
       </div>
+      {#if iceTestRunning}
+        <p class="hint">Gathering ICE candidates (up to 5s)...</p>
+      {/if}
+      {#if iceTestResult}
+        <div class="ice-test-result ice-test-{iceTestResult.status}">
+          {#if iceTestResult.error}
+            <p>Error: {iceTestResult.error}</p>
+          {/if}
+          {#if iceTestResult.detail}
+            <p>{iceTestResult.detail}</p>
+          {/if}
+          {#if iceTestResult.candidates && iceTestResult.candidates.length > 0}
+            <details>
+              <summary>{iceTestResult.candidates.length} candidate{iceTestResult.candidates.length === 1 ? "" : "s"} found</summary>
+              <ul class="ice-candidates">
+                {#each iceTestResult.candidates as c}
+                  <li>{c}</li>
+                {/each}
+              </ul>
+            </details>
+          {/if}
+        </div>
+      {/if}
     </section>
 
     {/if}
@@ -2937,6 +3066,21 @@
     font-size: 0.7rem;
     color: var(--text-dim);
   }
+
+  .ice-test-result {
+    margin-top: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 4px;
+    font-size: 0.8rem;
+  }
+  .ice-test-ok { background: rgba(0, 180, 0, 0.15); color: #4caf50; }
+  .ice-test-warning { background: rgba(255, 165, 0, 0.15); color: #ffa726; }
+  .ice-test-error { background: rgba(255, 50, 50, 0.15); color: #ff4444; }
+  .ice-test-result p { margin: 0 0 0.25rem; }
+  .ice-test-result details { margin-top: 0.25rem; }
+  .ice-test-result summary { cursor: pointer; font-size: 0.75rem; }
+  .ice-candidates { margin: 0.25rem 0 0; padding-left: 1.2rem; font-size: 0.7rem; font-family: monospace; }
+  .ice-candidates li { margin: 0.1rem 0; }
 
   .toggle-row {
     flex-direction: row;

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -2624,20 +2624,17 @@
     <section class="settings-section">
       <h3>TURN Server (WebRTC)</h3>
       <p class="hint">Configure a TURN relay server for P2P connections across the internet. Leave empty for LAN-only connections.</p>
-      <div class="form-field">
-        <!-- svelte-ignore a11y-label-has-associated-control -->
-        <label>Server:Port</label>
-        <input type="text" bind:value={iceTurnServer} placeholder="turn.example.com:3478" />
+      <div class="setting-row">
+        <label for="ice-turn-server">Server:Port</label>
+        <input id="ice-turn-server" type="text" bind:value={iceTurnServer} placeholder="turn.example.com:3478" />
       </div>
-      <div class="form-field">
-        <!-- svelte-ignore a11y-label-has-associated-control -->
-        <label>Username</label>
-        <input type="text" bind:value={iceTurnUsername} placeholder="username" />
+      <div class="setting-row">
+        <label for="ice-turn-user">Username</label>
+        <input id="ice-turn-user" type="text" bind:value={iceTurnUsername} placeholder="username" />
       </div>
-      <div class="form-field">
-        <!-- svelte-ignore a11y-label-has-associated-control -->
-        <label>Credential</label>
-        <input type="password" bind:value={iceTurnCredential} placeholder="credential" />
+      <div class="setting-row">
+        <label for="ice-turn-cred">Credential</label>
+        <input id="ice-turn-cred" type="password" bind:value={iceTurnCredential} placeholder="credential" />
       </div>
       <div class="button-row">
         <button class="save-btn" on:click={saveAndTestIceServers} disabled={iceServersSaving || iceTestRunning}>

--- a/frontend/src/p2p.js
+++ b/frontend/src/p2p.js
@@ -205,19 +205,29 @@ export function connect(rid, name, ownFp, peerFp) {
 
 /**
  * Push a single record (and its attachments) to the connected peer
- * if the peer is a recipient. Called after record save.
+ * if the peer is a recipient. If not connected, auto-connects first
+ * (the on-open sync will deliver the record).
  */
 export async function pushRecord(record) {
-  if (!dc || dc.readyState !== "open" || !peerFingerprint) return;
-  if (!record.recipients || !record.recipients.includes(peerFingerprint))
-    return;
+  if (!record.recipients || record.recipients.length === 0) return;
 
-  // Send the record
-  dc.send(JSON.stringify({ type: "sync-offer", records: [record] }));
-  log(`Pushed record to peer: ${record.title}`);
+  // If connected and peer is a recipient, push immediately
+  if (dc && dc.readyState === "open" && peerFingerprint) {
+    if (record.recipients.includes(peerFingerprint)) {
+      dc.send(JSON.stringify({ type: "sync-offer", records: [record] }));
+      log(`Pushed record to peer: ${record.title}`);
+      await pushAttachments(record);
+      return;
+    }
+  }
 
-  // Send attachments
-  if (!record.id) return;
+  // Not connected (or connected to a different peer) — auto-connect
+  // to the first recipient that has a mutual room
+  await autoConnectForRecipients(record.recipients);
+}
+
+async function pushAttachments(record) {
+  if (!record.id || !dc || dc.readyState !== "open") return;
   try {
     const attRes = await fetch(`/api/records/${record.id}/attachments/`);
     if (!attRes.ok) return;
@@ -236,6 +246,30 @@ export async function pushRecord(record) {
       );
     }
     if (atts.length > 0) log(`Pushed ${atts.length} attachments`);
+  } catch {}
+}
+
+async function autoConnectForRecipients(recipients) {
+  // Already connected to one of the recipients — on-open sync will handle it
+  if (pc && !isStale() && peerFingerprint && recipients.includes(peerFingerprint))
+    return;
+  try {
+    const [statusRes, roomsRes] = await Promise.all([
+      fetch("/api/chat/status"),
+      fetch("/api/chat/rooms"),
+    ]);
+    if (!statusRes.ok || !roomsRes.ok) return;
+    const chatStatus = await statusRes.json();
+    const rooms = await roomsRes.json();
+    if (!chatStatus.fingerprint) return;
+
+    for (const fp of recipients) {
+      const room = rooms.find((r) => r.fingerprint === fp);
+      if (!room) continue;
+      log(`Auto-connecting to ${room.name} for record sync`);
+      connect(room.id, room.name, chatStatus.fingerprint, room.fingerprint);
+      return;
+    }
   } catch {}
 }
 

--- a/frontend/src/p2p.js
+++ b/frontend/src/p2p.js
@@ -135,6 +135,7 @@ function setupDataChannel(channel) {
       } else if (msg.type === "chat-file") {
         log(`Received file: ${msg.filename} (${msg.size} bytes)`);
         window.dispatchEvent(new CustomEvent("chat-file-received", { detail: {
+          fileId: msg.fileId,
           filename: msg.filename,
           content_type: msg.content_type,
           size: msg.size,
@@ -142,6 +143,11 @@ function setupDataChannel(channel) {
           peerName: peerName,
           peerFingerprint: peerFingerprint,
           roomId: roomId,
+        }}));
+      } else if (msg.type === "chat-file-delete") {
+        log(`Received file delete: ${msg.fileId}`);
+        window.dispatchEvent(new CustomEvent("chat-file-deleted", { detail: {
+          fileId: msg.fileId,
         }}));
       }
     } catch {}
@@ -385,6 +391,8 @@ export function sendPing() {
  * The file is read as base64 and sent over the data channel.
  * Returns a promise that resolves with the message payload on success.
  */
+let fileIdCounter = 0;
+
 export function sendChatFile(file) {
   return new Promise((resolve, reject) => {
     if (!dc || dc.readyState !== "open") {
@@ -394,8 +402,10 @@ export function sendChatFile(file) {
     const reader = new FileReader();
     reader.onloadend = () => {
       const b64 = reader.result.split(",")[1];
+      const fileId = `${Date.now()}-${++fileIdCounter}`;
       const msg = {
         type: "chat-file",
+        fileId,
         filename: file.name,
         content_type: file.type || "application/octet-stream",
         size: file.size,
@@ -408,6 +418,12 @@ export function sendChatFile(file) {
     reader.onerror = () => reject(reader.error);
     reader.readAsDataURL(file);
   });
+}
+
+export function sendChatFileDelete(fileId) {
+  if (!dc || dc.readyState !== "open") return;
+  dc.send(JSON.stringify({ type: "chat-file-delete", fileId }));
+  log(`Sent file delete: ${fileId}`);
 }
 
 export function hangup() {

--- a/frontend/src/p2p.js
+++ b/frontend/src/p2p.js
@@ -20,6 +20,7 @@ let state = {
   iceState: "",
   signalingState: "",
   dcOpen: false,
+  routeType: "", // "direct" | "relay" | ""
   roomId: null,
   peerName: null,
   ownFingerprint: null,
@@ -55,6 +56,28 @@ function log(msg) {
   notify();
 }
 
+async function detectRouteType() {
+  if (!pc) return;
+  try {
+    const stats = await pc.getStats();
+    for (const report of stats.values()) {
+      if (report.type === "candidate-pair" && report.state === "succeeded") {
+        const localId = report.localCandidateId;
+        const local = stats.get(localId);
+        if (local && local.candidateType === "relay") {
+          state.routeType = "relay";
+          log("Route: relay (TURN)");
+        } else {
+          state.routeType = "direct";
+          log("Route: direct");
+        }
+        notify();
+        return;
+      }
+    }
+  } catch {}
+}
+
 async function sendSignal(type, fields = {}) {
   if (!roomId) return;
   try {
@@ -75,6 +98,7 @@ function setupDataChannel(channel) {
     state.dcOpen = true;
     dc = channel;
     log("Data channel open");
+    detectRouteType();
     channel.send(JSON.stringify({ type: "sync-request" }));
     log("Sync request sent");
   };
@@ -360,6 +384,7 @@ function cleanup(silent) {
   state.iceState = "";
   state.signalingState = "";
   state.dcOpen = false;
+  state.routeType = "";
   state.roomId = null;
   state.peerName = null;
   state.ownFingerprint = null;

--- a/frontend/src/p2p.js
+++ b/frontend/src/p2p.js
@@ -110,15 +110,22 @@ function setupDataChannel(channel) {
   };
 }
 
-function createPC() {
+async function createPC() {
   if (pc) return;
   log("Creating RTCPeerConnection");
   state.connectionState = "connecting";
   notify();
 
-  pc = new RTCPeerConnection({
-    iceServers: [{ urls: "stun:stun.l.google.com:19302" }],
-  });
+  let iceServers = [];
+  try {
+    const res = await fetch("/api/chat/ice-servers");
+    if (res.ok) iceServers = await res.json();
+  } catch {}
+  if (iceServers.length > 0) {
+    log(`ICE servers: ${iceServers.map((s) => s.urls).join(", ")}`);
+  }
+
+  pc = new RTCPeerConnection({ iceServers });
 
   pc.onicecandidate = ({ candidate }) => {
     if (candidate) {
@@ -192,7 +199,7 @@ function isStale() {
 }
 
 /** Start a P2P connection to a peer (called from UI). */
-export function connect(rid, name, ownFp, peerFp) {
+export async function connect(rid, name, ownFp, peerFp) {
   if (pc && isStale()) { log("Clearing stale connection"); cleanup(true); }
   if (pc) return;
   roomId = rid;
@@ -204,7 +211,7 @@ export function connect(rid, name, ownFp, peerFp) {
   state.ownFingerprint = ownFp;
   state.peerFingerprint = peerFp;
   state.polite = ownFp < peerFp;
-  createPC();
+  await createPC();
 }
 
 /**
@@ -368,7 +375,7 @@ function cleanup(silent) {
 
 // --- Event handlers called from App.svelte SSE dispatch ---
 
-export function handleOffer(detail, rooms, chatStatus) {
+export async function handleOffer(detail, rooms, chatStatus) {
   if (detail.room_id === roomId && pc) {
     if (isStale()) {
       // Stale connection to same room — tear down and reconnect
@@ -395,7 +402,7 @@ export function handleOffer(detail, rooms, chatStatus) {
   state.ownFingerprint = ownFingerprint;
   state.peerFingerprint = peerFingerprint;
   state.polite = ownFingerprint < peerFingerprint;
-  createPC();
+  await createPC();
   _handleOfferInternal(detail);
 }
 

--- a/frontend/src/p2p.js
+++ b/frontend/src/p2p.js
@@ -99,6 +99,8 @@ function setupDataChannel(channel) {
         handleSyncOffer(msg.records, channel);
       } else if (msg.type === "sync-attachment") {
         handleSyncAttachment(msg);
+      } else if (msg.type === "sync-delete-attachment") {
+        handleSyncDeleteAttachment(msg);
       } else if (msg.type === "sync-ack") {
         log(`Sync ack: ${msg.accepted} accepted, ${msg.skipped} skipped`);
       }
@@ -247,6 +249,34 @@ async function pushAttachments(record) {
     }
     if (atts.length > 0) log(`Pushed ${atts.length} attachments`);
   } catch {}
+}
+
+/**
+ * Notify the connected peer that an attachment was deleted.
+ * Auto-connects if needed.
+ */
+export async function pushDeleteAttachment(recordUuid, filename, recipients) {
+  if (!recipients || recipients.length === 0) return;
+
+  if (dc && dc.readyState === "open" && peerFingerprint) {
+    if (recipients.includes(peerFingerprint)) {
+      dc.send(
+        JSON.stringify({
+          type: "sync-delete-attachment",
+          record_uuid: recordUuid,
+          filename: filename,
+        })
+      );
+      log(`Pushed attachment deletion: ${filename}`);
+      return;
+    }
+  }
+
+  // Not connected — auto-connect; on-open sync won't delete, but the
+  // attachment won't exist on our side so it won't be sent either.
+  // For an explicit delete we need to queue it and send after connect.
+  // For now, auto-connect so future syncs are consistent.
+  await autoConnectForRecipients(recipients);
 }
 
 async function autoConnectForRecipients(recipients) {
@@ -518,5 +548,26 @@ async function handleSyncAttachment(msg) {
     }
   } catch (err) {
     log(`Attachment sync error: ${err.message}`);
+  }
+}
+
+async function handleSyncDeleteAttachment(msg) {
+  try {
+    const res = await fetch("/api/records/sync-delete-attachment", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        record_uuid: msg.record_uuid,
+        filename: msg.filename,
+      }),
+    });
+    if (res.ok) {
+      const result = await res.json();
+      if (result.action === "deleted") {
+        log(`Attachment deleted via sync: ${msg.filename}`);
+      }
+    }
+  } catch (err) {
+    log(`Attachment delete sync error: ${err.message}`);
   }
 }

--- a/frontend/src/p2p.js
+++ b/frontend/src/p2p.js
@@ -203,6 +203,42 @@ export function connect(rid, name, ownFp, peerFp) {
   createPC();
 }
 
+/**
+ * Push a single record (and its attachments) to the connected peer
+ * if the peer is a recipient. Called after record save.
+ */
+export async function pushRecord(record) {
+  if (!dc || dc.readyState !== "open" || !peerFingerprint) return;
+  if (!record.recipients || !record.recipients.includes(peerFingerprint))
+    return;
+
+  // Send the record
+  dc.send(JSON.stringify({ type: "sync-offer", records: [record] }));
+  log(`Pushed record to peer: ${record.title}`);
+
+  // Send attachments
+  if (!record.id) return;
+  try {
+    const attRes = await fetch(`/api/records/${record.id}/attachments/`);
+    if (!attRes.ok) return;
+    const atts = await attRes.json();
+    for (const att of atts) {
+      const b64 = await fetchAttachmentAsBase64(record.id, att.id);
+      if (!b64) continue;
+      dc.send(
+        JSON.stringify({
+          type: "sync-attachment",
+          record_uuid: record.uuid,
+          filename: att.filename,
+          content_type: att.content_type,
+          data: b64,
+        })
+      );
+    }
+    if (atts.length > 0) log(`Pushed ${atts.length} attachments`);
+  } catch {}
+}
+
 export function sendPing() {
   if (dc && dc.readyState === "open") {
     dc.send(JSON.stringify({ type: "ping", ts: Date.now() }));

--- a/frontend/src/p2p.js
+++ b/frontend/src/p2p.js
@@ -101,6 +101,8 @@ function setupDataChannel(channel) {
         handleSyncAttachment(msg);
       } else if (msg.type === "sync-delete-attachment") {
         handleSyncDeleteAttachment(msg);
+      } else if (msg.type === "sync-delete-record") {
+        handleSyncDeleteRecord(msg);
       } else if (msg.type === "sync-ack") {
         log(`Sync ack: ${msg.accepted} accepted, ${msg.skipped} skipped`);
       }
@@ -276,6 +278,29 @@ export async function pushDeleteAttachment(recordUuid, filename, recipients) {
   // attachment won't exist on our side so it won't be sent either.
   // For an explicit delete we need to queue it and send after connect.
   // For now, auto-connect so future syncs are consistent.
+  await autoConnectForRecipients(recipients);
+}
+
+/**
+ * Notify the connected peer that a record was deleted.
+ * Auto-connects if needed.
+ */
+export async function pushDeleteRecord(recordUuid, recipients) {
+  if (!recipients || recipients.length === 0) return;
+
+  if (dc && dc.readyState === "open" && peerFingerprint) {
+    if (recipients.includes(peerFingerprint)) {
+      dc.send(
+        JSON.stringify({
+          type: "sync-delete-record",
+          record_uuid: recordUuid,
+        })
+      );
+      log(`Pushed record deletion: ${recordUuid}`);
+      return;
+    }
+  }
+
   await autoConnectForRecipients(recipients);
 }
 
@@ -569,5 +594,23 @@ async function handleSyncDeleteAttachment(msg) {
     }
   } catch (err) {
     log(`Attachment delete sync error: ${err.message}`);
+  }
+}
+
+async function handleSyncDeleteRecord(msg) {
+  try {
+    const res = await fetch("/api/records/sync-delete-record", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ record_uuid: msg.record_uuid }),
+    });
+    if (res.ok) {
+      const result = await res.json();
+      if (result.action === "deleted") {
+        log(`Record deleted via sync: ${msg.record_uuid}`);
+      }
+    }
+  } catch (err) {
+    log(`Record delete sync error: ${err.message}`);
   }
 }

--- a/frontend/src/p2p.js
+++ b/frontend/src/p2p.js
@@ -536,6 +536,13 @@ async function handleSyncOffer(records, channel) {
   let skipped = 0;
   for (const rec of records) {
     try {
+      // Add the sender as a recipient so updates flow back
+      if (peerFingerprint) {
+        const recipients = rec.recipients || [];
+        if (!recipients.includes(peerFingerprint)) {
+          rec.recipients = [...recipients, peerFingerprint];
+        }
+      }
       const res = await fetch("/api/records/sync", {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/frontend/src/p2p.js
+++ b/frontend/src/p2p.js
@@ -132,6 +132,17 @@ function setupDataChannel(channel) {
         handleSyncDeleteRecord(msg);
       } else if (msg.type === "sync-ack") {
         log(`Sync ack: ${msg.accepted} accepted, ${msg.skipped} skipped`);
+      } else if (msg.type === "chat-file") {
+        log(`Received file: ${msg.filename} (${msg.size} bytes)`);
+        window.dispatchEvent(new CustomEvent("chat-file-received", { detail: {
+          filename: msg.filename,
+          content_type: msg.content_type,
+          size: msg.size,
+          data: msg.data,
+          peerName: peerName,
+          peerFingerprint: peerFingerprint,
+          roomId: roomId,
+        }}));
       }
     } catch {}
   };
@@ -367,6 +378,36 @@ export function sendPing() {
     dc.send(JSON.stringify({ type: "ping", ts: Date.now() }));
     log("Ping sent");
   }
+}
+
+/**
+ * Send a file to the connected peer as a chat file transfer.
+ * The file is read as base64 and sent over the data channel.
+ * Returns a promise that resolves with the message payload on success.
+ */
+export function sendChatFile(file) {
+  return new Promise((resolve, reject) => {
+    if (!dc || dc.readyState !== "open") {
+      reject(new Error("No open P2P connection"));
+      return;
+    }
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const b64 = reader.result.split(",")[1];
+      const msg = {
+        type: "chat-file",
+        filename: file.name,
+        content_type: file.type || "application/octet-stream",
+        size: file.size,
+        data: b64,
+      };
+      dc.send(JSON.stringify(msg));
+      log(`Sent file: ${file.name} (${file.size} bytes)`);
+      resolve(msg);
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
 }
 
 export function hangup() {

--- a/frontend/src/p2p.js
+++ b/frontend/src/p2p.js
@@ -75,6 +75,8 @@ function setupDataChannel(channel) {
     state.dcOpen = true;
     dc = channel;
     log("Data channel open");
+    channel.send(JSON.stringify({ type: "sync-request" }));
+    log("Sync request sent");
   };
   channel.onclose = () => {
     log("Data channel closed");
@@ -91,6 +93,12 @@ function setupDataChannel(channel) {
         const rtt = Date.now() - msg.ts;
         state.pingResults = [...state.pingResults, rtt];
         log(`Pong: ${rtt}ms RTT`);
+      } else if (msg.type === "sync-request") {
+        handleSyncRequest(channel);
+      } else if (msg.type === "sync-offer") {
+        handleSyncOffer(msg.records, channel);
+      } else if (msg.type === "sync-ack") {
+        log(`Sync ack: ${msg.accepted} accepted, ${msg.skipped} skipped`);
       }
     } catch {}
   };
@@ -313,4 +321,52 @@ export function handleHangup(detail) {
   if (detail.room_id !== roomId) return;
   log("Remote peer hung up");
   cleanup(false);
+}
+
+// --- P2P Record Sync ---
+
+const SYNC_BATCH_SIZE = 50;
+
+async function handleSyncRequest(channel) {
+  try {
+    const res = await fetch("/api/records/?limit=10000");
+    if (!res.ok) return;
+    const records = await res.json();
+    const forPeer = records.filter(
+      (r) => r.recipients && r.recipients.includes(peerFingerprint)
+    );
+    // Send in batches to stay within data channel message size limits
+    for (let i = 0; i < forPeer.length; i += SYNC_BATCH_SIZE) {
+      const batch = forPeer.slice(i, i + SYNC_BATCH_SIZE);
+      channel.send(JSON.stringify({ type: "sync-offer", records: batch }));
+    }
+    if (forPeer.length === 0) {
+      channel.send(JSON.stringify({ type: "sync-offer", records: [] }));
+    }
+    log(`Sync offer sent: ${forPeer.length} records`);
+  } catch (err) {
+    log(`Sync request error: ${err.message}`);
+  }
+}
+
+async function handleSyncOffer(records, channel) {
+  let accepted = 0;
+  let skipped = 0;
+  for (const rec of records) {
+    try {
+      const res = await fetch("/api/records/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(rec),
+      });
+      if (res.ok) {
+        const result = await res.json();
+        if (result.action === "created" || result.action === "updated")
+          accepted++;
+        else skipped++;
+      }
+    } catch {}
+  }
+  channel.send(JSON.stringify({ type: "sync-ack", accepted, skipped }));
+  log(`Sync complete: ${accepted} accepted, ${skipped} skipped`);
 }

--- a/frontend/src/p2p.js
+++ b/frontend/src/p2p.js
@@ -96,6 +96,7 @@ async function sendSignal(type, fields = {}) {
 
 function setupDataChannel(channel) {
   dc = channel;
+  channel.binaryType = "arraybuffer";
   channel.onopen = () => {
     state.connectionState = "connected";
     state.dcOpen = true;
@@ -112,6 +113,11 @@ function setupDataChannel(channel) {
     notify();
   };
   channel.onmessage = (e) => {
+    // Binary messages are file chunks
+    if (e.data instanceof ArrayBuffer) {
+      handleFileChunk(e.data);
+      return;
+    }
     try {
       const msg = JSON.parse(e.data);
       if (msg.type === "ping") {
@@ -133,6 +139,7 @@ function setupDataChannel(channel) {
       } else if (msg.type === "sync-ack") {
         log(`Sync ack: ${msg.accepted} accepted, ${msg.skipped} skipped`);
       } else if (msg.type === "chat-file") {
+        // Small inline file (< 10 MB)
         log(`Received file: ${msg.filename} (${msg.size} bytes)`);
         window.dispatchEvent(new CustomEvent("chat-file-received", { detail: {
           fileId: msg.fileId,
@@ -144,6 +151,33 @@ function setupDataChannel(channel) {
           peerFingerprint: peerFingerprint,
           roomId: roomId,
         }}));
+      } else if (msg.type === "chat-file-offer") {
+        // Large file offer — receiver must accept
+        log(`Received file offer: ${msg.filename} (${msg.size} bytes)`);
+        incomingTransfers[msg.fileId] = {
+          filename: msg.filename,
+          content_type: msg.content_type,
+          totalBytes: msg.size,
+          chunks: [],
+          receivedBytes: 0,
+        };
+        window.dispatchEvent(new CustomEvent("chat-file-offer-incoming", { detail: {
+          fileId: msg.fileId,
+          filename: msg.filename,
+          content_type: msg.content_type,
+          size: msg.size,
+          peerName: peerName,
+          peerFingerprint: peerFingerprint,
+          roomId: roomId,
+        }}));
+      } else if (msg.type === "chat-file-accept") {
+        const cb = pendingOfferCallbacks[msg.fileId];
+        if (cb) { delete pendingOfferCallbacks[msg.fileId]; cb.resolve(); }
+      } else if (msg.type === "chat-file-reject") {
+        const cb = pendingOfferCallbacks[msg.fileId];
+        if (cb) { delete pendingOfferCallbacks[msg.fileId]; cb.reject(); }
+      } else if (msg.type === "chat-file-complete") {
+        handleFileComplete(msg.fileId);
       } else if (msg.type === "chat-file-delete") {
         log(`Received file delete: ${msg.fileId}`);
         window.dispatchEvent(new CustomEvent("chat-file-deleted", { detail: {
@@ -386,23 +420,37 @@ export function sendPing() {
   }
 }
 
-/**
- * Send a file to the connected peer as a chat file transfer.
- * The file is read as base64 and sent over the data channel.
- * Returns a promise that resolves with the message payload on success.
- */
-let fileIdCounter = 0;
+// --- Chat file transfer ---
 
+const LARGE_FILE_THRESHOLD = 10 * 1024 * 1024; // 10 MB
+const CHUNK_SIZE = 65536; // 64 KB
+const MAX_BUFFERED = 1048576; // 1 MB
+
+let fileIdCounter = 0;
+const pendingOfferCallbacks = {};
+const incomingTransfers = {};
+
+/**
+ * Send a file to the connected peer.
+ * Small files (< 10 MB) are sent inline as base64.
+ * Large files use chunked binary transfer with offer/accept.
+ */
 export function sendChatFile(file) {
+  if (!dc || dc.readyState !== "open") {
+    return Promise.reject(new Error("No open P2P connection"));
+  }
+  const fileId = `${Date.now()}-${++fileIdCounter}`;
+  if (file.size < LARGE_FILE_THRESHOLD) {
+    return sendSmallFile(file, fileId);
+  }
+  return sendLargeFile(file, fileId);
+}
+
+function sendSmallFile(file, fileId) {
   return new Promise((resolve, reject) => {
-    if (!dc || dc.readyState !== "open") {
-      reject(new Error("No open P2P connection"));
-      return;
-    }
     const reader = new FileReader();
     reader.onloadend = () => {
       const b64 = reader.result.split(",")[1];
-      const fileId = `${Date.now()}-${++fileIdCounter}`;
       const msg = {
         type: "chat-file",
         fileId,
@@ -420,6 +468,132 @@ export function sendChatFile(file) {
   });
 }
 
+function sendLargeFile(file, fileId) {
+  dc.send(JSON.stringify({
+    type: "chat-file-offer",
+    fileId,
+    filename: file.name,
+    content_type: file.type || "application/octet-stream",
+    size: file.size,
+  }));
+  log(`Sent file offer: ${file.name} (${file.size} bytes)`);
+
+  window.dispatchEvent(new CustomEvent("chat-file-offer-sent", { detail: {
+    fileId,
+    filename: file.name,
+    content_type: file.type || "application/octet-stream",
+    size: file.size,
+  }}));
+
+  return new Promise((resolve, reject) => {
+    pendingOfferCallbacks[fileId] = {
+      resolve: async () => {
+        try {
+          await sendFileChunks(fileId, file);
+          dc.send(JSON.stringify({ type: "chat-file-complete", fileId }));
+          log(`File transfer complete: ${file.name}`);
+          resolve({ fileId, filename: file.name, content_type: file.type || "application/octet-stream", size: file.size });
+        } catch (err) {
+          reject(err);
+        }
+      },
+      reject: () => {
+        log(`File transfer rejected: ${file.name}`);
+        reject(new Error("File transfer rejected"));
+      },
+    };
+  });
+}
+
+async function sendFileChunks(fileId, file) {
+  const encoder = new TextEncoder();
+  const idBytes = encoder.encode(fileId);
+  let offset = 0;
+
+  while (offset < file.size) {
+    if (!dc || dc.readyState !== "open") throw new Error("Connection lost");
+
+    // Flow control: wait if send buffer is full
+    while (dc.bufferedAmount > MAX_BUFFERED) {
+      await new Promise((resolve) => {
+        const onLow = () => { resolve(); };
+        dc.addEventListener("bufferedamountlow", onLow, { once: true });
+        dc.bufferedAmountLowThreshold = MAX_BUFFERED / 2;
+      });
+      if (!dc || dc.readyState !== "open") throw new Error("Connection lost");
+    }
+
+    const end = Math.min(offset + CHUNK_SIZE, file.size);
+    const chunkData = await file.slice(offset, end).arrayBuffer();
+
+    // Binary message: [idLen:2][id:N][data:...]
+    const header = new Uint8Array(2 + idBytes.length);
+    header[0] = (idBytes.length >> 8) & 0xff;
+    header[1] = idBytes.length & 0xff;
+    header.set(idBytes, 2);
+    const msg = new Uint8Array(header.length + chunkData.byteLength);
+    msg.set(header);
+    msg.set(new Uint8Array(chunkData), header.length);
+    dc.send(msg.buffer);
+
+    offset = end;
+    window.dispatchEvent(new CustomEvent("chat-file-send-progress", {
+      detail: { fileId, sentBytes: offset, totalBytes: file.size },
+    }));
+  }
+}
+
+function handleFileChunk(buffer) {
+  const view = new Uint8Array(buffer);
+  const idLen = (view[0] << 8) | view[1];
+  const decoder = new TextDecoder();
+  const fileId = decoder.decode(view.slice(2, 2 + idLen));
+  const chunkData = view.slice(2 + idLen);
+
+  const transfer = incomingTransfers[fileId];
+  if (!transfer) return;
+  transfer.chunks.push(chunkData);
+  transfer.receivedBytes += chunkData.byteLength;
+
+  window.dispatchEvent(new CustomEvent("chat-file-recv-progress", {
+    detail: { fileId, receivedBytes: transfer.receivedBytes, totalBytes: transfer.totalBytes },
+  }));
+}
+
+function handleFileComplete(fileId) {
+  const transfer = incomingTransfers[fileId];
+  if (!transfer) return;
+  delete incomingTransfers[fileId];
+
+  const blob = new Blob(transfer.chunks, { type: transfer.content_type });
+  const url = URL.createObjectURL(blob);
+  log(`File received: ${transfer.filename} (${transfer.totalBytes} bytes)`);
+
+  window.dispatchEvent(new CustomEvent("chat-file-received", { detail: {
+    fileId,
+    filename: transfer.filename,
+    content_type: transfer.content_type,
+    size: transfer.totalBytes,
+    blobUrl: url,
+    peerName: peerName,
+    peerFingerprint: peerFingerprint,
+    roomId: roomId,
+  }}));
+}
+
+export function acceptFileTransfer(fileId) {
+  if (!dc || dc.readyState !== "open") return;
+  dc.send(JSON.stringify({ type: "chat-file-accept", fileId }));
+  log(`Accepted file transfer: ${fileId}`);
+}
+
+export function rejectFileTransfer(fileId) {
+  if (!dc || dc.readyState !== "open") return;
+  dc.send(JSON.stringify({ type: "chat-file-reject", fileId }));
+  delete incomingTransfers[fileId];
+  log(`Rejected file transfer: ${fileId}`);
+}
+
 export function sendChatFileDelete(fileId) {
   if (!dc || dc.readyState !== "open") return;
   dc.send(JSON.stringify({ type: "chat-file-delete", fileId }));
@@ -433,6 +607,14 @@ export function hangup() {
 
 function cleanup(silent) {
   if (iceDisconnectTimer) { clearTimeout(iceDisconnectTimer); iceDisconnectTimer = null; }
+  // Abort pending file transfers
+  for (const fileId of Object.keys(pendingOfferCallbacks)) {
+    pendingOfferCallbacks[fileId].reject();
+    delete pendingOfferCallbacks[fileId];
+  }
+  for (const fileId of Object.keys(incomingTransfers)) {
+    delete incomingTransfers[fileId];
+  }
   if (dc) { try { dc.close(); } catch {} dc = null; }
   if (pc) { try { pc.close(); } catch {} pc = null; }
   roomId = null;

--- a/frontend/src/p2p.js
+++ b/frontend/src/p2p.js
@@ -97,6 +97,8 @@ function setupDataChannel(channel) {
         handleSyncRequest(channel);
       } else if (msg.type === "sync-offer") {
         handleSyncOffer(msg.records, channel);
+      } else if (msg.type === "sync-attachment") {
+        handleSyncAttachment(msg);
       } else if (msg.type === "sync-ack") {
         log(`Sync ack: ${msg.accepted} accepted, ${msg.skipped} skipped`);
       }
@@ -327,6 +329,23 @@ export function handleHangup(detail) {
 
 const SYNC_BATCH_SIZE = 50;
 
+async function fetchAttachmentAsBase64(recordId, attId) {
+  const res = await fetch(
+    `/api/records/${recordId}/attachments/${attId}/download`
+  );
+  if (!res.ok) return null;
+  const blob = await res.blob();
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      // Strip the data:...;base64, prefix
+      const b64 = reader.result.split(",")[1];
+      resolve(b64);
+    };
+    reader.readAsDataURL(blob);
+  });
+}
+
 async function handleSyncRequest(channel) {
   try {
     const res = await fetch("/api/records/?limit=10000");
@@ -335,7 +354,24 @@ async function handleSyncRequest(channel) {
     const forPeer = records.filter(
       (r) => r.recipients && r.recipients.includes(peerFingerprint)
     );
-    // Send in batches to stay within data channel message size limits
+
+    // Fetch attachment metadata for each record
+    for (const rec of forPeer) {
+      try {
+        const attRes = await fetch(`/api/records/${rec.id}/attachments/`);
+        if (attRes.ok) {
+          const atts = await attRes.json();
+          rec.attachments = atts.map((a) => ({
+            id: a.id,
+            filename: a.filename,
+            content_type: a.content_type,
+            size: a.size,
+          }));
+        }
+      } catch {}
+    }
+
+    // Send record metadata in batches
     for (let i = 0; i < forPeer.length; i += SYNC_BATCH_SIZE) {
       const batch = forPeer.slice(i, i + SYNC_BATCH_SIZE);
       channel.send(JSON.stringify({ type: "sync-offer", records: batch }));
@@ -344,6 +380,27 @@ async function handleSyncRequest(channel) {
       channel.send(JSON.stringify({ type: "sync-offer", records: [] }));
     }
     log(`Sync offer sent: ${forPeer.length} records`);
+
+    // Send attachment data for each record
+    let attCount = 0;
+    for (const rec of forPeer) {
+      if (!rec.attachments || rec.attachments.length === 0) continue;
+      for (const att of rec.attachments) {
+        const b64 = await fetchAttachmentAsBase64(rec.id, att.id);
+        if (!b64) continue;
+        channel.send(
+          JSON.stringify({
+            type: "sync-attachment",
+            record_uuid: rec.uuid,
+            filename: att.filename,
+            content_type: att.content_type,
+            data: b64,
+          })
+        );
+        attCount++;
+      }
+    }
+    if (attCount > 0) log(`Sent ${attCount} attachments`);
   } catch (err) {
     log(`Sync request error: ${err.message}`);
   }
@@ -369,4 +426,27 @@ async function handleSyncOffer(records, channel) {
   }
   channel.send(JSON.stringify({ type: "sync-ack", accepted, skipped }));
   log(`Sync complete: ${accepted} accepted, ${skipped} skipped`);
+}
+
+async function handleSyncAttachment(msg) {
+  try {
+    const res = await fetch("/api/records/sync-attachment", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        record_uuid: msg.record_uuid,
+        filename: msg.filename,
+        content_type: msg.content_type,
+        data: msg.data,
+      }),
+    });
+    if (res.ok) {
+      const result = await res.json();
+      if (result.action === "created") {
+        log(`Attachment synced: ${msg.filename}`);
+      }
+    }
+  } catch (err) {
+    log(`Attachment sync error: ${err.message}`);
+  }
 }

--- a/frontend/src/p2p.js
+++ b/frontend/src/p2p.js
@@ -62,14 +62,17 @@ async function detectRouteType() {
     const stats = await pc.getStats();
     for (const report of stats.values()) {
       if (report.type === "candidate-pair" && report.state === "succeeded") {
-        const localId = report.localCandidateId;
-        const local = stats.get(localId);
-        if (local && local.candidateType === "relay") {
+        const local = stats.get(report.localCandidateId);
+        const typ = local ? local.candidateType : "unknown";
+        if (typ === "relay") {
           state.routeType = "relay";
           log("Route: relay (TURN)");
+        } else if (typ === "srflx") {
+          state.routeType = "srflx";
+          log("Route: direct via NAT traversal (STUN)");
         } else {
-          state.routeType = "direct";
-          log("Route: direct");
+          state.routeType = "host";
+          log("Route: direct LAN");
         }
         notify();
         return;

--- a/src/guidebook/db.py
+++ b/src/guidebook/db.py
@@ -163,6 +163,7 @@ class Record(Base):
         DateTime, default=lambda: datetime.now(timezone.utc)
     )
     updated_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    recipients: Mapped[str | None] = mapped_column(String, nullable=True)
 
 
 class Attachment(Base):
@@ -416,7 +417,9 @@ INSTANCE_MIGRATIONS.append(_global_migration_1_client_certs)
 def _global_migration_2_client_certs_pending_session(conn):
     """Add pending_session_id column to client_certs for upgrade state tracking."""
     try:
-        conn.execute(text("ALTER TABLE client_certs ADD COLUMN pending_session_id INTEGER"))
+        conn.execute(
+            text("ALTER TABLE client_certs ADD COLUMN pending_session_id INTEGER")
+        )
     except Exception:
         pass  # column may already exist
 
@@ -674,9 +677,7 @@ class DatabaseManager:
         await self._migrate_last_opened()
         async with self.instance_engine.connect() as conn:
             gsv = await conn.run_sync(lambda c: _get_schema_version(c, "settings"))
-        logger.info(
-            "Opened instance database: %s (schema v%d)", INSTANCE_DB_PATH, gsv
-        )
+        logger.info("Opened instance database: %s (schema v%d)", INSTANCE_DB_PATH, gsv)
 
     async def close_instance(self) -> None:
         """Dispose of the instance database engine."""
@@ -697,7 +698,9 @@ class DatabaseManager:
             for name, ts in data.items():
                 existing = (
                     await session.execute(
-                        select(InstanceLastOpened).where(InstanceLastOpened.name == name)
+                        select(InstanceLastOpened).where(
+                            InstanceLastOpened.name == name
+                        )
                     )
                 ).scalar_one_or_none()
                 if existing:

--- a/src/guidebook/db.py
+++ b/src/guidebook/db.py
@@ -98,6 +98,7 @@ INSTANCE_ONLY_KEYS = {
     "nats_client_key",
     "nats_chat_enabled",
     "nats_lobby_enabled",
+    "ice_servers",
     "app_name",
 }
 

--- a/src/guidebook/db.py
+++ b/src/guidebook/db.py
@@ -98,7 +98,8 @@ INSTANCE_ONLY_KEYS = {
     "nats_client_key",
     "nats_chat_enabled",
     "nats_lobby_enabled",
-    "ice_servers",
+    "turn_server",
+    "turn_secret",
     "app_name",
 }
 

--- a/src/guidebook/routes/chat.py
+++ b/src/guidebook/routes/chat.py
@@ -1,8 +1,11 @@
+import json
 import logging
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
+from sqlalchemy import select
 
+from guidebook.db import InstanceSetting, db_manager
 from guidebook.chat import (
     WEBRTC_SIGNAL_TYPES,
     accept_verification,
@@ -34,6 +37,22 @@ class SignalMessage(BaseModel):
     sdpMid: str | None = None
     sdpMLineIndex: int | None = None
     ts: float | None = None
+
+
+@router.get("/ice-servers")
+async def get_ice_servers():
+    """Return configured ICE servers for WebRTC, or empty list if none set."""
+    async with db_manager.instance_session() as session:
+        result = await session.execute(
+            select(InstanceSetting).where(InstanceSetting.key == "ice_servers")
+        )
+        row = result.scalar_one_or_none()
+    if row and row.value:
+        try:
+            return json.loads(row.value)
+        except (json.JSONDecodeError, TypeError):
+            return []
+    return []
 
 
 @router.get("/status")

--- a/src/guidebook/routes/chat.py
+++ b/src/guidebook/routes/chat.py
@@ -1,5 +1,8 @@
-import json
+import base64
+import hashlib
+import hmac
 import logging
+import time
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
@@ -39,20 +42,43 @@ class SignalMessage(BaseModel):
     ts: float | None = None
 
 
+TURN_TTL_SECONDS = 14400  # 4 hours
+
+
 @router.get("/ice-servers")
 async def get_ice_servers():
-    """Return configured ICE servers for WebRTC, or empty list if none set."""
+    """Return ICE servers with ephemeral TURN credentials computed from shared secret."""
     async with db_manager.instance_session() as session:
-        result = await session.execute(
-            select(InstanceSetting).where(InstanceSetting.key == "ice_servers")
+        rows = (
+            (
+                await session.execute(
+                    select(InstanceSetting).where(
+                        InstanceSetting.key.in_(["turn_server", "turn_secret"])
+                    )
+                )
+            )
+            .scalars()
+            .all()
         )
-        row = result.scalar_one_or_none()
-    if row and row.value:
-        try:
-            return json.loads(row.value)
-        except (json.JSONDecodeError, TypeError):
-            return []
-    return []
+    settings = {r.key: r.value for r in rows if r.value}
+    server = settings.get("turn_server", "").strip()
+    secret = settings.get("turn_secret", "").strip()
+    if not server or not secret:
+        return []
+
+    expiry = int(time.time()) + TURN_TTL_SECONDS
+    username = f"{expiry}:guidebook"
+    password = base64.b64encode(
+        hmac.new(secret.encode(), username.encode(), hashlib.sha1).digest()
+    ).decode()
+
+    return [
+        {
+            "urls": f"turn:{server}",
+            "username": username,
+            "credential": password,
+        }
+    ]
 
 
 @router.get("/status")

--- a/src/guidebook/routes/chat.py
+++ b/src/guidebook/routes/chat.py
@@ -48,7 +48,9 @@ TURN_TTL_SECONDS = 14400  # 4 hours
 @router.get("/ice-servers")
 async def get_ice_servers():
     """Return ICE servers with ephemeral TURN credentials computed from shared secret."""
-    async with db_manager.instance_session() as session:
+    if db_manager._instance_session_factory is None:
+        return []
+    async with db_manager._instance_session_factory() as session:
         rows = (
             (
                 await session.execute(

--- a/src/guidebook/routes/chat.py
+++ b/src/guidebook/routes/chat.py
@@ -75,11 +75,12 @@ async def get_ice_servers():
     ).decode()
 
     return [
+        {"urls": f"stun:{server}"},
         {
             "urls": f"turn:{server}",
             "username": username,
             "credential": password,
-        }
+        },
     ]
 
 

--- a/src/guidebook/routes/instance_settings.py
+++ b/src/guidebook/routes/instance_settings.py
@@ -17,7 +17,12 @@ logger = logging.getLogger("guidebook")
 router = APIRouter(prefix="/api/instance-settings", tags=["instance-settings"])
 
 ALLOWED_KEYS = INSTANCE_DEFAULTABLE_KEYS | INSTANCE_ONLY_KEYS
-HIDDEN_KEYS: set[str] = {"nats_ca_cert", "nats_client_cert", "nats_client_key"}
+HIDDEN_KEYS: set[str] = {
+    "nats_ca_cert",
+    "nats_client_cert",
+    "nats_client_key",
+    "turn_secret",
+}
 
 
 class SettingValue(BaseModel):
@@ -44,8 +49,12 @@ async def list_instance_settings(gdb: AsyncSession = Depends(get_instance_sessio
 
 
 @router.get("/{key}", response_model=SettingResponse)
-async def get_instance_setting(key: str, gdb: AsyncSession = Depends(get_instance_session)):
-    result = await gdb.execute(select(InstanceSetting).where(InstanceSetting.key == key))
+async def get_instance_setting(
+    key: str, gdb: AsyncSession = Depends(get_instance_session)
+):
+    result = await gdb.execute(
+        select(InstanceSetting).where(InstanceSetting.key == key)
+    )
     setting = result.scalar_one_or_none()
     if not setting:
         return SettingResponse(key=key, value=None)
@@ -66,7 +75,9 @@ async def upsert_instance_setting(
     from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
     stmt = sqlite_insert(InstanceSetting).values(key=key, value=data.value)
-    stmt = stmt.on_conflict_do_update(index_elements=["key"], set_={"value": data.value})
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["key"], set_={"value": data.value}
+    )
     await gdb.execute(stmt)
     await gdb.commit()
     log_value = "***" if key in HIDDEN_KEYS else data.value

--- a/src/guidebook/routes/records.py
+++ b/src/guidebook/routes/records.py
@@ -74,6 +74,7 @@ class RecordCreate(BaseModel):
     content: str | None = None
     tags: str | None = None
     timestamp: datetime | None = None
+    recipients: list[str] | None = None
 
     @field_validator("title")
     @classmethod
@@ -98,12 +99,30 @@ class RecordUpdate(BaseModel):
     content: str | None = None
     tags: str | None = None
     timestamp: datetime | None = None
+    recipients: list[str] | None = None
 
     @field_validator("timestamp")
     @classmethod
     def normalize_timestamp(cls, v: datetime | None) -> datetime | None:
         if v is None:
             return v
+        if v.tzinfo is not None:
+            v = v.astimezone(timezone.utc).replace(tzinfo=None)
+        return v
+
+
+class RecordSync(BaseModel):
+    uuid: str
+    title: str
+    content: str | None = None
+    tags: str | None = None
+    recipients: list[str] | None = None
+    timestamp: datetime
+    updated_at: datetime
+
+    @field_validator("timestamp", "updated_at")
+    @classmethod
+    def normalize_timestamp(cls, v: datetime) -> datetime:
         if v.tzinfo is not None:
             v = v.astimezone(timezone.utc).replace(tzinfo=None)
         return v
@@ -117,6 +136,14 @@ class RecordResponse(BaseModel):
     tags: str | None
     timestamp: datetime
     updated_at: datetime | None = None
+    recipients: list[str] | None = None
+
+    @field_validator("recipients", mode="before")
+    @classmethod
+    def parse_recipients(cls, v: str | list | None) -> list[str] | None:
+        if isinstance(v, str):
+            return json.loads(v)
+        return v
 
     @field_serializer("timestamp")
     def serialize_timestamp(self, v: datetime) -> str:
@@ -160,12 +187,50 @@ async def list_records(
     return result.scalars().all()
 
 
+@router.post("/sync")
+async def sync_record(data: RecordSync, session: AsyncSession = Depends(get_session)):
+    result = await session.execute(select(Record).where(Record.uuid == data.uuid))
+    existing = result.scalar_one_or_none()
+
+    recipients_json = json.dumps(data.recipients) if data.recipients else None
+
+    if existing is None:
+        record = Record(
+            uuid=data.uuid,
+            title=data.title,
+            content=data.content,
+            tags=data.tags,
+            recipients=recipients_json,
+            timestamp=data.timestamp,
+            updated_at=data.updated_at,
+        )
+        session.add(record)
+        await session.commit()
+        _broadcast_records_changed()
+        return {"action": "created", "uuid": data.uuid}
+
+    local_ts = existing.updated_at or existing.timestamp
+    if data.updated_at > local_ts:
+        existing.title = data.title
+        existing.content = data.content
+        existing.tags = data.tags
+        existing.recipients = recipients_json
+        existing.updated_at = data.updated_at
+        await session.commit()
+        _broadcast_records_changed()
+        return {"action": "updated", "uuid": data.uuid}
+
+    return {"action": "skipped", "uuid": data.uuid}
+
+
 @router.post("/", response_model=RecordResponse, status_code=201)
 async def create_record(
     data: RecordCreate, session: AsyncSession = Depends(get_session)
 ):
     fields = data.model_dump(exclude_unset=True)
     fields["updated_at"] = fields.get("timestamp") or datetime.now(timezone.utc)
+    if "recipients" in fields and fields["recipients"] is not None:
+        fields["recipients"] = json.dumps(fields["recipients"])
     record = Record(**fields)
     session.add(record)
     await session.commit()
@@ -192,6 +257,8 @@ async def update_record(
     if not record:
         raise HTTPException(status_code=404, detail="Record not found")
     for key, value in data.model_dump(exclude_unset=True).items():
+        if key == "recipients" and value is not None:
+            value = json.dumps(value)
         setattr(record, key, value)
     record.updated_at = datetime.now(timezone.utc)
     await session.commit()

--- a/src/guidebook/routes/records.py
+++ b/src/guidebook/routes/records.py
@@ -142,6 +142,10 @@ class AttachmentDeleteSync(BaseModel):
     filename: str
 
 
+class RecordDeleteSync(BaseModel):
+    record_uuid: str
+
+
 class RecordResponse(BaseModel):
     id: int
     uuid: str | None
@@ -308,6 +312,30 @@ async def sync_delete_attachment(
         filepath.unlink()
 
     await session.delete(att)
+    await session.commit()
+    _broadcast_records_changed()
+    return {"action": "deleted"}
+
+
+@router.post("/sync-delete-record")
+async def sync_delete_record(
+    data: RecordDeleteSync, session: AsyncSession = Depends(get_session)
+):
+    from guidebook.routes.attachments import (
+        cleanup_record_attachments,
+        delete_attachments_for_record,
+    )
+
+    result = await session.execute(
+        select(Record).where(Record.uuid == data.record_uuid)
+    )
+    record = result.scalar_one_or_none()
+    if not record:
+        return {"action": "skipped", "reason": "not found"}
+
+    cleanup_record_attachments(record)
+    await delete_attachments_for_record(record.id, session)
+    await session.delete(record)
     await session.commit()
     _broadcast_records_changed()
     return {"action": "deleted"}

--- a/src/guidebook/routes/records.py
+++ b/src/guidebook/routes/records.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import json
 import logging
 from datetime import datetime, timezone
@@ -9,7 +10,7 @@ from pydantic import BaseModel, field_serializer, field_validator
 from sqlalchemy import delete, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from guidebook.db import Attachment, Record, get_session
+from guidebook.db import Attachment, Record, get_session, _ensure_data_dir
 from guidebook.sse import _get_shutdown_event
 
 logger = logging.getLogger("guidebook")
@@ -119,6 +120,7 @@ class RecordSync(BaseModel):
     recipients: list[str] | None = None
     timestamp: datetime
     updated_at: datetime
+    attachments: list[dict] | None = None
 
     @field_validator("timestamp", "updated_at")
     @classmethod
@@ -126,6 +128,13 @@ class RecordSync(BaseModel):
         if v.tzinfo is not None:
             v = v.astimezone(timezone.utc).replace(tzinfo=None)
         return v
+
+
+class AttachmentSync(BaseModel):
+    record_uuid: str
+    filename: str
+    content_type: str = "application/octet-stream"
+    data: str  # base64-encoded file content
 
 
 class RecordResponse(BaseModel):
@@ -221,6 +230,48 @@ async def sync_record(data: RecordSync, session: AsyncSession = Depends(get_sess
         return {"action": "updated", "uuid": data.uuid}
 
     return {"action": "skipped", "uuid": data.uuid}
+
+
+@router.post("/sync-attachment")
+async def sync_attachment(
+    data: AttachmentSync, session: AsyncSession = Depends(get_session)
+):
+    from guidebook.routes.attachments import _attachments_dir
+
+    result = await session.execute(
+        select(Record).where(Record.uuid == data.record_uuid)
+    )
+    record = result.scalar_one_or_none()
+    if not record:
+        return {"action": "skipped", "reason": "record not found"}
+
+    existing_att = (
+        await session.execute(
+            select(Attachment).where(
+                Attachment.record_id == record.id,
+                Attachment.filename == data.filename,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing_att:
+        return {"action": "skipped", "reason": "already exists"}
+
+    file_data = base64.b64decode(data.data)
+    att_dir = _attachments_dir(record.uuid)
+    _ensure_data_dir(att_dir)
+    filepath = att_dir / data.filename
+    filepath.write_bytes(file_data)
+
+    att = Attachment(
+        record_id=record.id,
+        filename=data.filename,
+        content_type=data.content_type,
+        size=len(file_data),
+    )
+    session.add(att)
+    await session.commit()
+    _broadcast_records_changed()
+    return {"action": "created"}
 
 
 @router.post("/", response_model=RecordResponse, status_code=201)

--- a/src/guidebook/routes/records.py
+++ b/src/guidebook/routes/records.py
@@ -137,6 +137,11 @@ class AttachmentSync(BaseModel):
     data: str  # base64-encoded file content
 
 
+class AttachmentDeleteSync(BaseModel):
+    record_uuid: str
+    filename: str
+
+
 class RecordResponse(BaseModel):
     id: int
     uuid: str | None
@@ -272,6 +277,40 @@ async def sync_attachment(
     await session.commit()
     _broadcast_records_changed()
     return {"action": "created"}
+
+
+@router.post("/sync-delete-attachment")
+async def sync_delete_attachment(
+    data: AttachmentDeleteSync, session: AsyncSession = Depends(get_session)
+):
+    from guidebook.routes.attachments import _attachments_dir
+
+    result = await session.execute(
+        select(Record).where(Record.uuid == data.record_uuid)
+    )
+    record = result.scalar_one_or_none()
+    if not record:
+        return {"action": "skipped", "reason": "record not found"}
+
+    att = (
+        await session.execute(
+            select(Attachment).where(
+                Attachment.record_id == record.id,
+                Attachment.filename == data.filename,
+            )
+        )
+    ).scalar_one_or_none()
+    if not att:
+        return {"action": "skipped", "reason": "not found"}
+
+    filepath = _attachments_dir(record.uuid) / att.filename
+    if filepath.is_file():
+        filepath.unlink()
+
+    await session.delete(att)
+    await session.commit()
+    _broadcast_records_changed()
+    return {"action": "deleted"}
 
 
 @router.post("/", response_model=RecordResponse, status_code=201)


### PR DESCRIPTION
## Summary
- P2P record sync over WebRTC: recipients selector, record/attachment push, deletion sync, auto-connect on save
- Configurable ICE servers: STUN/TURN settings UI, ephemeral TURN credentials, connectivity test
- Drag-and-drop file transfer in chat via WebRTC with chunked binary transfer for large files
- File transfer UX: offer/accept flow, progress bars, inline media previews, delete sync to both peers
- Connection quality indicators: color-coded P2P route type (direct/relay/NATS), tooltips
- UI fixes: redundant NATS reconnect button removed, online friends count in header

## Commits
- Record recipients selector and P2P record sync (#33)
- Sync attachments, attachment deletions, and record deletions over P2P (#33)
- Auto-connect P2P and push records immediately on save (#33)
- Configurable ICE servers, remove Google STUN dependency (#33)
- TURN server config with connectivity test and ephemeral credentials (#33)
- STUN entry with TURN, detect host/srflx/relay route types (#33)
- Color-coded P2P route indicator and connection type tooltips (#33)
- Drag-and-drop file transfer via WebRTC in private chat
- Image/video/audio preview for chat file transfers
- Auto-connect P2P when dropping files on chat
- Delete button for chat files synced to both peers
- Chunked binary file transfer for large files with offer/accept and progress bars