### PR TITLE
Dev mode improvements and UI layout fixes

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["-y", "chrome-devtools-mcp@latest", "--browserUrl", "http://127.0.0.1:9222"]
+    }
+  }
+}

--- a/Justfile
+++ b/Justfile
@@ -159,11 +159,19 @@ _instance-host instance:
         echo "127.$(( (dec >> 16) & 255 )).$(( (dec >> 8) & 255 )).$(( dec & 255 ))"
     fi
 
-# Install local dev SSB launcher (e.g. just ssb-install, just ssb-install foo)
-ssb-install instance="default": ssb-deps build-frontend
+# Install local dev SSB launcher (e.g. just ssb-install, just ssb-install foo, just ssb-install foo --dev)
+ssb-install instance="default" *FLAGS="": ssb-deps build-frontend
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p ~/.local/bin ~/.local/share/applications
+    flags="{{ FLAGS }}"
+    dev=false
+    for flag in $flags; do
+        case "$flag" in
+            --dev) dev=true ;;
+            *) echo "Unknown flag: $flag" >&2; exit 1 ;;
+        esac
+    done
     instance="{{ instance }}"
     if [[ ! "$instance" =~ ^[a-zA-Z0-9_-]+$ ]]; then
         echo "Error: instance name must contain only letters, digits, hyphens, and underscores" >&2
@@ -190,6 +198,7 @@ ssb-install instance="default": ssb-deps build-frontend
         -e "s|__INSTANCE__|${instance}|g" \
         -e "s|__HOST__|${host}|g" \
         -e "s|__PORT__|${port}|g" \
+        -e "s|__DEV__|${dev}|g" \
         ssb/guidebook-ssb > "$launcher"
     chmod +x "$launcher"
     # Install desktop entry

--- a/Justfile
+++ b/Justfile
@@ -159,20 +159,20 @@ _instance-host instance:
         echo "127.$(( (dec >> 16) & 255 )).$(( (dec >> 8) & 255 )).$(( dec & 255 ))"
     fi
 
-# Install local dev SSB launcher (e.g. just ssb-install, just ssb-install foo, just ssb-install foo --dev)
-ssb-install instance="default" *FLAGS="": ssb-deps build-frontend
+# Install local dev SSB launcher (e.g. just ssb-install, just ssb-install foo, just ssb-install --dev foo)
+ssb-install *ARGS="": ssb-deps build-frontend
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p ~/.local/bin ~/.local/share/applications
-    flags="{{ FLAGS }}"
+    instance="default"
     dev=false
-    for flag in $flags; do
-        case "$flag" in
+    for arg in {{ ARGS }}; do
+        case "$arg" in
             --dev) dev=true ;;
-            *) echo "Unknown flag: $flag" >&2; exit 1 ;;
+            --*) echo "Unknown flag: $arg" >&2; exit 1 ;;
+            *) instance="$arg" ;;
         esac
     done
-    instance="{{ instance }}"
     if [[ ! "$instance" =~ ^[a-zA-Z0-9_-]+$ ]]; then
         echo "Error: instance name must contain only letters, digits, hyphens, and underscores" >&2
         exit 1

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -67,7 +67,7 @@
   let recordsRef = null;
   let chatRef = null;
   let recordAutoCreated = false;
-  let databaseRight = false;
+  let databaseRight = true;
   let mediaSearchQuery = "";
   let mediaSelectedTags = [];
   let mediaSelectedRecordId = null;
@@ -796,7 +796,7 @@
       const res = await fetch("/api/settings/database_right");
       if (res.ok) {
         const data = await res.json();
-        databaseRight = data.value === "true";
+        databaseRight = data.value !== "false";
       }
     } catch {}
   }

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -28,7 +28,7 @@
   let updateBuildRepo = "";
   let updateBuildSha = "";
   let updateOfficialBuild = false;
-  let database_right = false;
+  let database_right = true;
   let wide_breakpoint = "1200";
   let wide_mode_enabled = true;
   let theme = "dark";
@@ -1338,7 +1338,7 @@
               wide_breakpoint = s.value || "1500";
             }
           }
-          if (s.key === "database_right") database_right = s.value === "true";
+          if (s.key === "database_right") database_right = s.value !== "false";
           if (s.key === "custom_header") custom_header = s.value || "";
           if (s.key === "default_page") default_page = s.value || "log";
           if (s.key === "theme") theme = s.value || (window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark");
@@ -1844,8 +1844,8 @@
     </div>
     <div class="setting-row toggle-row">
       <label>
-        <input type="checkbox" bind:checked={database_right} on:change={onDatabaseRightChange} disabled={!wide_mode_enabled} />
-        Database on right side
+        <input type="checkbox" checked={!database_right} on:change={(e) => { database_right = !e.target.checked; onDatabaseRightChange(); }} disabled={!wide_mode_enabled} />
+        Database on left side
       </label>
     </div>
   </section>

--- a/ssb/guidebook-ssb
+++ b/ssb/guidebook-ssb
@@ -14,6 +14,7 @@ SCALE="${GUIDEBOOK_SSB_SCALE:-1.5}"
 INSTANCE="__INSTANCE__"
 AUTH_TOKEN=""
 DEV=__DEV__
+REMOTE_DEBUGGING_PORT="${GUIDEBOOK_SSB_REMOTE_DEBUGGING_PORT:-9222}"
 SSB_DIR="__SSB_DIR__"
 PROJECT_DIR="__PROJECT_DIR__"
 LOCAL_MODE=true
@@ -27,6 +28,7 @@ while [[ $# -gt 0 ]]; do
         --instance) INSTANCE="$2"; shift 2 ;;
         --auth-token) AUTH_TOKEN="$2"; shift 2 ;;
         --dev) DEV=true; shift ;;
