### PR TITLE
Electron SSB: transparent window, devtools, and scale fixes

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -159,8 +159,8 @@ _instance-host instance:
         echo "127.$(( (dec >> 16) & 255 )).$(( (dec >> 8) & 255 )).$(( dec & 255 ))"
     fi
 
-# Install local dev SSB launcher (e.g. just ssb-install, just ssb-install foo)
-ssb-install instance="default": ssb-deps build-frontend
+# Install local dev SSB launcher (e.g. just ssb-install, just ssb-install foo 1.5)
+ssb-install instance="default" scale="1.5": ssb-deps build-frontend
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p ~/.local/bin ~/.local/share/applications
@@ -180,12 +180,14 @@ ssb-install instance="default": ssb-deps build-frontend
     fi
     launcher=~/.local/bin/guidebook-ssb${suffix}
     desktop=~/.local/share/applications/guidebook-ssb${suffix}.desktop
+    scale="{{ scale }}"
     # Generate launcher with paths baked in
     sed -e "s|__SSB_DIR__|${ssb_dir}|g" \
         -e "s|__PROJECT_DIR__|${project_dir}|g" \
         -e "s|__INSTANCE__|${instance}|g" \
         -e "s|__HOST__|${host}|g" \
         -e "s|__PORT__|${port}|g" \
+        -e "s|__SCALE__|${scale}|g" \
         ssb/guidebook-ssb > "$launcher"
     chmod +x "$launcher"
     # Install desktop entry

--- a/Justfile
+++ b/Justfile
@@ -165,6 +165,10 @@ ssb-install instance="default" scale="1.5": ssb-deps build-frontend
     set -euo pipefail
     mkdir -p ~/.local/bin ~/.local/share/applications
     instance="{{ instance }}"
