### PR TITLE
Add Woodpecker CI with release and Docker workflows

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,3 +1,11 @@
+matrix:
+  platform:
+    - linux/amd64
+    - linux/arm64
+
+labels:
+  platform: ${platform}
+
 steps:
   - name: test
     image: python:3.12-bookworm

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -7,7 +7,7 @@ steps:
       - uv sync
       - uv run ruff check .
       - uv run ruff format --check .
-      - uv run pytest
+      - uv run pytest || [ $? -eq 5 ]
 
   - name: build
     image: python:3.12-bookworm

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,0 +1,20 @@
+steps:
+  - name: test
+    image: python:3.12-bookworm
+    commands:
+      - curl -LsSf https://astral.sh/uv/install.sh | sh
+      - export PATH="$HOME/.local/bin:$PATH"
+      - uv sync
+      - uv run ruff check .
+      - uv run ruff format --check .
+      - uv run pytest
+
+  - name: build
+    image: python:3.12-bookworm
+    commands:
+      - apt-get update && apt-get install -y nodejs npm
+      - curl -LsSf https://astral.sh/uv/install.sh | sh
+      - curl -LsSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+      - export PATH="$HOME/.local/bin:$PATH"
+      - just deps
+      - just build-binary

--- a/.woodpecker/docker.yml
+++ b/.woodpecker/docker.yml
@@ -14,8 +14,8 @@ steps:
     commands:
       - apk add --no-cache curl
       - mkdir -p dist
-      - 'curl -fSL -H "Authorization: token $FORGEJO_TOKEN" "${CI_FORGE_URL}/${CI_REPO}/releases/download/${CI_COMMIT_TAG}/guidebook-linux-amd64" -o dist/guidebook-linux-amd64'
-      - 'curl -fSL -H "Authorization: token $FORGEJO_TOKEN" "${CI_FORGE_URL}/${CI_REPO}/releases/download/${CI_COMMIT_TAG}/guidebook-linux-arm64" -o dist/guidebook-linux-arm64'
+      - curl -fSL -u "token:$FORGEJO_TOKEN" "${CI_FORGE_URL}/${CI_REPO}/releases/download/${CI_COMMIT_TAG}/guidebook-linux-amd64" -o dist/guidebook-linux-amd64
+      - curl -fSL -u "token:$FORGEJO_TOKEN" "${CI_FORGE_URL}/${CI_REPO}/releases/download/${CI_COMMIT_TAG}/guidebook-linux-arm64" -o dist/guidebook-linux-arm64
 
   - name: docker
     image: woodpeckerci/plugin-docker-buildx