+        --remote-debugging-port) REMOTE_DEBUGGING_PORT="$2"; shift 2 ;;
         *) echo "Unknown option: $1" >&2; exit 1 ;;
     esac
 done
@@ -66,6 +68,7 @@ if [[ -n "$AUTH_TOKEN" ]]; then
 fi
 if [[ "$DEV" == true ]]; then
     ELECTRON_ARGS+=(--dev)
+    ELECTRON_ARGS+=(--remote-debugging-port "$REMOTE_DEBUGGING_PORT")
 fi
 
 cd "$SSB_DIR"

--- a/ssb/guidebook-ssb
+++ b/ssb/guidebook-ssb
@@ -13,6 +13,7 @@ PORT="${GUIDEBOOK_SSB_PORT:-__PORT__}"
 SCALE="${GUIDEBOOK_SSB_SCALE:-1.5}"
 INSTANCE="__INSTANCE__"
 AUTH_TOKEN=""
+DEV=__DEV__
 SSB_DIR="__SSB_DIR__"
 PROJECT_DIR="__PROJECT_DIR__"
 LOCAL_MODE=true
@@ -25,6 +26,7 @@ while [[ $# -gt 0 ]]; do
         --scale) SCALE="$2"; shift 2 ;;
         --instance) INSTANCE="$2"; shift 2 ;;
         --auth-token) AUTH_TOKEN="$2"; shift 2 ;;
+        --dev) DEV=true; shift ;;
         *) echo "Unknown option: $1" >&2; exit 1 ;;
     esac
 done
@@ -61,6 +63,9 @@ fi
 ELECTRON_ARGS=(. --host "$HOST" --port "$PORT" --scale "$SCALE")
 if [[ -n "$AUTH_TOKEN" ]]; then
     ELECTRON_ARGS+=(--auth-token "$AUTH_TOKEN")
+fi
+if [[ "$DEV" == true ]]; then
+    ELECTRON_ARGS+=(--dev)
 fi
 
 cd "$SSB_DIR"

--- a/ssb/main.js
+++ b/ssb/main.js
@@ -9,7 +9,11 @@ const PORT = parseInt(args.port || process.env.GUIDEBOOK_SSB_PORT || "4280", 10)
 const AUTH_TOKEN = args.authToken || null;
 const DEV = args.dev || false;
 const SCALE = parseFloat(args.scale || process.env.GUIDEBOOK_SSB_SCALE || "1.5");
+const REMOTE_DEBUGGING_PORT = parseInt(args.remoteDebuggingPort || process.env.GUIDEBOOK_SSB_REMOTE_DEBUGGING_PORT || "0", 10);
 app.commandLine.appendSwitch("force-device-scale-factor", String(SCALE));
+if (DEV && REMOTE_DEBUGGING_PORT > 0) {
+  app.commandLine.appendSwitch("remote-debugging-port", String(REMOTE_DEBUGGING_PORT));
+}
 
 // Isolate session data (cookies, localStorage) per host:port
 app.setPath("userData", path.join(app.getPath("appData"), `guidebook-ssb-${HOST}-${PORT}`));
@@ -26,6 +30,7 @@ function parseArgs(argv) {
     else if (argv[i] === "--port" && argv[i + 1]) result.port = argv[++i];
     else if (argv[i] === "--auth-token" && argv[i + 1]) result.authToken = argv[++i];
     else if (argv[i] === "--scale" && argv[i + 1]) result.scale = argv[++i];
+    else if (argv[i] === "--remote-debugging-port" && argv[i + 1]) result.remoteDebuggingPort = argv[++i];
     else if (argv[i] === "--dev") result.dev = true;
   }
   return result;


### PR DESCRIPTION
## Summary

- Add `--dev` flag support to `ssb-install` and fix flag position handling
- Default database panel to right side in wide mode, add left side option
- Enable Chrome remote debugging port in dev mode
- Add chrome-devtools MCP server config

## Commits

- `efc34cb` Add chrome-devtools MCP server config
- `bbe24a7` Enable Chrome remote debugging port in dev mode
- `f4a5e50` Default database to right side in wide mode, add left side option
- `3c05708` Fix ssb-install to accept --dev flag in any position
- `8a7067e` Add --dev flag support to ssb-install