### PR TITLE
Add Docker Compose support and just targets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,18 @@ COPY src/ src/
 RUN uv sync --no-dev --frozen
 
 FROM python:3.12-slim
+ARG UID=1000
+ARG GID=1000
+RUN if [ "$UID" != "0" ]; then \
+      groupadd --gid "$GID" guidebook && \
+      useradd --uid "$UID" --gid "$GID" --create-home guidebook; \
+    fi
 WORKDIR /app
 COPY --from=backend /app /app
 COPY --from=frontend /app/src/guidebook/static src/guidebook/static
+RUN if [ "$UID" != "0" ]; then \
+      chown -R guidebook:guidebook /app; \
+    fi
+USER $UID:$GID
 EXPOSE 4280
 CMD [".venv/bin/guidebook"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,9 @@ WORKDIR /app
 COPY --from=backend /app /app
 COPY --from=frontend /app/src/guidebook/static src/guidebook/static
 RUN if [ "$UID" != "0" ]; then \
-      chown -R guidebook:guidebook /app; \
+      chown -R guidebook:guidebook /app && \
+      mkdir -p /home/guidebook/.local/share && \
+      chown -R guidebook:guidebook /home/guidebook/.local/share; \
     fi
 USER $UID:$GID
 EXPOSE 4280

--- a/Justfile
+++ b/Justfile
@@ -96,6 +96,10 @@ docker-build: _check-docker
 docker-install: docker-build
     docker compose up -d
 
+# Follow container logs
+docker-logs: _check-docker
+    docker compose logs -f
+
 # Remove containers (preserves volumes)
 docker-uninstall: _check-docker
     docker compose down

--- a/Justfile
+++ b/Justfile
@@ -94,7 +94,18 @@ docker-build: _check-docker
 
 # Build and install on the current Docker context
 docker-install: docker-build
+    #!/usr/bin/env bash
+    set -euo pipefail
     docker compose up -d
+    endpoint=$(docker context inspect --format '{{`{{.Endpoints.docker.Host}}`}}')
+    case "$endpoint" in
+        unix://*) host=localhost ;;
+        ssh://*)  host=$(echo "$endpoint" | sed 's|ssh://\([^@]*@\)\?\([^:/]*\).*|\2|') ;;
+        tcp://*)  host=$(echo "$endpoint" | sed 's|tcp://\([^:/]*\).*|\1|') ;;
+        *)        host=localhost ;;
+    esac
+    port=${GUIDEBOOK_PORT:-4280}
+    echo "Open https://${host}:${port}"
 
 # Follow container logs
 docker-logs: _check-docker

--- a/Justfile
+++ b/Justfile
@@ -85,6 +85,33 @@ next-dev-version:
     done
     echo "${BASE}.dev$(( MAX + 1 ))"
 
+_check-docker:
+    @command -v docker >/dev/null 2>&1 || { echo "Error: docker is not installed."; exit 1; }
+
+# Build the Docker image from local source
+docker-build: _check-docker
+    docker compose build
+
+# Build and install on the current Docker context
+docker-install: docker-build
+    docker compose up -d
+
+# Remove containers (preserves volumes)
+docker-uninstall: _check-docker
+    docker compose down
+
+# Destroy containers and volumes (with confirmation)
+docker-destroy: _check-docker
+    #!/usr/bin/env bash
+    set -euo pipefail
+    read -rp "This will destroy all guidebook containers AND volumes. Are you sure? [y/N] " ans
+    if [[ "$ans" =~ ^[Yy]$ ]]; then
+        docker compose down -v
+        echo "Destroyed."
+    else
+        echo "Cancelled."
+    fi
+
 # Remove build artifacts and stamp files
 clean:
     rm -rf dist/ build/

--- a/Justfile
+++ b/Justfile
@@ -109,7 +109,7 @@ docker-install: docker-build
 
 # Reset authentication (interactive)
 docker-reset-auth: _check-docker
-    docker compose run --rm -it guidebook .venv/bin/guidebook --reset-auth
+    docker compose run --rm -it --init guidebook .venv/bin/guidebook --reset-auth
 
 # Follow container logs
 docker-logs: _check-docker

--- a/Justfile
+++ b/Justfile
@@ -107,6 +107,10 @@ docker-install: docker-build
     port=${GUIDEBOOK_PORT:-4280}
     echo "Open https://${host}:${port}"
 
+# Reset authentication (interactive)
+docker-reset-auth: _check-docker
+    docker compose run --rm -it guidebook .venv/bin/guidebook --reset-auth
+
 # Follow container logs
 docker-logs: _check-docker
     docker compose logs -f

--- a/Justfile
+++ b/Justfile
@@ -107,10 +107,10 @@ docker-install: docker-build
     port=${GUIDEBOOK_PORT:-4280}
     echo "Open https://${host}:${port}"
 
-# Reset authentication (interactive, stops service first)
+# Reset authentication (interactive, restarts service after)
 docker-reset-auth: _check-docker
     docker compose stop guidebook
-    docker compose run --rm -it guidebook .venv/bin/guidebook --reset-auth
+    docker compose run --rm -it -e GUIDEBOOK_RESET_AUTH_ONLY=true guidebook .venv/bin/guidebook --reset-auth
     docker compose start guidebook
 
 # Follow container logs