--- a/.woodpecker/docker.yml
+++ b/.woodpecker/docker.yml
@@ -1,0 +1,23 @@
+depends_on:
+  - release
+
+when:
+  - event: tag
+    ref: refs/tags/v*
+
+steps:
+  - name: docker
+    image: woodpeckerci/plugin-docker-buildx
+    settings:
+      repo: ${CI_FORGE_URL##https://}/${CI_REPO}
+      registry: ${CI_FORGE_URL##https://}
+      username:
+        from_secret: forgejo_user
+      password:
+        from_secret: forgejo_token
+      platforms:
+        - linux/amd64
+        - linux/arm64
+      tag:
+        - ${CI_COMMIT_TAG##v}
+        - latest

--- a/.woodpecker/docker.yml
+++ b/.woodpecker/docker.yml
@@ -24,8 +24,4 @@ steps:
         - latest
       build_args:
         - VERSION=${CI_COMMIT_TAG##v}
-      build_args_from_env:
-        - FORGE_URL
-    environment:
-      FORGE_URL:
-        from_secret: forge_url
+        - FORGE_URL=${CI_FORGE_URL}/${CI_REPO}

--- a/.woodpecker/docker.yml
+++ b/.woodpecker/docker.yml
@@ -14,8 +14,8 @@ steps:
     commands:
       - apk add --no-cache curl
       - mkdir -p dist
-      - curl -fSL -H "Authorization: token $FORGEJO_TOKEN" "${CI_FORGE_URL}/${CI_REPO}/releases/download/${CI_COMMIT_TAG}/guidebook-linux-amd64" -o dist/guidebook-linux-amd64
-      - curl -fSL -H "Authorization: token $FORGEJO_TOKEN" "${CI_FORGE_URL}/${CI_REPO}/releases/download/${CI_COMMIT_TAG}/guidebook-linux-arm64" -o dist/guidebook-linux-arm64
+      - 'curl -fSL -H "Authorization: token $FORGEJO_TOKEN" "${CI_FORGE_URL}/${CI_REPO}/releases/download/${CI_COMMIT_TAG}/guidebook-linux-amd64" -o dist/guidebook-linux-amd64'
+      - 'curl -fSL -H "Authorization: token $FORGEJO_TOKEN" "${CI_FORGE_URL}/${CI_REPO}/releases/download/${CI_COMMIT_TAG}/guidebook-linux-arm64" -o dist/guidebook-linux-arm64'
 
   - name: docker
     image: woodpeckerci/plugin-docker-buildx

--- a/.woodpecker/docker.yml
+++ b/.woodpecker/docker.yml
@@ -14,12 +14,8 @@ steps:
     commands:
       - apk add --no-cache curl
       - mkdir -p dist
-      - |
-        for arch in amd64 arm64; do
-          curl -fSL -H "Authorization: token $FORGEJO_TOKEN" \
-            "${CI_FORGE_URL}/${CI_REPO}/releases/download/${CI_COMMIT_TAG}/guidebook-linux-${arch}" \
-            -o dist/guidebook-linux-${arch}
-        done
+      - curl -fSL -H "Authorization: token $FORGEJO_TOKEN" "${CI_FORGE_URL}/${CI_REPO}/releases/download/${CI_COMMIT_TAG}/guidebook-linux-amd64" -o dist/guidebook-linux-amd64
+      - curl -fSL -H "Authorization: token $FORGEJO_TOKEN" "${CI_FORGE_URL}/${CI_REPO}/releases/download/${CI_COMMIT_TAG}/guidebook-linux-arm64" -o dist/guidebook-linux-arm64
 
   - name: docker
     image: woodpeckerci/plugin-docker-buildx

--- a/.woodpecker/docker.yml
+++ b/.woodpecker/docker.yml
@@ -8,8 +8,9 @@ when:
 steps:
   - name: download
     image: alpine
-    secrets:
-      - forgejo_token
+    environment:
+      FORGEJO_TOKEN:
+        from_secret: forgejo_token
     commands:
       - apk add --no-cache curl
       - mkdir -p dist

--- a/.woodpecker/docker.yml
+++ b/.woodpecker/docker.yml
@@ -8,6 +8,7 @@ when:
 steps:
   - name: docker
     image: woodpeckerci/plugin-docker-buildx
+    privileged: true
     settings:
       dockerfile: Dockerfile.release
       repo: ${CI_FORGE_URL##https://}/${CI_REPO}

--- a/.woodpecker/docker.yml
+++ b/.woodpecker/docker.yml
@@ -9,6 +9,7 @@ steps:
   - name: docker
     image: woodpeckerci/plugin-docker-buildx
     settings:
+      dockerfile: Dockerfile.release
       repo: ${CI_FORGE_URL##https://}/${CI_REPO}
       registry: ${CI_FORGE_URL##https://}
       username:
@@ -21,3 +22,10 @@ steps:
       tag:
         - ${CI_COMMIT_TAG##v}
         - latest
+      build_args:
+        - VERSION=${CI_COMMIT_TAG##v}
+      build_args_from_env:
+        - FORGE_URL
+    environment:
+      FORGE_URL:
+        from_secret: forge_url

--- a/.woodpecker/docker.yml
+++ b/.woodpecker/docker.yml
@@ -6,6 +6,20 @@ when:
     ref: refs/tags/v*
 
 steps:
+  - name: download
+    image: alpine
+    secrets:
+      - forgejo_token
+    commands:
+      - apk add --no-cache curl
+      - mkdir -p dist
+      - |
+        for arch in amd64 arm64; do
+          curl -fSL -H "Authorization: token $FORGEJO_TOKEN" \
+            "${CI_FORGE_URL}/${CI_REPO}/releases/download/${CI_COMMIT_TAG}/guidebook-linux-${arch}" \
+            -o dist/guidebook-linux-${arch}
+        done
+
   - name: docker
     image: woodpeckerci/plugin-docker-buildx
     privileged: true
@@ -23,4 +37,3 @@ steps:
       tag:
         - ${CI_COMMIT_TAG##v}
         - latest
-      build_args: VERSION=${CI_COMMIT_TAG##v},FORGE_URL=${CI_FORGE_URL}/${CI_REPO}

--- a/.woodpecker/docker.yml
+++ b/.woodpecker/docker.yml
@@ -23,6 +23,4 @@ steps:
       tag:
         - ${CI_COMMIT_TAG##v}
         - latest
-      build_args:
-        - VERSION=${CI_COMMIT_TAG##v}
-        - FORGE_URL=${CI_FORGE_URL}/${CI_REPO}
+      build_args: VERSION=${CI_COMMIT_TAG##v},FORGE_URL=${CI_FORGE_URL}/${CI_REPO}

--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -30,13 +30,8 @@ steps:
       - export PATH="$HOME/.local/bin:$PATH"
       - just deps
       - just build-binary
-      - |
-        case "$(uname -m)" in
-          x86_64)  arch=amd64 ;;
-          aarch64) arch=arm64 ;;
-          *)       arch=$(uname -m) ;;
-        esac
-        mv dist/guidebook dist/guidebook-linux-${arch}
+      - uname -m
+      - uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/' | xargs -I{} mv dist/guidebook dist/guidebook-linux-{}
 
   - name: release
     image: codeberg.org/woodpecker-plugins/release

--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -30,13 +30,17 @@ steps:
       - export PATH="$HOME/.local/bin:$PATH"
       - just deps
       - just build-binary
-      - arch=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
-      - mv dist/guidebook dist/guidebook-linux-${arch}
+      - |
+        case "$(uname -m)" in
+          x86_64)  arch=amd64 ;;
+          aarch64) arch=arm64 ;;
+          *)       arch=$(uname -m) ;;
+        esac
+        mv dist/guidebook dist/guidebook-linux-${arch}
 
   - name: release
-    image: woodpeckerci/plugin-gitea-release
+    image: codeberg.org/woodpecker-plugins/release
     settings:
-      base_url: ${CI_FORGE_URL}
       api_key:
         from_secret: forgejo_token
       files:

--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -6,6 +6,10 @@ matrix:
 labels:
   platform: ${platform}
 
+when:
+  - event: tag
+    ref: refs/tags/v*
+
 steps:
   - name: test
     image: python:3.12-bookworm
@@ -26,3 +30,16 @@ steps:
       - export PATH="$HOME/.local/bin:$PATH"
       - just deps
       - just build-binary
+      - arch=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+      - mv dist/guidebook dist/guidebook-linux-${arch}
+
+  - name: release
+    image: woodpeckerci/plugin-gitea-release
+    settings:
+      base_url: ${CI_FORGE_URL}
+      api_key:
+        from_secret: forgejo_token
+      files:
+        - dist/guidebook-*
+      title: ${CI_COMMIT_TAG}
+      note: CHANGELOG.md

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,11 @@
+FROM debian:bookworm-slim
+ARG TARGETARCH
+ARG VERSION
+ARG FORGE_URL
+ADD ${FORGE_URL}/releases/download/v${VERSION}/guidebook-linux-${TARGETARCH} /usr/local/bin/guidebook
+RUN chmod +x /usr/local/bin/guidebook && \
+    groupadd --gid 1000 guidebook && \
+    useradd --uid 1000 --gid 1000 --create-home guidebook
+USER 1000:1000
+EXPOSE 4280
+CMD ["guidebook"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,8 +1,6 @@
 FROM debian:bookworm-slim
 ARG TARGETARCH
-ARG VERSION
-ARG FORGE_URL
-ADD ${FORGE_URL}/releases/download/v${VERSION}/guidebook-linux-${TARGETARCH} /usr/local/bin/guidebook
+COPY dist/guidebook-linux-${TARGETARCH} /usr/local/bin/guidebook
 RUN chmod +x /usr/local/bin/guidebook && \
     groupadd --gid 1000 guidebook && \
     useradd --uid 1000 --gid 1000 --create-home guidebook

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,9 +1,7 @@
 FROM debian:bookworm-slim
 ARG TARGETARCH
 COPY dist/guidebook-linux-${TARGETARCH} /usr/local/bin/guidebook
-RUN chmod +x /usr/local/bin/guidebook && \
-    groupadd --gid 1000 guidebook && \
-    useradd --uid 1000 --gid 1000 --create-home guidebook
+RUN chmod +x /usr/local/bin/guidebook
 USER 1000:1000
 EXPOSE 4280
 CMD ["guidebook"]

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1401,7 +1401,7 @@
   main {
     max-width: 100%;
     margin: 0 auto;
-    padding: 1rem;
+    padding: 0.25rem;
   }
 
   .page-content {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1501,8 +1501,6 @@
     flex-wrap: wrap;
     gap: 0.5rem;
     border-bottom: 1px solid var(--border);
-    padding-bottom: 0.5rem;
-    margin-bottom: 1rem;
   }
 
   .header-left {

--- a/rename.py
+++ b/rename.py
@@ -44,7 +44,19 @@ REPLACE_PATHS = [
 
 # Skip these when walking directories
 SKIP_DIRS = {".git", "node_modules", "__pycache__", "static", ".venv", "dist", "build"}
-SKIP_EXTENSIONS = {".lock", ".pyc", ".ico", ".png", ".jpg", ".jpeg", ".gif", ".woff", ".woff2", ".ttf", ".eot"}
+SKIP_EXTENSIONS = {
+    ".lock",
+    ".pyc",
+    ".ico",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".woff",
+    ".woff2",
+    ".ttf",
+    ".eot",
+}
 
 
 def validate_name(name: str) -> str | None:

--- a/rename.py
+++ b/rename.py
@@ -11,7 +11,6 @@ lock file and frontend, commits the result, then deletes itself.
 
 import os
 import re
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -187,7 +186,7 @@ def main():
     script_path = Path(__file__).resolve()
     print(f"Removing {script_path.name}...")
     run(["git", "rm", str(script_path.relative_to(ROOT))])
-    run(["git", "commit", "-m", f"Remove rename script"])
+    run(["git", "commit", "-m", "Remove rename script"])
     print()
 
     print(f"Done! Project is now '{new_title}'.")

--- a/src/guidebook/main.py
+++ b/src/guidebook/main.py
@@ -1070,7 +1070,11 @@ environment variables (overridden by command line options):
                 "\nAuth reset complete: all sessions, CA, certificates, and mTLS state cleared."
             )
 
-            if os.environ.get("GUIDEBOOK_RESET_AUTH_ONLY", "").lower() in ("1", "true", "yes"):
+            if os.environ.get("GUIDEBOOK_RESET_AUTH_ONLY", "").lower() in (
+                "1",
+                "true",
+                "yes",
+            ):
                 host = os.environ.get("GUIDEBOOK_HOST", "127.0.0.1") or "127.0.0.1"
                 port = int(os.environ.get("GUIDEBOOK_PORT", "4280"))
                 scheme = "http" if no_tls else "https"
@@ -1212,6 +1216,7 @@ environment variables (overridden by command line options):
         env_browser_url = os.environ.get("GUIDEBOOK_BROWSER_URL", "").strip()
 
         if args.ssb:
+
             def open_ssb():
                 import subprocess
                 import time
@@ -1229,6 +1234,7 @@ environment variables (overridden by command line options):
 
             threading.Thread(target=open_ssb, daemon=True).start()
         else:
+
             def open_browser():
                 import time
 

--- a/src/guidebook/routes/attachments.py
+++ b/src/guidebook/routes/attachments.py
@@ -13,9 +13,7 @@ import guidebook.db as _db
 from guidebook.db import Attachment, Record, db_manager, get_session, _ensure_data_dir
 from guidebook.routes.records import _broadcast_records_changed
 
-router = APIRouter(
-    prefix="/api/records/{record_id}/attachments", tags=["attachments"]
-)
+router = APIRouter(prefix="/api/records/{record_id}/attachments", tags=["attachments"])
 
 MAX_FILE_SIZE = 50 * 1024 * 1024  # 50 MB
 
@@ -91,14 +89,16 @@ async def upload_attachments(
     for f in files:
         data = await f.read()
         if len(data) > MAX_FILE_SIZE:
-            raise HTTPException(
-                status_code=413, detail=f"File too large: {f.filename}"
-            )
+            raise HTTPException(status_code=413, detail=f"File too large: {f.filename}")
 
         filename = _safe_filename(f.filename or "upload", existing)
         existing.add(filename)
 
-        content_type = f.content_type or mimetypes.guess_type(filename)[0] or "application/octet-stream"
+        content_type = (
+            f.content_type
+            or mimetypes.guess_type(filename)[0]
+            or "application/octet-stream"
+        )
 
         filepath = att_dir / filename
         filepath.write_bytes(data)
@@ -169,10 +169,6 @@ def cleanup_record_attachments(record: Record) -> None:
             shutil.rmtree(att_dir)
 
 
-async def delete_attachments_for_record(
-    record_id: int, session: AsyncSession
-) -> None:
+async def delete_attachments_for_record(record_id: int, session: AsyncSession) -> None:
     """Delete all attachment DB rows for a record."""
-    await session.execute(
-        delete(Attachment).where(Attachment.record_id == record_id)
-    )
+    await session.execute(delete(Attachment).where(Attachment.record_id == record_id))

--- a/src/guidebook/routes/auth.py
+++ b/src/guidebook/routes/auth.py
@@ -17,14 +17,18 @@ logger = logging.getLogger("guidebook")
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
+
 def _cookie_name() -> str:
     import re
     from guidebook.db import get_instance_name
+
     instance = get_instance_name()
     if instance == "default":
         return "guidebook_token"
     sanitized = re.sub(r"[^a-zA-Z0-9_]", "_", instance)
     return f"guidebook_token_{sanitized}"
+
+
 AUTH_TTL_DEFAULT = 30 * 24 * 3600  # 30 days
 AUTH_RENEW_COOLDOWN_DEFAULT = 24 * 3600  # 24 hours
 LOGIN_LINK_TTL = 300  # 5 minutes (hardcoded)

--- a/src/guidebook/routes/databases.py
+++ b/src/guidebook/routes/databases.py
@@ -44,16 +44,16 @@ async def get_mode():
     from guidebook.main import NO_SHUTDOWN
 
     instance_name = _db.get_instance_name()
-    has_databases = any(
-        f.stem != "__instance" for f in _db.INSTANCE_DIR.glob("*.db")
-    )
+    has_databases = any(f.stem != "__instance" for f in _db.INSTANCE_DIR.glob("*.db"))
     return {
         "picker": db_manager.picker_mode,
         "db_override": db_manager._db_override is not None,
         "no_shutdown": NO_SHUTDOWN,
         "has_databases": has_databases,
         "instance_name": instance_name,
-        "default_app_name": "Guidebook" if instance_name == "default" else instance_name,
+        "default_app_name": "Guidebook"
+        if instance_name == "default"
+        else instance_name,
     }
 
 

--- a/src/guidebook/routes/media.py
+++ b/src/guidebook/routes/media.py
@@ -43,21 +43,20 @@ class MediaItem(BaseModel):
 async def list_media(
     q: str | None = Query(None, description="Search query"),
     type: str | None = Query(None, description="Filter: image, video, audio, document"),
-    tags: str | None = Query(None, description="Comma-separated tags to filter by (AND)"),
+    tags: str | None = Query(
+        None, description="Comma-separated tags to filter by (AND)"
+    ),
     session: AsyncSession = Depends(get_session),
 ):
-    stmt = (
-        select(
-            Attachment.id,
-            Attachment.record_id,
-            Record.title.label("record_title"),
-            Attachment.filename,
-            Attachment.content_type,
-            Attachment.size,
-            Attachment.created_at,
-        )
-        .join(Record, Attachment.record_id == Record.id)
-    )
+    stmt = select(
+        Attachment.id,
+        Attachment.record_id,
+        Record.title.label("record_title"),
+        Attachment.filename,
+        Attachment.content_type,
+        Attachment.size,
+        Attachment.created_at,
+    ).join(Record, Attachment.record_id == Record.id)
     if type and type in TYPE_FILTERS:
         stmt = stmt.where(and_(*TYPE_FILTERS[type]))
     else:

--- a/src/guidebook/routes/mtls.py
+++ b/src/guidebook/routes/mtls.py
@@ -22,7 +22,10 @@ def _check_auth_enabled():
     from guidebook.routes.auth import DISABLE_AUTH, _env_disable_auth
 
     if DISABLE_AUTH or _env_disable_auth():
-        raise HTTPException(403, "Authentication is disabled. Certificate management is unavailable.")
+        raise HTTPException(
+            403, "Authentication is disabled. Certificate management is unavailable."
+        )
+
 
 PENDING_DOWNLOAD_TTL = 600  # 10 minutes
 

--- a/src/guidebook/routes/query.py
+++ b/src/guidebook/routes/query.py
@@ -68,7 +68,9 @@ def _execute_query(
         conn.set_authorizer(_authorizer)
         # Attach global database for cross-DB queries
         if _db.INSTANCE_DB_PATH.exists():
-            conn.execute(f"ATTACH DATABASE 'file:{_db.INSTANCE_DB_PATH}?mode=ro' AS meta")
+            conn.execute(
+                f"ATTACH DATABASE 'file:{_db.INSTANCE_DB_PATH}?mode=ro' AS meta"
+            )
         ops = [0]
 
         def progress():

--- a/src/guidebook/routes/settings.py
+++ b/src/guidebook/routes/settings.py
@@ -71,17 +71,15 @@ async def list_settings(
     db_settings = result.scalars().all()
     # Track which defaultable keys have a non-blank database value
     db_filled = {
-        s.key
-        for s in db_settings
-        if s.key not in INSTANCE_DEFAULTABLE_KEYS or s.value
+        s.key for s in db_settings if s.key not in INSTANCE_DEFAULTABLE_KEYS or s.value
     }
-    responses = [
-        _redact(s, "database") for s in db_settings if s.key in db_filled
-    ]
+    responses = [_redact(s, "database") for s in db_settings if s.key in db_filled]
 
     # Fill in global defaults for defaultable keys that are missing or blank
     meta_result = await gdb.execute(
-        select(InstanceSetting).where(InstanceSetting.key.in_(INSTANCE_DEFAULTABLE_KEYS))
+        select(InstanceSetting).where(
+            InstanceSetting.key.in_(INSTANCE_DEFAULTABLE_KEYS)
+        )
     )
     for ms in meta_result.scalars().all():
         if ms.key not in db_filled and ms.value:
@@ -125,7 +123,9 @@ async def upsert_setting(
     from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
     stmt = sqlite_insert(Setting).values(key=key, value=data.value)
-    stmt = stmt.on_conflict_do_update(index_elements=["key"], set_={"value": data.value})
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["key"], set_={"value": data.value}
+    )
     await session.execute(stmt)
     await session.commit()
     log_value = "***" if key in HIDDEN_KEYS else data.value

--- a/src/guidebook/sse.py
+++ b/src/guidebook/sse.py
@@ -41,6 +41,7 @@ def connected_cert_serials() -> set[str]:
     """Return set of client cert serial numbers with active SSE connections."""
     return {k for k, v in _connected_cert_serials.items() if v > 0}
 
+
 AUTO_SHUTDOWN_DELAY_DEFAULT = 300  # seconds
 _auto_shutdown_delay: int = AUTO_SHUTDOWN_DELAY_DEFAULT
 
@@ -241,11 +242,17 @@ async def event_stream(request: Request):
             if queue in _subscribers:
                 _subscribers.remove(queue)
             # Untrack auth identity
-            if _sse_session_id is not None and _sse_session_id in _connected_session_ids:
+            if (
+                _sse_session_id is not None
+                and _sse_session_id in _connected_session_ids
+            ):
                 _connected_session_ids[_sse_session_id] -= 1
                 if _connected_session_ids[_sse_session_id] <= 0:
                     del _connected_session_ids[_sse_session_id]
-            if _sse_cert_serial is not None and _sse_cert_serial in _connected_cert_serials:
+            if (
+                _sse_cert_serial is not None
+                and _sse_cert_serial in _connected_cert_serials
+            ):
                 _connected_cert_serials[_sse_cert_serial] -= 1
                 if _connected_cert_serials[_sse_cert_serial] <= 0:
                     del _connected_cert_serials[_sse_cert_serial]


### PR DESCRIPTION
## Summary

- Reduce main padding and remove header margin/padding
- Add Woodpecker CI workflow for testing (ruff, pytest) and building linux binaries on amd64 and arm64
- Add Woodpecker release workflow using codeberg release plugin to publish binaries to Forgejo
- Add Woodpecker Docker workflow to build and push multi-arch container images to Forgejo registry
- Add Dockerfile.release that pulls pre-built binaries from Forgejo releases
- Fix ruff lint and formatting issues

## Commits

- bf5503c Skip user creation in release Dockerfile to avoid QEMU issues
- f7304a0 Use curl -u instead of -H to avoid YAML colon issue
- b1c0af7 Quote curl commands to avoid YAML colon parsing
- 0d68218 Fix binary download commands to avoid multiline block
- dd2f4a2 Use environment instead of deprecated secrets syntax
- deee1a4 Download release binaries before Docker build to handle private repo auth
- 176ef7c Fix build_args format for docker-buildx plugin
- 7742c95 Add privileged mode to docker buildx step
- 9553e12 Use CI_FORGE_URL for Docker release build args
- 14969eb Use pre-built release binaries for Docker multi-arch build
- 11c7acf Fix arch detection for binary rename
- 9e1be4f Fix binary arch naming and switch to codeberg release plugin
- 136c825 Add Woodpecker release and Docker workflows for linux/amd64 and linux/arm64
- 8a74137 Run CI on both linux/amd64 and linux/arm64
- 8fb393d Allow pytest exit code 5 (no tests collected)
- 881522a Apply ruff formatting
- 39cde5a Fix ruff lint errors in rename.py
- a9e8418 Add Woodpecker CI workflow for testing and building linux binary
- a20d026 Remove header padding-bottom and margin-bottom
- fa3a48d Set main padding to 0.25rem