+    if [[ ! "$instance" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+        echo "Error: instance name must contain only letters, digits, hyphens, and underscores" >&2
+        exit 1
+    fi
     host=$(just _instance-host "$instance")
     port=4280
     project_dir="$(pwd)"

--- a/Justfile
+++ b/Justfile
@@ -159,8 +159,8 @@ _instance-host instance:
         echo "127.$(( (dec >> 16) & 255 )).$(( (dec >> 8) & 255 )).$(( dec & 255 ))"
     fi
 
-# Install local dev SSB launcher (e.g. just ssb-install, just ssb-install foo 1.5)
-ssb-install instance="default" scale="1.5": ssb-deps build-frontend
+# Install local dev SSB launcher (e.g. just ssb-install, just ssb-install foo)
+ssb-install instance="default": ssb-deps build-frontend
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p ~/.local/bin ~/.local/share/applications
@@ -184,14 +184,12 @@ ssb-install instance="default" scale="1.5": ssb-deps build-frontend
     fi
     launcher=~/.local/bin/guidebook-ssb${suffix}
     desktop=~/.local/share/applications/guidebook-ssb${suffix}.desktop
-    scale="{{ scale }}"
     # Generate launcher with paths baked in
     sed -e "s|__SSB_DIR__|${ssb_dir}|g" \
         -e "s|__PROJECT_DIR__|${project_dir}|g" \
         -e "s|__INSTANCE__|${instance}|g" \
         -e "s|__HOST__|${host}|g" \
         -e "s|__PORT__|${port}|g" \
-        -e "s|__SCALE__|${scale}|g" \
         ssb/guidebook-ssb > "$launcher"
     chmod +x "$launcher"
     # Install desktop entry

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1378,9 +1378,18 @@
     box-sizing: border-box;
   }
 
+  :global(html) {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    background: var(--bg-gradient, var(--bg));
+    background-attachment: fixed;
+  }
+
   :global(body) {
     margin: 0;
     padding: 0;
+    min-height: 100%;
     background: var(--bg-gradient, var(--bg));
     background-attachment: fixed;
     color: var(--text);

--- a/src/guidebook/routes/auth.py
+++ b/src/guidebook/routes/auth.py
@@ -18,11 +18,13 @@ logger = logging.getLogger("guidebook")
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
 def _cookie_name() -> str:
+    import re
     from guidebook.db import get_instance_name
     instance = get_instance_name()
     if instance == "default":
         return "guidebook_token"
-    return f"guidebook_token_{instance}"
+    sanitized = re.sub(r"[^a-zA-Z0-9_]", "_", instance)
+    return f"guidebook_token_{sanitized}"
 AUTH_TTL_DEFAULT = 30 * 24 * 3600  # 30 days
 AUTH_RENEW_COOLDOWN_DEFAULT = 24 * 3600  # 24 hours
 LOGIN_LINK_TTL = 300  # 5 minutes (hardcoded)

--- a/ssb/guidebook-ssb
+++ b/ssb/guidebook-ssb
@@ -10,7 +10,7 @@ set -euo pipefail
 # Defaults (overridden by args or env)
 HOST="${GUIDEBOOK_SSB_HOST:-__HOST__}"
 PORT="${GUIDEBOOK_SSB_PORT:-__PORT__}"
-SCALE="${GUIDEBOOK_SSB_SCALE:-__SCALE__}"
+SCALE="${GUIDEBOOK_SSB_SCALE:-1.5}"
 INSTANCE="__INSTANCE__"
 AUTH_TOKEN=""
 SSB_DIR="__SSB_DIR__"

--- a/ssb/guidebook-ssb
+++ b/ssb/guidebook-ssb
@@ -10,7 +10,7 @@ set -euo pipefail
 # Defaults (overridden by args or env)
 HOST="${GUIDEBOOK_SSB_HOST:-__HOST__}"
 PORT="${GUIDEBOOK_SSB_PORT:-__PORT__}"
-SCALE="${GUIDEBOOK_SSB_SCALE:-2}"
+SCALE="${GUIDEBOOK_SSB_SCALE:-__SCALE__}"
 INSTANCE="__INSTANCE__"
 AUTH_TOKEN=""
 SSB_DIR="__SSB_DIR__"

--- a/ssb/main.js
+++ b/ssb/main.js
@@ -78,7 +78,7 @@ function createWindow() {
   win.webContents.on("before-input-event", (event, input) => {
     if (DEV && input.key === "F12" && input.type === "keyDown") {
       event.preventDefault();
-      win.webContents.toggleDevTools();
+      win.webContents.toggleDevTools({ mode: "detach" });
     } else if (input.alt && !input.control && !input.meta && input.key === "w" && input.type === "keyDown") {
       event.preventDefault();
       const now = Date.now();

--- a/ssb/main.js
+++ b/ssb/main.js
@@ -78,7 +78,7 @@ function createWindow() {
   win.webContents.on("before-input-event", (event, input) => {
     if (DEV && input.key === "F12" && input.type === "keyDown") {
       event.preventDefault();
-      win.webContents.toggleDevTools({ mode: "detach" });
+      win.webContents.toggleDevTools();
     } else if (input.alt && !input.control && !input.meta && input.key === "w" && input.type === "keyDown") {
       event.preventDefault();
       const now = Date.now();

--- a/ssb/main.js
+++ b/ssb/main.js
@@ -8,7 +8,7 @@ const HOST = args.host || process.env.GUIDEBOOK_SSB_HOST || "127.0.0.1";
 const PORT = parseInt(args.port || process.env.GUIDEBOOK_SSB_PORT || "4280", 10);
 const AUTH_TOKEN = args.authToken || null;
 const DEV = args.dev || false;
-const SCALE = parseFloat(args.scale || process.env.GUIDEBOOK_SSB_SCALE || "2");
+const SCALE = parseFloat(args.scale || process.env.GUIDEBOOK_SSB_SCALE || "1.5");
 app.commandLine.appendSwitch("force-device-scale-factor", String(SCALE));
 
 // Isolate session data (cookies, localStorage) per host:port

--- a/ssb/main.js
+++ b/ssb/main.js
@@ -75,7 +75,10 @@ function createWindow() {
 
   // App-local keyboard shortcuts
   win.webContents.on("before-input-event", (event, input) => {
-    if (input.alt && !input.control && !input.meta && input.key === "w" && input.type === "keyDown") {
+    if (input.key === "F12" && input.type === "keyDown") {
+      event.preventDefault();
+      win.webContents.toggleDevTools();
+    } else if (input.alt && !input.control && !input.meta && input.key === "w" && input.type === "keyDown") {
       event.preventDefault();
       const now = Date.now();
       if (now - lastWindowCreate > 500) {

--- a/ssb/main.js
+++ b/ssb/main.js
@@ -41,7 +41,7 @@ function createWindow() {
     height: 900,
     frame: false,
     show: false,
-    backgroundColor: "#000000",
+    backgroundColor: "#24252b",
     autoHideMenuBar: true,
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),

--- a/ssb/main.js
+++ b/ssb/main.js
@@ -7,7 +7,6 @@ const args = parseArgs(process.argv.slice(2));
 const HOST = args.host || process.env.GUIDEBOOK_SSB_HOST || "127.0.0.1";
 const PORT = parseInt(args.port || process.env.GUIDEBOOK_SSB_PORT || "4280", 10);
 const AUTH_TOKEN = args.authToken || null;
-const DEV = args.dev || false;
 const SCALE = parseFloat(args.scale || process.env.GUIDEBOOK_SSB_SCALE || "2");
 app.commandLine.appendSwitch("force-device-scale-factor", String(SCALE));
 
@@ -26,7 +25,7 @@ function parseArgs(argv) {
     else if (argv[i] === "--port" && argv[i + 1]) result.port = argv[++i];
     else if (argv[i] === "--auth-token" && argv[i + 1]) result.authToken = argv[++i];
     else if (argv[i] === "--scale" && argv[i + 1]) result.scale = argv[++i];
-    else if (argv[i] === "--dev") result.dev = true;
+
   }
   return result;
 }
@@ -86,20 +85,12 @@ function createWindow() {
     }
   });
 
-  win.once("ready-to-show", () => {
-    win.show();
-    if (DEV) win.webContents.openDevTools();
-  });
+  win.once("ready-to-show", () => win.show());
   win.loadURL(START_URL);
 }
 
 // Disable default keyboard shortcuts
 function blockShortcuts() {
-  const devShortcuts = [
-    "CommandOrControl+Shift+I",
-    "CommandOrControl+Shift+J",
-    "F12",
-  ];
   const blocked = [
     "CommandOrControl+R",
     "CommandOrControl+Shift+R",
@@ -107,7 +98,8 @@ function blockShortcuts() {
     "CommandOrControl+T",
     "CommandOrControl+N",
     "CommandOrControl+W",
-    ...(DEV ? [] : devShortcuts),
+    "CommandOrControl+Shift+I",
+    "CommandOrControl+Shift+J",
     "F5",
     "F11",
     "Alt+Left",

--- a/ssb/main.js
+++ b/ssb/main.js
@@ -7,6 +7,7 @@ const args = parseArgs(process.argv.slice(2));
 const HOST = args.host || process.env.GUIDEBOOK_SSB_HOST || "127.0.0.1";
 const PORT = parseInt(args.port || process.env.GUIDEBOOK_SSB_PORT || "4280", 10);
 const AUTH_TOKEN = args.authToken || null;
+const DEV = args.dev || false;
 const SCALE = parseFloat(args.scale || process.env.GUIDEBOOK_SSB_SCALE || "2");
 app.commandLine.appendSwitch("force-device-scale-factor", String(SCALE));
 
@@ -25,6 +26,7 @@ function parseArgs(argv) {
     else if (argv[i] === "--port" && argv[i + 1]) result.port = argv[++i];
     else if (argv[i] === "--auth-token" && argv[i + 1]) result.authToken = argv[++i];
     else if (argv[i] === "--scale" && argv[i + 1]) result.scale = argv[++i];
+    else if (argv[i] === "--dev") result.dev = true;
   }
   return result;
 }
@@ -84,12 +86,20 @@ function createWindow() {
     }
   });
 
-  win.once("ready-to-show", () => win.show());
+  win.once("ready-to-show", () => {
+    win.show();
+    if (DEV) win.webContents.openDevTools();
+  });
   win.loadURL(START_URL);
 }
 
 // Disable default keyboard shortcuts
 function blockShortcuts() {
+  const devShortcuts = [
+    "CommandOrControl+Shift+I",
+    "CommandOrControl+Shift+J",
+    "F12",
+  ];
   const blocked = [
     "CommandOrControl+R",
     "CommandOrControl+Shift+R",
@@ -97,11 +107,9 @@ function blockShortcuts() {
     "CommandOrControl+T",
     "CommandOrControl+N",
     "CommandOrControl+W",
-    "CommandOrControl+Shift+I",
-    "CommandOrControl+Shift+J",
+    ...(DEV ? [] : devShortcuts),
     "F5",
     "F11",
-    "F12",
     "Alt+Left",
     "Alt+Right",
     "Alt+Home",

--- a/ssb/main.js
+++ b/ssb/main.js
@@ -7,6 +7,7 @@ const args = parseArgs(process.argv.slice(2));
 const HOST = args.host || process.env.GUIDEBOOK_SSB_HOST || "127.0.0.1";
 const PORT = parseInt(args.port || process.env.GUIDEBOOK_SSB_PORT || "4280", 10);
 const AUTH_TOKEN = args.authToken || null;
+const DEV = args.dev || false;
 const SCALE = parseFloat(args.scale || process.env.GUIDEBOOK_SSB_SCALE || "2");
 app.commandLine.appendSwitch("force-device-scale-factor", String(SCALE));
 
@@ -25,7 +26,7 @@ function parseArgs(argv) {
     else if (argv[i] === "--port" && argv[i + 1]) result.port = argv[++i];
     else if (argv[i] === "--auth-token" && argv[i + 1]) result.authToken = argv[++i];
     else if (argv[i] === "--scale" && argv[i + 1]) result.scale = argv[++i];
-
+    else if (argv[i] === "--dev") result.dev = true;
   }
   return result;
 }
@@ -75,7 +76,7 @@ function createWindow() {
 
   // App-local keyboard shortcuts
   win.webContents.on("before-input-event", (event, input) => {
-    if (input.key === "F12" && input.type === "keyDown") {
+    if (DEV && input.key === "F12" && input.type === "keyDown") {
       event.preventDefault();
       win.webContents.toggleDevTools();
     } else if (input.alt && !input.control && !input.meta && input.key === "w" && input.type === "keyDown") {
@@ -103,6 +104,7 @@ function blockShortcuts() {
     "CommandOrControl+W",
     "CommandOrControl+Shift+I",
     "CommandOrControl+Shift+J",
+    ...(DEV ? [] : ["F12"]),
     "F5",
     "F11",
     "Alt+Left",

--- a/ssb/main.js
+++ b/ssb/main.js
@@ -42,8 +42,8 @@ function createWindow() {
     width: 1280,
     height: 900,
     frame: false,
+    transparent: true,
     show: false,
-    backgroundColor: "#24252b",
     autoHideMenuBar: true,
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),


### PR DESCRIPTION
- Use transparent frameless window to eliminate native black border
- Add --dev flag to gate F12 devtools toggle
- Change default Electron scale to 1.5 (overridable at runtime)
- Remove scale arg from ssb-install to avoid positional confusion
- Sanitize instance name in cookie to prevent illegal characters
- Validate instance names in ssb-install (alphanumeric, hyphens, underscores)
- Add :global(html) CSS to fill full window background