--- a/Justfile
+++ b/Justfile
@@ -97,7 +97,7 @@ docker-install: docker-build
     #!/usr/bin/env bash
     set -euo pipefail
     docker compose up -d
-    endpoint=$(docker context inspect --format '{{`{{.Endpoints.docker.Host}}`}}')
+    endpoint=$(docker context inspect --format '{{"{{.Endpoints.docker.Host}}"}}')
     case "$endpoint" in
         unix://*) host=localhost ;;
         ssh://*)  host=$(echo "$endpoint" | sed 's|ssh://\([^@]*@\)\?\([^:/]*\).*|\2|') ;;

--- a/Justfile
+++ b/Justfile
@@ -107,9 +107,11 @@ docker-install: docker-build
     port=${GUIDEBOOK_PORT:-4280}
     echo "Open https://${host}:${port}"
 
-# Reset authentication (interactive)
+# Reset authentication (interactive, stops service first)
 docker-reset-auth: _check-docker
+    docker compose stop guidebook
     docker compose run --rm -it guidebook .venv/bin/guidebook --reset-auth
+    docker compose start guidebook
 
 # Follow container logs
 docker-logs: _check-docker

--- a/Justfile
+++ b/Justfile
@@ -109,7 +109,7 @@ docker-install: docker-build
 
 # Reset authentication (interactive)
 docker-reset-auth: _check-docker
-    docker compose run --rm -it --init guidebook .venv/bin/guidebook --reset-auth
+    docker compose run --rm -it guidebook .venv/bin/guidebook --reset-auth
 
 # Follow container logs
 docker-logs: _check-docker

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,31 @@
+services:
+  guidebook:
+    build:
+      context: .
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
+    ports:
+      - "${GUIDEBOOK_PORT:-4280}:4280"
+    volumes:
+      - data:/home/guidebook/.local/share
+    environment:
+      GUIDEBOOK_INSTANCE: ${GUIDEBOOK_INSTANCE:-default}
+      GUIDEBOOK_DB: ${GUIDEBOOK_DB:-guidebook}
+      GUIDEBOOK_PICKER: ${GUIDEBOOK_PICKER:-false}
+      GUIDEBOOK_NO_BROWSER: "true"
+      GUIDEBOOK_NO_SHUTDOWN: ${GUIDEBOOK_NO_SHUTDOWN:-true}
+      GUIDEBOOK_HOST: "0.0.0.0"
+      GUIDEBOOK_PORT: "4280"
+      GUIDEBOOK_DISABLE_AUTH: ${GUIDEBOOK_DISABLE_AUTH:-false}
+      GUIDEBOOK_AUTH_SLOTS: ${GUIDEBOOK_AUTH_SLOTS:-1}
+      GUIDEBOOK_AUTH_TTL: ${GUIDEBOOK_AUTH_TTL:-30d}
+      GUIDEBOOK_AUTH_RENEW_COOLDOWN: ${GUIDEBOOK_AUTH_RENEW_COOLDOWN:-24h}
+      GUIDEBOOK_ALLOW_TRANSFER: ${GUIDEBOOK_ALLOW_TRANSFER:-false}
+      GUIDEBOOK_NO_TLS: ${GUIDEBOOK_NO_TLS:-false}
+      GUIDEBOOK_PROXY: ${GUIDEBOOK_PROXY:-}
+      GUIDEBOOK_BROWSER_URL: ${GUIDEBOOK_BROWSER_URL:-}
+    restart: unless-stopped
+
+volumes:
+  data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,6 +25,7 @@ services:
       GUIDEBOOK_NO_TLS: ${GUIDEBOOK_NO_TLS:-false}
       GUIDEBOOK_PROXY: ${GUIDEBOOK_PROXY:-}
       GUIDEBOOK_BROWSER_URL: ${GUIDEBOOK_BROWSER_URL:-}
+    init: true
     restart: unless-stopped
 
 volumes:

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -1059,6 +1059,15 @@ environment variables (overridden by command line options):
                 "\nAuth reset complete: all sessions, CA, certificates, and mTLS state cleared."
             )
 
+            if os.environ.get("GUIDEBOOK_RESET_AUTH_ONLY", "").lower() in ("1", "true", "yes"):
+                host = os.environ.get("GUIDEBOOK_HOST", "127.0.0.1") or "127.0.0.1"
+                port = int(os.environ.get("GUIDEBOOK_PORT", "4280"))
+                scheme = "http" if no_tls else "https"
+                browser_url = os.environ.get("GUIDEBOOK_BROWSER_URL", "").strip()
+                base = browser_url or f"{scheme}://{host}:{port}"
+                print(f"Login URL: {base}/?auth_token={token_str}")
+                sys.exit(0)
+
         # If mTLS is enforced, cookie sessions are useless — clear them
         _mtls_row = conn.execute(
             "SELECT value FROM settings WHERE key = 'mtls_mode'"


### PR DESCRIPTION
## Summary
- Add Docker Compose configuration with configurable UID/GID
- Add Dockerfile with proper data directory ownership
- Add just targets: docker-build, docker-install, docker-uninstall, docker-destroy, docker-logs, docker-reset-auth
- Print server URL after docker-install using docker context inspection
- Use init in compose service for proper signal handling
- Exit after reset-auth in Docker, print login link without starting server